### PR TITLE
feat: Add configuration system from TOML file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,69 @@
+# Configuration
+
+`fleche` can be configured using a TOML file located at `$XDG_CONFIG_HOME/fleche/cache.toml` (or `~/.config/fleche/cache.toml` if `$XDG_CONFIG_HOME` is not set).
+
+## The `[default]` section
+
+The `[default]` section is used to configure the default behavior of `fleche`.
+
+### `cache`
+
+The `cache` key specifies the name of the default cache to use.
+
+Example:
+```toml
+[default]
+cache = "mycache"
+```
+
+### `metadata`
+
+The `metadata` key specifies the default metadata chain to use. This is a list of strings, where each string is the name of a metadata class from the `fleche.metadata` module.
+
+Example:
+```toml
+[default]
+metadata = ["Runtime", "InvocationInfo"]
+```
+
+**Note:** The `Tags` metadata cannot be configured from the config file, as it requires arguments.
+
+## Cache sections
+
+You can define multiple cache configurations in the same file, each in its own section.
+
+Each cache section must define two storage backends: `values` and `invocs`. `values` is used to store the results of function calls, and `invocs` is used to store the function invocation details.
+
+### Storage backends
+
+Each storage backend is configured using a `type` key, which specifies the name of the storage class from the `fleche.storage` module. Other keys are passed as arguments to the storage class constructor.
+
+Example:
+```toml
+[mycache]
+values.type = "Memory"
+invocs.type = "Memory"
+```
+
+### Available storage types
+
+*   `Memory`: Stores data in an in-memory dictionary. It takes no arguments.
+*   `CloudpickleFile`: Stores data as files on the filesystem, using `cloudpickle` for serialization. It takes a `root` argument, which is the path to the directory where the files will be stored.
+*   `BagOfHoldingH5File`: Stores data in an HDF5 file using the `bagofholding` library. It takes a `root` argument, which is the path to the directory where the files will be stored.
+
+### Nested storage
+
+You can also nest storage configurations. This is useful for creating complex storage backends, like a compressed storage that wraps another storage.
+
+To configure a nested storage, you can use a `inner` key, which contains the configuration for the inner storage.
+
+Example:
+```toml
+[nested]
+values.type = "CompressedStorage"
+values.compression = "gzip"
+values.inner.type = "BagOfHoldingH5File"
+values.inner.root  = "..."
+invocs.type = "CloudpickleFile"
+invocs.root = "~/.fleche/invocs"
+```

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -1,0 +1,132 @@
+"""
+Configuration system for fleche.
+
+Example cache.toml:
+
+[default]
+cache = "mycache"
+metadata = ["Runtime", "InvocationInfo"]
+
+[mycache]
+values.type = "Memory"
+invocs.type = "Memory"
+
+[transient]
+values.type = "CloudpickleFile"
+values.root = ".fleche/values"
+invocs.type = "CloudpickleFile"
+invocs.root = ".fleche/invocs"
+
+[global]
+values.type = "BagOfHoldingH5File"
+values.root = "~/.fleche/values"
+invocs.type = "CloudpickleFile"
+invocs.root = "~/.fleche/invocs"
+
+"""
+
+import tomllib
+from pathlib import Path
+import os
+from typing import Any
+
+from . import storage, metadata
+from .cache import Cache
+
+_live_caches: dict[str, Cache] = {}
+
+
+def _get_config_path() -> Path | None:
+    if "XDG_CONFIG_HOME" in os.environ:
+        return Path(os.environ["XDG_CONFIG_HOME"]) / "fleche/cache.toml"
+    elif "HOME" in os.environ:
+        return Path(os.environ["HOME"]) / ".config/fleche/cache.toml"
+    else:
+        return None
+
+
+def _get_storage(config: dict[str, Any]) -> storage.Storage:
+    storage_type = config.pop("type")
+
+    if storage_type == "Memory":
+        return storage.Memory({})
+
+    if "inner" in config:
+        config["inner"] = _get_storage(config["inner"])
+
+    cls = getattr(storage, storage_type)
+    return cls(**config)
+
+
+def load_default_metadata():
+    """
+    Load the default metadata from the configuration file.
+    """
+    path = _get_config_path()
+    if path is None or not path.exists():
+        return (metadata.Runtime(), metadata.InvocationInfo())
+
+    with open(path, "rb") as f:
+        config = tomllib.load(f)
+
+    if "default" not in config or "metadata" not in config["default"]:
+        return (metadata.Runtime(), metadata.InvocationInfo())
+
+    meta_names = config["default"]["metadata"]
+
+    meta_objects = []
+    for name in meta_names:
+        if name == "Tags":
+            raise ValueError("Tags metadata cannot be configured from the config file.")
+        else:
+            meta_objects.append(getattr(metadata, name)())
+
+    return tuple(meta_objects)
+
+
+def _create_cache(cache_config: dict[str, Any]) -> Cache:
+    values = _get_storage(cache_config["values"])
+    invocs = _get_storage(cache_config["invocs"])
+    return Cache(values=values, invocs=invocs)
+
+
+def from_config(name: str | None = None) -> Cache:
+    """
+    Load a cache from the configuration file.
+
+    If name is None, the default cache is loaded.
+
+    Note: The `Tags` metadata cannot be configured from the config file.
+    """
+    path = _get_config_path()
+    if path is None or not path.exists():
+        print("Warning: No config file found. Using default memory cache.")
+        return Cache(storage.Memory({}), storage.Memory({}))
+
+    with open(path, "rb") as f:
+        config = tomllib.load(f)
+
+    cache_name = name
+    cache_config = None
+
+    if cache_name is None:
+        if "default" not in config or "cache" not in config["default"]:
+            print("Warning: No default cache configured. Using default memory cache.")
+            return Cache(storage.Memory({}), storage.Memory({}))
+
+        default_cache = config["default"]["cache"]
+        if isinstance(default_cache, str):
+            cache_name = default_cache
+        else:
+            cache_name = "default"
+            cache_config = default_cache
+
+    if cache_name in _live_caches:
+        return _live_caches[cache_name]
+
+    if cache_config is None:
+        cache_config = config[cache_name]
+
+    cache = _create_cache(cache_config)
+    _live_caches[cache_name] = cache
+    return cache

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,229 @@
+import os
+import tempfile
+from pathlib import Path
+import textwrap
+import pytest
+from dataclasses import dataclass
+
+from fleche import from_config, storage, cache, set_metadata
+from fleche.cache import Cache
+from fleche import metadata
+
+
+@dataclass
+class NestedStorage(storage.Storage):
+    inner: storage.Storage
+    arg: str
+
+    def save(self, value, key=None):
+        pass
+
+    def load(self, key):
+        pass
+
+    def list(self):
+        pass
+
+
+@pytest.fixture
+def config_file():
+    config = textwrap.dedent("""
+        [default]
+        cache = "mycache"
+        metadata = ["Runtime", "InvocationInfo"]
+
+        [mycache]
+        values.type = "Memory"
+        invocs.type = "Memory"
+
+        [transient]
+        values.type = "CloudpickleFile"
+        values.root = ".fleche/values"
+        invocs.type = "CloudpickleFile"
+        invocs.root = ".fleche/invocs"
+        
+        [global]
+        values.type = "BagOfHoldingH5File"
+        values.root = "~/.fleche/values"
+        invocs.type = "CloudpickleFile"
+        invocs.root = "~/.fleche/invocs"
+
+        [nested]
+        values.type = "NestedStorage"
+        values.arg = "test"
+        values.inner.type = "Memory"
+        invocs.type = "Memory"
+    """)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_dir = Path(tmpdir) / "fleche"
+        config_dir.mkdir()
+        config_path = config_dir / "cache.toml"
+        config_path.write_text(config)
+        yield tmpdir
+
+
+@pytest.fixture
+def config_file_explicit_default():
+    config = textwrap.dedent("""
+        [default]
+        metadata = ["Runtime", "InvocationInfo"]
+        [default.cache]
+        values.type = "Memory"
+        invocs.type = "Memory"
+    """)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_dir = Path(tmpdir) / "fleche"
+        config_dir.mkdir()
+        config_path = config_dir / "cache.toml"
+        config_path.write_text(config)
+        yield tmpdir
+
+
+@pytest.fixture
+def config_file_with_tags():
+    config = textwrap.dedent("""
+        [default]
+        cache = "mycache"
+        metadata = ["Runtime", "InvocationInfo", "Tags"]
+    """)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_dir = Path(tmpdir) / "fleche"
+        config_dir.mkdir()
+        config_path = config_dir / "cache.toml"
+        config_path.write_text(config)
+        yield tmpdir
+
+
+@pytest.fixture
+def config_file_no_default():
+    config = textwrap.dedent("""
+        [mycache]
+        values.type = "Memory"
+        invocs.type = "Memory"
+    """)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_dir = Path(tmpdir) / "fleche"
+        config_dir.mkdir()
+        config_path = config_dir / "cache.toml"
+        config_path.write_text(config)
+        yield tmpdir
+
+
+def test_from_config_default(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    cache_obj = from_config()
+
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, storage.Memory)
+    assert isinstance(cache_obj.invocs, storage.Memory)
+
+
+def test_from_config_explicit_default(monkeypatch, config_file_explicit_default):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file_explicit_default)
+
+    cache_obj = from_config()
+
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, storage.Memory)
+    assert isinstance(cache_obj.invocs, storage.Memory)
+
+
+def test_from_config_specific(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    cache_obj = from_config("transient")
+
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, storage.CloudpickleFile)
+    assert cache_obj.values.root == Path(".fleche/values")
+    assert isinstance(cache_obj.invocs, storage.CloudpickleFile)
+    assert cache_obj.invocs.root == Path(".fleche/invocs")
+
+
+def test_from_config_no_file(monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/nonexistent")
+    cache_obj = from_config()
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, storage.Memory)
+    assert isinstance(cache_obj.invocs, storage.Memory)
+
+
+def test_from_config_no_default(monkeypatch, config_file_no_default):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file_no_default)
+    cache_obj = from_config()
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, storage.Memory)
+    assert isinstance(cache_obj.invocs, storage.Memory)
+
+
+def test_cache_function_loads_by_name(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    with cache("global"):
+        cache_obj = cache()
+        assert isinstance(cache_obj, Cache)
+        assert isinstance(cache_obj.values, storage.BagOfHoldingH5File)
+        assert str(cache_obj.values.root) == "~/.fleche/values"
+
+
+def test_cache_instances_are_persistent(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    with cache("global"):
+        cache1 = cache()
+
+    with cache("global"):
+        cache2 = cache()
+
+    assert cache1 is cache2
+
+
+def test_nested_storage(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+    storage.NestedStorage = NestedStorage
+
+    cache_obj = from_config("nested")
+
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, NestedStorage)
+    assert cache_obj.values.arg == "test"
+    assert isinstance(cache_obj.values.inner, storage.Memory)
+
+
+def test_load_default_metadata(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    import importlib
+    import fleche
+
+    importlib.reload(fleche)
+
+    meta = fleche._METADATA.get()
+    assert len(meta) == 2
+    assert isinstance(meta[0], metadata.Runtime)
+    assert isinstance(meta[1], metadata.InvocationInfo)
+
+
+def test_load_default_cache(monkeypatch, config_file):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    import importlib
+    import fleche
+
+    importlib.reload(fleche)
+
+    cache_obj = fleche._CACHE.get()
+    assert isinstance(cache_obj, Cache)
+    assert isinstance(cache_obj.values, storage.Memory)
+    assert isinstance(cache_obj.invocs, storage.Memory)
+
+
+def test_tags_disallowed(monkeypatch, config_file_with_tags):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file_with_tags)
+
+    import importlib
+    import fleche
+
+    with pytest.raises(ValueError):
+        importlib.reload(fleche)


### PR DESCRIPTION
Add a new configuration system that loads cache and metadata settings from a TOML file.

The configuration file is expected to be at `$XDG_CONFIG_HOME/fleche/cache.toml`.

The default cache and metadata can be configured in the `[default]` section.

Multiple cache configurations can be defined, and they can be loaded by name using `fleche.cache(my-cache)`.

The default cache is loaded at startup and used as the default for the `_CACHE` context variable.