### PR TITLE
Implement helper attributes on fleche decorator

### DIFF
--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -124,6 +124,14 @@ def fleche(
         if version is not None:
             func.__version__ = version
 
+        def get_invocation(*args, **kwargs):
+            inv = Invocation.from_call(func, *args, **kwargs)
+            if not hash_version:
+                inv.version = None
+            if not hash_module:
+                inv.module = None
+            return inv
+
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> _T:
             if require is None:
@@ -137,12 +145,8 @@ def fleche(
                 return func(*args, **kwargs)
             cache: Cache = _CACHE.get()
             try:
-                inv = Invocation.from_call(func, *args, **kwargs)
-                if not hash_version:
-                    inv.version = None
-                if not hash_module:
-                    inv.module = None
-                key: str = digest.digest(inv.to_lookup())
+                inv = get_invocation(*args, **kwargs)
+                key = wrapper.key(*args, **kwargs)
             except digest.Unhashable as e:
                 print("WARNING NO HASH:", e.args[0])
                 return func(*args, **kwargs)
@@ -179,6 +183,12 @@ def fleche(
                         return _run_and_cache()
             else:
                 return _run_and_cache()
+
+        wrapper.invocation = get_invocation
+        wrapper.key = lambda *args, **kwargs: digest.digest(get_invocation(*args, **kwargs).to_lookup())
+        wrapper.load = lambda *args, **kwargs: _CACHE.get().load(wrapper.key(*args, **kwargs)).result
+        wrapper.contains = lambda *args, **kwargs: _CACHE.get().contains(wrapper.key(*args, **kwargs))
+
         return wrapper
 
     if callable(_func):

--- a/tests/unit/test_decorator_attributes.py
+++ b/tests/unit/test_decorator_attributes.py
@@ -1,0 +1,52 @@
+
+from fleche import fleche, Cache, cache
+from fleche.storage import Memory
+from fleche.invocation import Invocation
+import pytest
+
+def test_fleche_extra_attributes():
+    c = Cache(Memory({}), Memory({}))
+    with cache(c):
+        @fleche(version=1)
+        def add(a, b=1):
+            return a + b
+
+        # Test invocation
+        inv = add.invocation(1, b=2)
+        assert inv.name == "add"
+        assert inv.args == (1,)
+        assert inv.kwargs == {"b": 2}
+        assert inv.version == 1
+
+        # Test key
+        key = add.key(1, b=2)
+        assert isinstance(key, str)
+
+        # Test contains
+        assert not add.contains(1, b=2)
+
+        # Run and cache
+        assert add(1, b=2) == 3
+
+        # Test contains again
+        assert add.contains(1, b=2)
+
+        # Test load
+        assert add.load(1, b=2) == 3
+
+def test_hash_settings():
+    c = Cache(Memory({}), Memory({}))
+    with cache(c):
+        @fleche(version=1, hash_version=False)
+        def func_no_version(x):
+            return x
+
+        inv = func_no_version.invocation(1)
+        assert inv.version is None
+
+        @fleche(hash_module=False)
+        def func_no_module(x):
+            return x
+
+        inv = func_no_module.invocation(1)
+        assert inv.module is None


### PR DESCRIPTION
This PR implements helper attributes on the `@fleche` decorator as requested in issue #23. It also includes several improvements to the core library and test suite:

- Decorated functions now have `.invocation(*args, **kwargs)`, `.key(*args, **kwargs)`, `.load(*args, **kwargs)`, and `.contains(*args, **kwargs)` helpers.
- The `cache()` context manager now supports resolving named caches from the configuration file by passing a string.
- Default cache and metadata are now automatically loaded from the configuration file if present.
- Fixed an `ImportError` in `tests/unit/test_config.py` and an outdated assertion in `tests/integration/test_integration.py`.
- Added new unit tests in `tests/unit/test_decorator_attributes.py`.

---
*PR created automatically by Jules for task [13313805676990299356](https://jules.google.com/task/13313805676990299356) started by @pmrv*