### PR TITLE
Add decorator helper methods

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -1,0 +1,32 @@
+# Decorator Helpers
+
+Functions decorated with `@fleche` are enhanced with several helper methods that allow for manual interaction with the cache and inspection of function calls.
+
+## Helper Methods
+
+The following methods are added to the decorated function:
+
+### `.invocation(*args, **kwargs)`
+Returns an `Invocation` object corresponding to the provided arguments. This object contains metadata about the call, such as the function name, arguments, and version, but does not execute the function.
+
+### `.key(*args, **kwargs)`
+Returns the unique cache key (a digest string) that would be used for the given call.
+
+### `.load(*args, **kwargs)`
+Attempts to load the result of a specific call from the cache. If the result is not cached, it raises a `KeyError`.
+
+### `.contains(*args, **kwargs)`
+Returns `True` if the result for the given call is already present in the cache, `False` otherwise.
+
+## Accessing the Original Function
+
+The original, undecorated function is always accessible via the `.__wrapped__` attribute. This is useful if you need to bypass the cache entirely for a specific call.
+
+```python
+@fleche
+def my_func(x):
+    return x * 2
+
+# Bypass cache
+result = my_func.__wrapped__(10)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://example.com/fleche
 nav:
   - Home: index.md
   - Installation: installation.md
+  - Decorator Helpers: helpers.md
 
 
 theme:

--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -116,6 +116,16 @@ def fleche(
     require: None | str | list[str] | tuple[str] = None,
     isolate: bool = False,
 ):
+    """
+    Cache decorator for functions.
+
+    The decorated function is enhanced with helper methods:
+    - .invocation(*args, **kwargs): Get the Invocation object.
+    - .key(*args, **kwargs): Get the cache key.
+    - .load(*args, **kwargs): Load result from cache.
+    - .contains(*args, **kwargs): Check if result is in cache.
+    The original function is available via .__wrapped__.
+    """
 
     def decorator(func: Callable[..., _T]) -> Callable[..., _T]:
         """
@@ -123,6 +133,14 @@ def fleche(
         """
         if version is not None:
             func.__version__ = version
+
+        def get_invocation(*args, **kwargs):
+            inv = Invocation.from_call(func, *args, **kwargs)
+            if not hash_version:
+                inv.version = None
+            if not hash_module:
+                inv.module = None
+            return inv
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> _T:
@@ -137,12 +155,8 @@ def fleche(
                 return func(*args, **kwargs)
             cache: Cache = _CACHE.get()
             try:
-                inv = Invocation.from_call(func, *args, **kwargs)
-                if not hash_version:
-                    inv.version = None
-                if not hash_module:
-                    inv.module = None
-                key: str = digest.digest(inv.to_lookup())
+                inv = get_invocation(*args, **kwargs)
+                key = wrapper.key(*args, **kwargs)
             except digest.Unhashable as e:
                 print("WARNING NO HASH:", e.args[0])
                 return func(*args, **kwargs)
@@ -179,6 +193,11 @@ def fleche(
                         return _run_and_cache()
             else:
                 return _run_and_cache()
+
+        wrapper.invocation = get_invocation
+        wrapper.key = lambda *args, **kwargs: digest.digest(get_invocation(*args, **kwargs).to_lookup())
+        wrapper.load = lambda *args, **kwargs: _CACHE.get().load(wrapper.key(*args, **kwargs)).result
+        wrapper.contains = lambda *args, **kwargs: _CACHE.get().contains(wrapper.key(*args, **kwargs))
         return wrapper
 
     if callable(_func):

--- a/tests/unit/test_decorator_attributes.py
+++ b/tests/unit/test_decorator_attributes.py
@@ -1,0 +1,52 @@
+
+from fleche import fleche, Cache, cache
+from fleche.storage import Memory
+from fleche.invocation import Invocation
+import pytest
+
+def test_fleche_extra_attributes():
+    c = Cache(Memory({}), Memory({}))
+    with cache(c):
+        @fleche(version=1)
+        def add(a, b=1):
+            return a + b
+
+        # Test invocation
+        inv = add.invocation(1, b=2)
+        assert inv.name == "add"
+        assert inv.args == (1,)
+        assert inv.kwargs == {"b": 2}
+        assert inv.version == 1
+
+        # Test key
+        key = add.key(1, b=2)
+        assert isinstance(key, str)
+
+        # Test contains
+        assert not add.contains(1, b=2)
+
+        # Run and cache
+        assert add(1, b=2) == 3
+
+        # Test contains again
+        assert add.contains(1, b=2)
+
+        # Test load
+        assert add.load(1, b=2) == 3
+
+def test_hash_settings():
+    c = Cache(Memory({}), Memory({}))
+    with cache(c):
+        @fleche(version=1, hash_version=False)
+        def func_no_version(x):
+            return x
+
+        inv = func_no_version.invocation(1)
+        assert inv.version is None
+
+        @fleche(hash_module=False)
+        def func_no_module(x):
+            return x
+
+        inv = func_no_module.invocation(1)
+        assert inv.module is None


### PR DESCRIPTION
This PR adds documentation for the recently implemented helper methods on the `@fleche` decorator. These helpers include `.invocation()`, `.key()`, `.load()`, and `.contains()`, which allow for manual interaction with the cache and inspection of function calls. The documentation is provided as a new markdown file `docs/helpers.md` and a concise summary in the `fleche` decorator's docstring. Both mentions also highlight the availability of the original undecorated function via the `.__wrapped__` attribute. In addition to documentation, this PR completes the integration of these helper attributes and their associated unit tests from the referenced PR #24.

---
*PR created automatically by Jules for task [11632256811298903905](https://jules.google.com/task/11632256811298903905) started by @pmrv*