### PR TITLE
Rename Invocation to Call and invocs to calls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ The `metadata` key specifies the default metadata chain to use. This is a list o
 Example:
 ```toml
 [default]
-metadata = ["Runtime", "InvocationInfo"]
+metadata = ["Runtime", "CallInfo"]
 ```
 
 **Note:** The `Tags` metadata cannot be configured from the config file, as it requires arguments.
@@ -32,7 +32,7 @@ metadata = ["Runtime", "InvocationInfo"]
 
 You can define multiple cache configurations in the same file, each in its own section.
 
-Each cache section must define two storage backends: `values` and `invocs`. `values` is used to store the results of function calls, and `invocs` is used to store the function invocation details.
+Each cache section must define two storage backends: `values` and `calls`. `values` is used to store the results of function calls, and `calls` is used to store the function call details.
 
 ### Storage backends
 
@@ -42,7 +42,7 @@ Example:
 ```toml
 [mycache]
 values.type = "Memory"
-invocs.type = "Memory"
+calls.type = "Memory"
 ```
 
 ### Available storage types
@@ -64,6 +64,6 @@ values.type = "CompressedStorage"
 values.compression = "gzip"
 values.inner.type = "BagOfHoldingH5File"
 values.inner.root  = "..."
-invocs.type = "CloudpickleFile"
-invocs.root = "~/.fleche/invocs"
+calls.type = "CloudpickleFile"
+calls.root = "~/.fleche/calls"
 ```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -6,8 +6,8 @@ Functions decorated with `@fleche` are enhanced with several helper methods that
 
 The following methods are added to the decorated function:
 
-### `.invocation(*args, **kwargs)`
-Returns an `Invocation` object corresponding to the provided arguments. This object contains metadata about the call, such as the function name, arguments, and version, but does not execute the function.
+### `.call(*args, **kwargs)`
+Returns a `Call` object corresponding to the provided arguments. This object contains metadata about the call, such as the function name, arguments, and version, but does not execute the function.
 
 ### `.key(*args, **kwargs)`
 Returns the unique cache key (a digest string) that would be used for the given call.

--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, TypeVar, Union
 
 from . import digest
-from .invocation import Invocation
+from .call import Call
 from .metadata import MetaData, Tags
 from .cache import Cache, Rejected
 from .config import load_cache_config, load_default_metadata
@@ -60,7 +60,7 @@ def cache(new_cache: Optional[Union[Cache, str]] = None, stack=False) -> Union[C
 
 _METADATA: ContextVar[tuple[MetaData]] = ContextVar(
     "fleche.METADATA",
-    # default=(Runtime(), Digest(), InvocationInfo())
+    # default=(Runtime(), Digest(), CallInfo())
     default=load_default_metadata()
 )
 
@@ -120,7 +120,7 @@ def fleche(
     Cache decorator for functions.
 
     The decorated function is enhanced with helper methods:
-    - .invocation(*args, **kwargs): Get the Invocation object.
+    - .call(*args, **kwargs): Get the Call object.
     - .key(*args, **kwargs): Get the cache key.
     - .load(*args, **kwargs): Load result from cache.
     - .contains(*args, **kwargs): Check if result is in cache.
@@ -134,8 +134,8 @@ def fleche(
         if version is not None:
             func.__version__ = version
 
-        def get_invocation(*args, **kwargs):
-            inv = Invocation.from_call(func, *args, **kwargs)
+        def get_call(*args, **kwargs):
+            inv = Call.from_call(func, *args, **kwargs)
             if not hash_version:
                 inv.version = None
             if not hash_module:
@@ -155,7 +155,7 @@ def fleche(
                 return func(*args, **kwargs)
             cache: Cache = _CACHE.get()
             try:
-                inv = get_invocation(*args, **kwargs)
+                inv = get_call(*args, **kwargs)
                 key = wrapper.key(*args, **kwargs)
             except digest.Unhashable as e:
                 print("WARNING NO HASH:", e.args[0])
@@ -194,8 +194,8 @@ def fleche(
             else:
                 return _run_and_cache()
 
-        wrapper.invocation = get_invocation
-        wrapper.key = lambda *args, **kwargs: digest.digest(get_invocation(*args, **kwargs).to_lookup())
+        wrapper.call = get_call
+        wrapper.key = lambda *args, **kwargs: digest.digest(get_call(*args, **kwargs).to_lookup())
         wrapper.load = lambda *args, **kwargs: _CACHE.get().load(wrapper.key(*args, **kwargs)).result
         wrapper.contains = lambda *args, **kwargs: _CACHE.get().contains(wrapper.key(*args, **kwargs))
         return wrapper

--- a/src/fleche/cache.py
+++ b/src/fleche/cache.py
@@ -6,11 +6,11 @@ from typing import Self, Any
 from .digest import digest
 from .metadata import MetaDB
 from . import storage
-from .invocation import Invocation
+from .call import Call
 
 
 class Rejected(Exception):
-    """Cache refused to cache the invocation for some reason or other."""
+    """Cache refused to cache the call for some reason or other."""
     pass
 
 
@@ -21,7 +21,7 @@ class BaseCache(ABC):
         ...
 
     @abstractmethod
-    def load(self, key: str) -> Invocation:
+    def load(self, key: str) -> Call:
         ...
 
     def contains(self, key: str) -> bool:
@@ -51,9 +51,9 @@ class BaseCache(ABC):
 @dataclass
 class Cache(BaseCache):
     values: storage.Storage
-    invocs: storage.Storage
+    calls: storage.Storage
 
-    def save(self, inv: Invocation) -> str:
+    def save(self, inv: Call) -> str:
         inv = copy(inv)
         try:
             inv.result = self.values.save(inv.result)
@@ -62,10 +62,10 @@ class Cache(BaseCache):
         except storage.SaveError as e:
             raise Rejected(e)
 
-        return self.invocs.save(inv, key=digest(inv.to_lookup()))
+        return self.calls.save(inv, key=digest(inv.to_lookup()))
 
-    def load(self, key: str) -> Invocation:
-        inv = deepcopy(self.invocs.load(key))
+    def load(self, key: str) -> Call:
+        inv = deepcopy(self.calls.load(key))
         inv.result = self.values.load(inv.result)
         return inv
 
@@ -75,7 +75,7 @@ class MetaCache(BaseCache):
     cache: BaseCache
     metadb: MetaDB
 
-    def save(self, inv: Invocation) -> str:
+    def save(self, inv: Call) -> str:
         self.cache.save(inv)
         self.metadb.save(digest(inv), inv.metadata)
 
@@ -88,7 +88,7 @@ class ReadOnlyCache(BaseCache):
     """A cache that can only be read from."""
     cache: BaseCache
 
-    def save(self, inv: Invocation):
+    def save(self, inv: Call):
         raise Rejected(self, inv)
 
     def load(self, key):
@@ -104,7 +104,7 @@ class CacheStack(BaseCache):
     """
     stack: tuple[Cache]
 
-    def save(self, inv: Invocation):
+    def save(self, inv: Call):
         self.stack[0].save(inv)
 
     def load(self, key):

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -5,13 +5,13 @@ import fleche.digest
 
 
 @dataclass
-class Invocation:
+class Call:
     """
-    Represents a function invocation, capturing its name, arguments, and keyword arguments.
+    Represents a function call, capturing its name, arguments, and keyword arguments.
 
-    `module` and `version` can be optionally set to be included in the hash of the invocation.
+    `module` and `version` can be optionally set to be included in the hash of the call.
     `version` should be a plain integer and monotonically increase.  Each different version will completely change the
-    hash of the invocation, invalidating previously cached results.
+    hash of the call, invalidating previously cached results.
     """
     name: str
     args: tuple[Any, ...]
@@ -31,7 +31,7 @@ class Invocation:
         return inv
 
     def to_lookup(self):
-        return InvocationLookup(
+        return CallLookup(
                 name=self.name,
                 args=tuple(fleche.digest.digest(a) for a in self.args),
                 kwargs={k: fleche.digest.digest(v) for k, v in self.kwargs.items()},
@@ -41,8 +41,8 @@ class Invocation:
 
 
 @dataclass(frozen=True)
-class InvocationLookup:
-    """Subset of :class:`.Invocation` to be used as a lookup key """
+class CallLookup:
+    """Subset of :class:`.Call` to be used as a lookup key """
     name: str
     args: tuple[str, ...]
     kwargs: dict[str, str]

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -5,23 +5,23 @@ Example cache.toml:
 
 [default]
 cache = "mycache"
-metadata = ["Runtime", "InvocationInfo"]
+metadata = ["Runtime", "CallInfo"]
 
 [mycache]
 values.type = "Memory"
-invocs.type = "Memory"
+calls.type = "Memory"
 
 [transient]
 values.type = "CloudpickleFile"
 values.root = ".fleche/values"
-invocs.type = "CloudpickleFile"
-invocs.root = ".fleche/invocs"
+calls.type = "CloudpickleFile"
+calls.root = ".fleche/calls"
 
 [global]
 values.type = "BagOfHoldingH5File"
 values.root = "~/.fleche/values"
-invocs.type = "CloudpickleFile"
-invocs.root = "~/.fleche/invocs"
+calls.type = "CloudpickleFile"
+calls.root = "~/.fleche/calls"
 
 """
 
@@ -64,13 +64,13 @@ def load_default_metadata():
     """
     path = _get_config_path()
     if path is None or not path.exists():
-        return (metadata.Runtime(), metadata.InvocationInfo())
+        return (metadata.Runtime(), metadata.CallInfo())
 
     with open(path, "rb") as f:
         config = tomllib.load(f)
 
     if "default" not in config or "metadata" not in config["default"]:
-        return (metadata.Runtime(), metadata.InvocationInfo())
+        return (metadata.Runtime(), metadata.CallInfo())
 
     meta_names = config["default"]["metadata"]
 
@@ -86,8 +86,8 @@ def load_default_metadata():
 
 def _create_cache(cache_config: dict[str, Any]) -> Cache:
     values = _get_storage(cache_config["values"])
-    invocs = _get_storage(cache_config["invocs"])
-    return Cache(values=values, invocs=invocs)
+    calls = _get_storage(cache_config["calls"])
+    return Cache(values=values, calls=calls)
 
 
 def load_cache_config(name: str | None = None) -> Cache:

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -6,7 +6,7 @@ from typing import Any, TypeVar, Callable
 
 import numpy as np
 
-from .invocation import Invocation
+from .call import Call
 
 
 class Unhashable(Exception):

--- a/src/fleche/metadata.py
+++ b/src/fleche/metadata.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pandas as pd
 
-from .invocation import Invocation
+from .call import Call
 
 
 class MetaDB(ABC):
@@ -94,27 +94,27 @@ class PandasDB(MetaDB):
 
 class MetaData(ABC):
     """Abstract base class for defining metadata types."""
-    def pre(self, invocation: Invocation) -> dict[str, Any]:
+    def pre(self, call: Call) -> dict[str, Any]:
         """
         Hook for collecting metadata before the function execution.
 
         Args:
-            invocation (Invocation): The invocation object of the decorated function.
+            call (Call): The call object of the decorated function.
 
         Returns:
             dict[str, Any]: A dictionary of metadata collected before execution.
         """
         return {}
 
-    def post(self, pre: dict[str, Any], invocation: Invocation) -> dict[str, Any]:
+    def post(self, pre: dict[str, Any], call: Call) -> dict[str, Any]:
         """
         Hook for collecting metadata after the function execution.
 
-        The return value of the function is available on the `invocation.result` attribute.
+        The return value of the function is available on the `call.result` attribute.
 
         Args:
             pre (dict[str, Any]): Metadata collected during the pre-execution phase.
-            invocation (Invocation): The invocation object of the decorated function.
+            call (Call): The call object of the decorated function.
 
         Returns:
             dict[str, Any]: A dictionary of metadata collected after execution.
@@ -152,13 +152,13 @@ class Runtime(MetaData):
         timestop (float): The timestamp when the execution stopped.
         walltime (float): The total execution time in seconds.
     """
-    def pre(self, invocation: Invocation) -> dict[str, Any]:
+    def pre(self, call: Call) -> dict[str, Any]:
         """
         Records the start time before function execution.
         """
         return {'timestart': time.time()}
 
-    def post(self, pre: dict[str, Any], invocation: Invocation) -> dict[str, Any]:
+    def post(self, pre: dict[str, Any], call: Call) -> dict[str, Any]:
         """
         Records the stop time and calculates the wall time after function execution.
         """
@@ -175,18 +175,18 @@ class Runtime(MetaData):
     }
 
 
-class InvocationInfo(MetaData):
-    """Metadata type for storing information about the function invocation.
+class CallInfo(MetaData):
+    """Metadata type for storing information about the function call.
 
     Keys:
         name (str): The name of the invoked function.
         module (str): The module where the invoked function is defined.
         version (int): The version of the invoked function.
     """
-    def pre(self, inv: Invocation) -> dict[str, Any]:
+    def pre(self, inv: Call) -> dict[str, Any]:
         return {k: getattr(inv, k) for k in ("module", "name", "version")}
 
-    name: str = "invocation"
+    name: str = "call"
     keys = {
             "name":  str,
             "module":  str,
@@ -205,7 +205,7 @@ class Tags(MetaData):
     """
     tags: dict[str, Any]
 
-    def pre(self, invocation: Invocation) -> dict[str, Any]:
+    def pre(self, call: Call) -> dict[str, Any]:
         return self.tags.copy()
 
     name: str = "tags"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,7 +4,7 @@ import tempfile
 
 from fleche import fleche, cache
 from fleche.digest import digest
-from fleche.invocation import Invocation
+from fleche.call import Call
 from fleche.cache import Cache, ReadOnlyCache, CacheStack
 from fleche.storage import CloudpickleFile, Memory
 
@@ -81,8 +81,8 @@ def test_fleche_cache_stack():
 
     stack = CacheStack(stack=(cache2, cache1))
 
-    key1 = digest(Invocation.from_call(func, 1).to_lookup())
-    key2 = digest(Invocation.from_call(func, 2).to_lookup())
+    key1 = digest(Call.from_call(func, 1).to_lookup())
+    key2 = digest(Call.from_call(func, 2).to_lookup())
 
     with cache(stack):
         # first call, should go in cache2
@@ -118,13 +118,13 @@ def test_fleche_cache_stack_context_manager():
     with cache(cache1):
         with cache(cache2, stack=True):
             func(1)
-            key = digest(Invocation.from_call(func, 1).to_lookup())
+            key = digest(Call.from_call(func, 1).to_lookup())
             assert cache2.contains(key)
             assert cache2.load(key).result == 1
             assert not cache1.contains(key)
 
         func(2)
-        key = digest(Invocation.from_call(func, 2).to_lookup())
+        key = digest(Call.from_call(func, 2).to_lookup())
         assert cache1.contains(key)
 
         with cache(cache2, stack=True):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -6,31 +6,31 @@ from fleche.cache import ReadOnlyCache, CacheStack, Rejected
 
 
 def test_cache_save():
-    from fleche.invocation import Invocation
+    from fleche.call import Call
     values_storage = Mock()
     values_storage.save.return_value = 1
-    invocs_storage = Mock()
+    calls_storage = Mock()
     metadata = Mock()
-    c = Cache(values_storage, invocs_storage).metadb(metadata)
+    c = Cache(values_storage, calls_storage).metadb(metadata)
 
-    inv = Invocation(name="test", args=(1,), kwargs={}, result="result")
+    inv = Call(name="test", args=(1,), kwargs={}, result="result")
     inv.metadata = {"test": {"key": "value"}}
     c.save(inv)
 
-    # Check that the underlying cache saves values and invocations
+    # Check that the underlying cache saves values and calls
     assert values_storage.save.called
-    assert invocs_storage.save.called
+    assert calls_storage.save.called
     # Check that metadata is saved
     assert metadata.save.called
 
 
 def test_cache_load():
     values_storage = Mock()
-    invocs_storage = Mock()
+    calls_storage = Mock()
     metadata = Mock()
-    c = Cache(values_storage, invocs_storage).metadb(metadata)
+    c = Cache(values_storage, calls_storage).metadb(metadata)
     c.load("key")
-    invocs_storage.load.assert_called_once_with("key")
+    calls_storage.load.assert_called_once_with("key")
     metadata.load.assert_not_called()
 
 
@@ -42,16 +42,16 @@ def test_cache_context_manager():
     # a mock cache to be the original one
     original_values = Mock()
     original_values.save.return_value = "digest_value"
-    original_invocs = Mock()
-    original_invocs.load.side_effect = KeyError
-    original_cache = Cache(original_values, original_invocs)
+    original_calls = Mock()
+    original_calls.load.side_effect = KeyError
+    original_cache = Cache(original_values, original_calls)
 
     # a mock cache to be the new one
     new_values = Mock()
     new_values.save.return_value = "digest_value"
-    new_invocs = Mock()
-    new_invocs.load.side_effect = KeyError
-    new_cache = Cache(new_values, new_invocs)
+    new_calls = Mock()
+    new_calls.load.side_effect = KeyError
+    new_cache = Cache(new_values, new_calls)
 
     # get the default cache and replace it with our mock original_cache
     default_cache = cache()
@@ -60,13 +60,13 @@ def test_cache_context_manager():
         with cache(new_cache):
             assert cache() is new_cache
             my_func(2)
-            new_cache.invocs.load.assert_called_once()
-            assert new_cache.invocs.save.call_count == 1
+            new_cache.calls.load.assert_called_once()
+            assert new_cache.calls.save.call_count == 1
 
         assert cache() is original_cache
         my_func(3)
-        original_cache.invocs.load.assert_called_once()
-        assert original_cache.invocs.save.call_count == 1
+        original_cache.calls.load.assert_called_once()
+        assert original_cache.calls.save.call_count == 1
 
     # ensure the default cache is restored
     assert cache() is default_cache
@@ -75,24 +75,24 @@ def test_cache_context_manager():
 @pytest.mark.xfail
 def test_base_cache_transfer():
     values_storage = Mock()
-    invocs_storage = Mock()
-    invocs_storage.list.return_value = ["key1", "key2"]
-    invocs_storage.load.side_effect = ["result1", "result2"]
+    calls_storage = Mock()
+    calls_storage.list.return_value = ["key1", "key2"]
+    calls_storage.load.side_effect = ["result1", "result2"]
     metadata = Mock()
     metadata.load.side_effect = ["metadata1", "metadata2"]
 
-    c1 = Cache(values_storage, invocs_storage).metadb(metadata)
+    c1 = Cache(values_storage, calls_storage).metadb(metadata)
 
     other_values_storage = Mock()
-    other_invocs_storage = Mock()
+    other_calls_storage = Mock()
     other_metadata = Mock()
-    c2 = Cache(other_values_storage, other_invocs_storage).metadb(other_metadata)
+    c2 = Cache(other_values_storage, other_calls_storage).metadb(other_metadata)
 
     c1.transfer(c2)
 
-    assert other_invocs_storage.save.call_count == 2
-    other_invocs_storage.save.assert_any_call("key1", "result1")
-    other_invocs_storage.save.assert_any_call("key2", "result2")
+    assert other_calls_storage.save.call_count == 2
+    other_calls_storage.save.assert_any_call("key1", "result1")
+    other_calls_storage.save.assert_any_call("key2", "result2")
 
     assert other_metadata.save.call_count == 2
     other_metadata.save.assert_any_call("key1", "metadata1")
@@ -100,9 +100,9 @@ def test_base_cache_transfer():
 
 
 def test_readonly_cache_save():
-    from fleche.invocation import Invocation
+    from fleche.call import Call
     c = ReadOnlyCache(Mock())
-    inv = Invocation(name="test", args=(1,), kwargs={}, result="result")
+    inv = Call(name="test", args=(1,), kwargs={}, result="result")
     with pytest.raises(Rejected):
         c.save(inv)
 
@@ -115,22 +115,22 @@ def test_readonly_cache_load():
 
 
 def test_cache_stack_save():
-    from fleche.invocation import Invocation
+    from fleche.call import Call
     c1 = Mock()
     c2 = Mock()
     stack = CacheStack((c1, c2))
-    inv = Invocation(name="test", args=(1,), kwargs={}, result="result")
+    inv = Call(name="test", args=(1,), kwargs={}, result="result")
     stack.save(inv)
     c1.save.assert_called_once()
     c2.save.assert_not_called()
 
 
 def test_cache_stack_load_hit():
-    from fleche.invocation import Invocation
+    from fleche.call import Call
     c1 = Mock()
     c1.load.side_effect = KeyError
     c2 = Mock()
-    inv = Invocation(name="test", args=(1,), kwargs={}, result="result")
+    inv = Call(name="test", args=(1,), kwargs={}, result="result")
     c2.load.return_value = inv
     stack = CacheStack((c1, c2))
     result = stack.load("key")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from fleche import load_cache_config, storage, cache
 from fleche.cache import Cache, BaseCache
-from fleche.metadata import Runtime, InvocationInfo
+from fleche.metadata import Runtime, CallInfo
 
 
 @dataclass
@@ -29,29 +29,29 @@ def config_file():
     config = textwrap.dedent("""
         [default]
         cache = "mycache"
-        metadata = ["Runtime", "InvocationInfo"]
+        metadata = ["Runtime", "CallInfo"]
 
         [mycache]
         values.type = "Memory"
-        invocs.type = "Memory"
+        calls.type = "Memory"
 
         [transient]
         values.type = "CloudpickleFile"
         values.root = ".fleche/values"
-        invocs.type = "CloudpickleFile"
-        invocs.root = ".fleche/invocs"
+        calls.type = "CloudpickleFile"
+        calls.root = ".fleche/calls"
 
         [global]
         values.type = "BagOfHoldingH5File"
         values.root = "~/.fleche/values"
-        invocs.type = "CloudpickleFile"
-        invocs.root = "~/.fleche/invocs"
+        calls.type = "CloudpickleFile"
+        calls.root = "~/.fleche/calls"
 
         [nested]
         values.type = "NestedStorage"
         values.arg = "test"
         values.inner.type = "Memory"
-        invocs.type = "Memory"
+        calls.type = "Memory"
     """)
     with tempfile.TemporaryDirectory() as tmpdir:
         config_dir = Path(tmpdir) / "fleche"
@@ -65,10 +65,10 @@ def config_file():
 def config_file_explicit_default():
     config = textwrap.dedent("""
         [default]
-        metadata = ["Runtime", "InvocationInfo"]
+        metadata = ["Runtime", "CallInfo"]
         [default.cache]
         values.type = "Memory"
-        invocs.type = "Memory"
+        calls.type = "Memory"
     """)
     with tempfile.TemporaryDirectory() as tmpdir:
         config_dir = Path(tmpdir) / "fleche"
@@ -83,7 +83,7 @@ def config_file_with_tags():
     config = textwrap.dedent("""
         [default]
         cache = "mycache"
-        metadata = ["Runtime", "InvocationInfo", "Tags"]
+        metadata = ["Runtime", "CallInfo", "Tags"]
     """)
     with tempfile.TemporaryDirectory() as tmpdir:
         config_dir = Path(tmpdir) / "fleche"
@@ -98,7 +98,7 @@ def config_file_no_default():
     config = textwrap.dedent("""
         [mycache]
         values.type = "Memory"
-        invocs.type = "Memory"
+        calls.type = "Memory"
     """)
     with tempfile.TemporaryDirectory() as tmpdir:
         config_dir = Path(tmpdir) / "fleche"
@@ -115,7 +115,7 @@ def test_load_cache_config_default(monkeypatch, config_file):
 
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.invocs, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.Memory)
 
 
 def test_load_cache_config_explicit_default(monkeypatch, config_file_explicit_default):
@@ -125,7 +125,7 @@ def test_load_cache_config_explicit_default(monkeypatch, config_file_explicit_de
 
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.invocs, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.Memory)
 
 
 def test_load_cache_config_specific(monkeypatch, config_file):
@@ -136,8 +136,8 @@ def test_load_cache_config_specific(monkeypatch, config_file):
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.CloudpickleFile)
     assert cache_obj.values.root == Path(".fleche/values")
-    assert isinstance(cache_obj.invocs, storage.CloudpickleFile)
-    assert cache_obj.invocs.root == Path(".fleche/invocs")
+    assert isinstance(cache_obj.calls, storage.CloudpickleFile)
+    assert cache_obj.calls.root == Path(".fleche/calls")
 
 
 def test_load_cache_config_no_file(monkeypatch):
@@ -145,7 +145,7 @@ def test_load_cache_config_no_file(monkeypatch):
     cache_obj = load_cache_config()
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.invocs, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.Memory)
 
 
 def test_load_cache_config_no_default(monkeypatch, config_file_no_default):
@@ -153,7 +153,7 @@ def test_load_cache_config_no_default(monkeypatch, config_file_no_default):
     cache_obj = load_cache_config()
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.invocs, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.Memory)
 
 
 def test_cache_function_loads_by_name(monkeypatch, config_file):
@@ -201,7 +201,7 @@ def test_load_default_metadata(monkeypatch, config_file):
     meta = fleche._METADATA.get()
     assert len(meta) == 2
     assert isinstance(meta[0], Runtime)
-    assert isinstance(meta[1], InvocationInfo)
+    assert isinstance(meta[1], CallInfo)
 
 
 def test_load_default_cache(monkeypatch, config_file):
@@ -216,10 +216,10 @@ def test_load_default_cache(monkeypatch, config_file):
     assert isinstance(cache_obj, BaseCache)
     if hasattr(cache_obj, "values"):
         assert isinstance(cache_obj.values, storage.Memory)
-        assert isinstance(cache_obj.invocs, storage.Memory)
+        assert isinstance(cache_obj.calls, storage.Memory)
     else:
         assert isinstance(cache_obj.cache.values, storage.Memory)
-        assert isinstance(cache_obj.cache.invocs, storage.Memory)
+        assert isinstance(cache_obj.cache.calls, storage.Memory)
 
 
 def test_tags_disallowed(monkeypatch, config_file_with_tags):

--- a/tests/unit/test_decorator_attributes.py
+++ b/tests/unit/test_decorator_attributes.py
@@ -1,7 +1,7 @@
 
 from fleche import fleche, Cache, cache
 from fleche.storage import Memory
-from fleche.invocation import Invocation
+from fleche.call import Call
 import pytest
 
 def test_fleche_extra_attributes():
@@ -11,8 +11,8 @@ def test_fleche_extra_attributes():
         def add(a, b=1):
             return a + b
 
-        # Test invocation
-        inv = add.invocation(1, b=2)
+        # Test call
+        inv = add.call(1, b=2)
         assert inv.name == "add"
         assert inv.args == (1,)
         assert inv.kwargs == {"b": 2}
@@ -41,12 +41,12 @@ def test_hash_settings():
         def func_no_version(x):
             return x
 
-        inv = func_no_version.invocation(1)
+        inv = func_no_version.call(1)
         assert inv.version is None
 
         @fleche(hash_module=False)
         def func_no_module(x):
             return x
 
-        inv = func_no_module.invocation(1)
+        inv = func_no_module.call(1)
         assert inv.module is None

--- a/tests/unit/test_digest.py
+++ b/tests/unit/test_digest.py
@@ -9,7 +9,7 @@ import string
 
 
 from fleche.digest import digest, Digest
-from fleche.invocation import Invocation
+from fleche.call import Call
 
 
 def test_custom_digest():
@@ -132,10 +132,10 @@ def dataclasses(draw, field_types, frozen=None):
     return cls(*fields)\
 
 
-def invocations(value_types):
-    """Generate random Invocation objects using st.builds."""
+def calls(value_types):
+    """Generate random Call objects using st.builds."""
     return st.builds(
-        Invocation,
+        Call,
         name=st.text(string.ascii_letters, min_size=1, max_size=10),
         args=st.lists(value_types, max_size=3).map(tuple),
         kwargs=st.dictionaries(
@@ -159,9 +159,9 @@ key_strategies = [
 key_strategies.append(dataclasses(st.one_of(*key_strategies), frozen=True))
 
 
-# Base values include all key strategies plus unhashable types like Invocation
+# Base values include all key strategies plus unhashable types like Call
 value_strategies = key_strategies.copy()
-value_strategies.append(invocations(st.one_of(*key_strategies)))
+value_strategies.append(calls(st.one_of(*key_strategies)))
 
 
 st_base_values = st.one_of(*value_strategies)
@@ -211,9 +211,9 @@ def randomly_digest_subvalues(value, data):
         field_dict = {f.name: randomly_digest_subvalues(getattr(value, f.name), data) 
                       for f in fields(value)}
         return type(value)(**field_dict)
-    elif isinstance(value, Invocation):
-        # For Invocation, replace args and kwargs values
-        return Invocation(
+    elif isinstance(value, Call):
+        # For Call, replace args and kwargs values
+        return Call(
             name=value.name,
             args=tuple(randomly_digest_subvalues(arg, data) for arg in value.args),
             kwargs={k: randomly_digest_subvalues(v, data) for k, v in value.kwargs.items()},
@@ -263,8 +263,8 @@ def foo(inp):
     ((Input(2),), (digest(Input(2)),)),
     (Other(Input(2)), Other(Input(digest(2)))),
     (Other(Input(2)), Other(digest(Input(2)))),
-    (Invocation.from_call(foo, Input(1), a=Input(2)), Invocation.from_call(foo, digest(Input(1)), a=Input(2))),
-    (Invocation.from_call(foo, Input(1), a=Input(2)), Invocation.from_call(foo, Input(1), a=digest(Input(2)))),
+    (Call.from_call(foo, Input(1), a=Input(2)), Call.from_call(foo, digest(Input(1)), a=Input(2))),
+    (Call.from_call(foo, Input(1), a=Input(2)), Call.from_call(foo, Input(1), a=digest(Input(2)))),
 ))
 def test_merkle_tree_property_fixed(value, partially_digested_value):
     assert digest(value) == digest(partially_digested_value), (value, partially_digested_value)

--- a/tests/unit/test_fleche.py
+++ b/tests/unit/test_fleche.py
@@ -3,16 +3,16 @@ from unittest.mock import Mock, MagicMock
 
 from fleche import fleche, Cache, _CACHE, cache
 from fleche.digest import digest
-from fleche.invocation import Invocation
+from fleche.call import Call
 from fleche.storage import Memory
 
 
 def setup_function():
     values_storage = Mock()
     values_storage.save.return_value = "digest_value"
-    invocs_storage = Mock()
-    invocs_storage.load.side_effect = KeyError
-    c = Cache(values_storage, invocs_storage)
+    calls_storage = Mock()
+    calls_storage.load.side_effect = KeyError
+    c = Cache(values_storage, calls_storage)
     _CACHE.set(c)
 
 
@@ -42,7 +42,7 @@ def test_fleche_with_meta():
 
     assert my_func(4) == 8
     mock_meta.pre.assert_called_once_with(
-            Invocation(name='my_func', args=(4,), kwargs={}, module='test_fleche', version=None)
+            Call(name='my_func', args=(4,), kwargs={}, module='test_fleche', version=None)
     )
     mock_meta.post.assert_called_once()
 
@@ -55,7 +55,7 @@ def test_fleche_retrieves_from_cache():
     def my_func(x):
         return mock_function(x)
 
-    key = digest(Invocation.from_call(my_func, 2).to_lookup())
+    key = digest(Call.from_call(my_func, 2).to_lookup())
 
     with cache(Cache(Memory({}), Memory({}))):
         # First call, should execute the function and save to cache
@@ -89,8 +89,8 @@ def test_fleche_with_version_argument():
         storage_content[k] = v
         return k
 
-    cache.invocs.load = Mock(side_effect=load_from_storage)
-    cache.invocs.save = Mock(side_effect=save_to_storage)
+    cache.calls.load = Mock(side_effect=load_from_storage)
+    cache.calls.save = Mock(side_effect=save_to_storage)
     cache.values.save = Mock(return_value="digest_value")
 
     # First call, should execute the function and save to cache
@@ -117,7 +117,7 @@ def test_fleche_with_version():
         # First call, should execute the function and save to cache
         assert my_func(2) == 42
         mock_function.assert_called_once_with(2)
-        inv = Invocation.from_call(my_func, 2)
+        inv = Call.from_call(my_func, 2)
         inv.version = 1
         key_v1 = digest(inv.to_lookup())
         assert cache().contains(key_v1)
@@ -145,7 +145,7 @@ def test_fleche_with_module():
 
         assert my_func(2) == 42
         mock_function.assert_called_once_with(2)
-        inv = Invocation.from_call(my_func, 2)
+        inv = Call.from_call(my_func, 2)
         inv.module = "module1"
         key_m1 = digest(inv.to_lookup())
         assert cache().contains(key_m1)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -5,7 +5,7 @@ import pytest
 
 from fleche import fleche, cache, tags, project, metadata
 from fleche.cache import Cache
-from fleche.metadata import MetaData, PandasDB, Invocation
+from fleche.metadata import MetaData, PandasDB, Call
 from fleche.storage import Memory
 
 
@@ -13,8 +13,8 @@ from fleche.storage import Memory
 def cache_it() -> Cache:
     db = PandasDB({})
     values_storage = Memory({})
-    invocs_storage = Memory({})
-    return Cache(values_storage, invocs_storage).metadb(db)
+    calls_storage = Memory({})
+    return Cache(values_storage, calls_storage).metadb(db)
 
 
 def test_fleche_decorator_default_metadata(cache_it: Cache):
@@ -29,8 +29,8 @@ def test_fleche_decorator_default_metadata(cache_it: Cache):
 
     df = cache_it.metadb.table()
     assert "walltime" in df.columns
-    assert "name" in df.columns  # From InvocationInfo
-    assert "module" in df.columns  # From InvocationInfo
+    assert "name" in df.columns  # From CallInfo
+    assert "module" in df.columns  # From CallInfo
     assert len(df) == 1
     assert df['walltime'].iloc[0] < 0.1
 
@@ -40,7 +40,7 @@ def test_fleche_decorator_custom_metadata(cache_it: Cache):
         name = "my_meta"
         keys = {"my_key": str}
 
-        def pre(self, invocation: Invocation):
+        def pre(self, call: Call):
             return {"my_key": "my_value"}
 
     @fleche(meta=(MyMetadata(),))
@@ -60,7 +60,7 @@ def test_metadata_context_manager(cache_it: Cache):
         name = "my_meta"
         keys = {"my_key": str}
 
-        def pre(self, invocation: Invocation):
+        def pre(self, call: Call):
             return {"my_key": "my_value"}
 
     @fleche
@@ -81,14 +81,14 @@ def test_metadata_context_manager_stacking(cache_it: Cache):
         name = "my_meta1"
         keys = {"my_key1": str}
 
-        def pre(self, invocation: Invocation):
+        def pre(self, call: Call):
             return {"my_key1": "my_value1"}
 
     class MyMetadata2(MetaData):
         name = "my_meta2"
         keys = {"my_key2": str}
 
-        def pre(self, invocation: Invocation):
+        def pre(self, call: Call):
             return {"my_key2": "my_value2"}
 
     @fleche
@@ -112,8 +112,8 @@ def test_metadb_table_filtering(cache_it: Cache):
         name = "my_meta"
         keys = {"my_key": str, "my_other_key": int}
 
-        def pre(self, invocation: Invocation):
-            if invocation.kwargs.get("b") == 2:
+        def pre(self, call: Call):
+            if call.kwargs.get("b") == 2:
                 return {"my_key": "my_value", "my_other_key": 1}
             return {"my_key": "another_value", "my_other_key": 2}
 
@@ -149,14 +149,14 @@ def test_fleche_decorator_and_context_manager(cache_it: Cache):
         name = "my_meta1"
         keys = {"my_key1": str}
 
-        def pre(self, invocation: Invocation):
+        def pre(self, call: Call):
             return {"my_key1": "my_value1"}
 
     class MyMetadata2(MetaData):
         name = "my_meta2"
         keys = {"my_key2": str}
 
-        def pre(self, invocation: Invocation):
+        def pre(self, call: Call):
             return {"my_key2": "my_value2"}
 
     @fleche(meta=(MyMetadata1(),))
@@ -176,10 +176,10 @@ def test_fleche_decorator_and_context_manager(cache_it: Cache):
 
 def test_tags():
     values_storage = Memory({})
-    invocs_storage = Memory({})
+    calls_storage = Memory({})
     mdb = PandasDB({})
 
-    with cache(Cache(values_storage, invocs_storage).metadb(mdb)):
+    with cache(Cache(values_storage, calls_storage).metadb(mdb)):
 
         @fleche
         def my_func(a, b):

--- a/tests/unit/test_workdir.py
+++ b/tests/unit/test_workdir.py
@@ -88,7 +88,7 @@ def test_fleche_cleans_up_on_save_error():
         # (or when the context manager exits)
         assert not os.path.exists(workdir)
 
-def test_distinct_workdirs_for_different_invocations():
+def test_distinct_workdirs_for_different_calls():
     workdirs = []
 
     @fleche(isolate=True)
@@ -101,7 +101,7 @@ def test_distinct_workdirs_for_different_invocations():
         func(2)
         assert workdirs[0] != workdirs[1]
 
-def test_distinct_workdirs_for_same_invocation():
+def test_distinct_workdirs_for_same_call():
     workdirs = []
 
     @fleche(isolate=True)


### PR DESCRIPTION
This PR performs a comprehensive refactor to rename the core terminology of the library. `Invocation` has been renamed to `Call`, and the cache attribute `invocs` has been renamed to `calls`.

Key changes:
- `src/fleche/invocation.py` -> `src/fleche/call.py`
- `Invocation` -> `Call`
- `InvocationLookup` -> `CallLookup`
- `InvocationInfo` -> `CallInfo`
- `Cache.invocs` -> `Cache.calls`
- Helper method `.invocation` -> `.call`
- Metadata tag "invocation" -> "call"

All tests pass, and documentation has been updated to reflect these changes.

---
*PR created automatically by Jules for task [11032975512082739717](https://jules.google.com/task/11032975512082739717) started by @pmrv*