### PR TITLE
Refactor test patterns to use .call() and .digest() helpers

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -9,7 +9,7 @@ The following methods are added to the decorated function:
 ### `.call(*args, **kwargs)`
 Returns a `Call` object corresponding to the provided arguments. This object contains metadata about the call, such as the function name, arguments, and version, but does not execute the function.
 
-### `.key(*args, **kwargs)`
+### `.digest(*args, **kwargs)`
 Returns the unique cache key (a digest string) that would be used for the given call.
 
 ### `.load(*args, **kwargs)`

--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -121,7 +121,7 @@ def fleche(
 
     The decorated function is enhanced with helper methods:
     - .call(*args, **kwargs): Get the Call object.
-    - .key(*args, **kwargs): Get the cache key.
+    - .digest(*args, **kwargs): Get the cache key.
     - .load(*args, **kwargs): Load result from cache.
     - .contains(*args, **kwargs): Check if result is in cache.
     The original function is available via .__wrapped__.
@@ -156,7 +156,7 @@ def fleche(
             cache: Cache = _CACHE.get()
             try:
                 inv = get_call(*args, **kwargs)
-                key = wrapper.key(*args, **kwargs)
+                key = wrapper.digest(*args, **kwargs)
             except digest.Unhashable as e:
                 print("WARNING NO HASH:", e.args[0])
                 return func(*args, **kwargs)
@@ -195,9 +195,9 @@ def fleche(
                 return _run_and_cache()
 
         wrapper.call = get_call
-        wrapper.key = lambda *args, **kwargs: digest.digest(get_call(*args, **kwargs).to_lookup())
-        wrapper.load = lambda *args, **kwargs: _CACHE.get().load(wrapper.key(*args, **kwargs)).result
-        wrapper.contains = lambda *args, **kwargs: _CACHE.get().contains(wrapper.key(*args, **kwargs))
+        wrapper.digest = lambda *args, **kwargs: digest.digest(get_call(*args, **kwargs).to_lookup())
+        wrapper.load = lambda *args, **kwargs: _CACHE.get().load(wrapper.digest(*args, **kwargs)).result
+        wrapper.contains = lambda *args, **kwargs: _CACHE.get().contains(wrapper.digest(*args, **kwargs))
         return wrapper
 
     if callable(_func):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -81,8 +81,8 @@ def test_fleche_cache_stack():
 
     stack = CacheStack(stack=(cache2, cache1))
 
-    key1 = digest(Call.from_call(func, 1).to_lookup())
-    key2 = digest(Call.from_call(func, 2).to_lookup())
+    key1 = func.digest(1)
+    key2 = func.digest(2)
 
     with cache(stack):
         # first call, should go in cache2
@@ -118,13 +118,13 @@ def test_fleche_cache_stack_context_manager():
     with cache(cache1):
         with cache(cache2, stack=True):
             func(1)
-            key = digest(Call.from_call(func, 1).to_lookup())
+            key = func.digest(1)
             assert cache2.contains(key)
             assert cache2.load(key).result == 1
             assert not cache1.contains(key)
 
         func(2)
-        key = digest(Call.from_call(func, 2).to_lookup())
+        key = func.digest(2)
         assert cache1.contains(key)
 
         with cache(cache2, stack=True):

--- a/tests/unit/test_decorator_attributes.py
+++ b/tests/unit/test_decorator_attributes.py
@@ -18,8 +18,8 @@ def test_fleche_extra_attributes():
         assert inv.kwargs == {"b": 2}
         assert inv.version == 1
 
-        # Test key
-        key = add.key(1, b=2)
+        # Test digest
+        key = add.digest(1, b=2)
         assert isinstance(key, str)
 
         # Test contains

--- a/tests/unit/test_digest.py
+++ b/tests/unit/test_digest.py
@@ -6,8 +6,10 @@ from dataclasses import dataclass, make_dataclass, is_dataclass, fields
 import math
 import hashlib
 import string
+import keyword
 
 
+from fleche import fleche
 from fleche.digest import digest, Digest
 from fleche.call import Call
 
@@ -126,7 +128,7 @@ def test_specific_iterables_dont_use_generic_iterable_path(monkeypatch):
 def dataclasses(draw, field_types, frozen=None):
     if frozen is None:
         frozen = draw(st.booleans())
-    fields = draw(st.dictionaries(st.text(string.ascii_letters, min_size=3, max_size=3), field_types, min_size=1, max_size=5))
+    fields = draw(st.dictionaries(st.text(string.ascii_letters, min_size=3, max_size=3).filter(lambda s: not keyword.iskeyword(s)), field_types, min_size=1, max_size=5))
     clsname = draw(st.text(string.ascii_letters, min_size=3, max_size=3))
     cls = make_dataclass(clsname, [(k, type(v)) for k, v in fields.items()], frozen=frozen)
     return cls(*fields)\
@@ -254,7 +256,8 @@ class Other:
     i: Input
 
 
-def foo(inp):
+@fleche
+def foo(inp, **kwargs):
     return inp.a / inp.b
 
 
@@ -263,8 +266,8 @@ def foo(inp):
     ((Input(2),), (digest(Input(2)),)),
     (Other(Input(2)), Other(Input(digest(2)))),
     (Other(Input(2)), Other(digest(Input(2)))),
-    (Call.from_call(foo, Input(1), a=Input(2)), Call.from_call(foo, digest(Input(1)), a=Input(2))),
-    (Call.from_call(foo, Input(1), a=Input(2)), Call.from_call(foo, Input(1), a=digest(Input(2)))),
+    (foo.call(Input(1), a=Input(2)), foo.call(digest(Input(1)), a=Input(2))),
+    (foo.call(Input(1), a=Input(2)), foo.call(Input(1), a=digest(Input(2)))),
 ))
 def test_merkle_tree_property_fixed(value, partially_digested_value):
     assert digest(value) == digest(partially_digested_value), (value, partially_digested_value)

--- a/tests/unit/test_fleche.py
+++ b/tests/unit/test_fleche.py
@@ -55,7 +55,7 @@ def test_fleche_retrieves_from_cache():
     def my_func(x):
         return mock_function(x)
 
-    key = digest(Call.from_call(my_func, 2).to_lookup())
+    key = my_func.digest(2)
 
     with cache(Cache(Memory({}), Memory({}))):
         # First call, should execute the function and save to cache
@@ -117,9 +117,7 @@ def test_fleche_with_version():
         # First call, should execute the function and save to cache
         assert my_func(2) == 42
         mock_function.assert_called_once_with(2)
-        inv = Call.from_call(my_func, 2)
-        inv.version = 1
-        key_v1 = digest(inv.to_lookup())
+        key_v1 = my_func.digest(2)
         assert cache().contains(key_v1)
 
         mock_function.__version__ = 2
@@ -128,8 +126,7 @@ def test_fleche_with_version():
         # Second call, with different version, should execute again
         assert my_func(2) == 42
         assert mock_function.call_count == 2
-        inv.version = 2
-        key_v2 = digest(inv.to_lookup())
+        key_v2 = my_func.digest(2)
         assert cache().contains(key_v2)
 
 
@@ -145,9 +142,7 @@ def test_fleche_with_module():
 
         assert my_func(2) == 42
         mock_function.assert_called_once_with(2)
-        inv = Call.from_call(my_func, 2)
-        inv.module = "module1"
-        key_m1 = digest(inv.to_lookup())
+        key_m1 = my_func.digest(2)
         assert cache().contains(key_m1)
 
         # Second call, with different module, should execute again
@@ -155,6 +150,5 @@ def test_fleche_with_module():
         my_func = fleche(mock_function)
         assert my_func(2) == 42
         assert mock_function.call_count == 2
-        inv.module = "module2"
-        key_m2 = digest(inv.to_lookup())
+        key_m2 = my_func.digest(2)
         assert cache().contains(key_m2)


### PR DESCRIPTION
This change refactors the tests to use the more concise `.call()` and `.digest()` helper methods provided by the `@fleche` decorator, replacing the manual creation of `Call` objects and explicit hashing with `digest(Call.from_call(...).to_lookup())`.

To support this, the `.key()` helper method on decorated functions was renamed to `.digest()`. Documentation and docstrings were updated accordingly.

Additionally, a bug in the property-based testing strategy for dataclasses was fixed by filtering out Python keywords from generated field names, which was causing occasional `TypeError` during test collection.

---
*PR created automatically by Jules for task [402587520080205144](https://jules.google.com/task/402587520080205144) started by @pmrv*