### PR TITLE
Add example notebook for fleche extra methods

### DIFF
--- a/notebooks/ExtraMethods.ipynb
+++ b/notebooks/ExtraMethods.ipynb
@@ -11,9 +11,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:45.080652Z",
+     "iopub.status.busy": "2026-02-15T02:47:45.080302Z",
+     "iopub.status.idle": "2026-02-15T02:47:46.270151Z",
+     "shell.execute_reply": "2026-02-15T02:47:46.268349Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: No config file found. Using default memory cache.\n"
+     ]
+    }
+   ],
    "source": [
     "from fleche import fleche\n",
     "import time"
@@ -21,8 +36,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:46.417857Z",
+     "iopub.status.busy": "2026-02-15T02:47:46.417050Z",
+     "iopub.status.idle": "2026-02-15T02:47:46.424233Z",
+     "shell.execute_reply": "2026-02-15T02:47:46.422332Z"
+    }
+   },
    "outputs": [],
    "source": [
     "@fleche\n",
@@ -43,9 +65,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:46.427796Z",
+     "iopub.status.busy": "2026-02-15T02:47:46.427383Z",
+     "iopub.status.idle": "2026-02-15T02:47:46.434033Z",
+     "shell.execute_reply": "2026-02-15T02:47:46.432279Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Function Name: slow_add\n",
+      "Arguments: (10,)\n",
+      "Keyword Arguments: {'b': 20}\n",
+      "Call Object: Call(name='slow_add', args=(10,), kwargs={'b': 20}, metadata={}, module='__main__', version=None, result=None)\n"
+     ]
+    }
+   ],
    "source": [
     "call_info = slow_add.call(10, b=20)\n",
     "print(f\"Function Name: {call_info.name}\")\n",
@@ -65,9 +105,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:46.437260Z",
+     "iopub.status.busy": "2026-02-15T02:47:46.436913Z",
+     "iopub.status.idle": "2026-02-15T02:47:46.442050Z",
+     "shell.execute_reply": "2026-02-15T02:47:46.440672Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cache Key: ebe3dae6bdd18eb9b888a662220433d2fa08c33a7540a0767b4da5cb3e9dcf08\n"
+     ]
+    }
+   ],
    "source": [
     "key = slow_add.digest(10, b=20)\n",
     "print(f\"Cache Key: {key}\")"
@@ -84,9 +139,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:46.445162Z",
+     "iopub.status.busy": "2026-02-15T02:47:46.444895Z",
+     "iopub.status.idle": "2026-02-15T02:47:47.452820Z",
+     "shell.execute_reply": "2026-02-15T02:47:47.450874Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Is (10, 20) in cache? False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Is (10, 20) in cache now? True\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"Is (10, 20) in cache? {slow_add.contains(10, b=20)}\")\n",
     "\n",
@@ -107,9 +184,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:47.456137Z",
+     "iopub.status.busy": "2026-02-15T02:47:47.455840Z",
+     "iopub.status.idle": "2026-02-15T02:47:47.462769Z",
+     "shell.execute_reply": "2026-02-15T02:47:47.461017Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded result: 30\n",
+      "Result for (1, 2) not in cache.\n"
+     ]
+    }
+   ],
    "source": [
     "result = slow_add.load(10, b=20)\n",
     "print(f\"Loaded result: {result}\")\n",
@@ -131,9 +224,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-15T02:47:47.466049Z",
+     "iopub.status.busy": "2026-02-15T02:47:47.465769Z",
+     "iopub.status.idle": "2026-02-15T02:47:48.472639Z",
+     "shell.execute_reply": "2026-02-15T02:47:48.470795Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Result: 30 (took 1.00 seconds bypassing cache)\n"
+     ]
+    }
+   ],
    "source": [
     "start = time.time()\n",
     "res = slow_add.__wrapped__(10, 20)\n",
@@ -158,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I have added a new example notebook `notebooks/ExtraMethods.ipynb` that demonstrates the extra methods added to a function when it is wrapped with the `@fleche` decorator. These methods include `.call()`, `.digest()`, `.contains()`, `.load()`, and the use of `.__wrapped__` to access the original function. I also verified the changes by running the existing test suite and confirmed that they all pass.

---
*PR created automatically by Jules for task [2245987145217727099](https://jules.google.com/task/2245987145217727099) started by @pmrv*