### PR TITLE
Exploit structural hashing for deduplication

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-`fleche` can be configured using a TOML file located at `$XDG_CONFIG_HOME/fleche/cache.toml` (or `~/.config/fleche/cache.toml` if `$XDG_CONFIG_HOME` is not set).
+`fleche` can be configured using a TOML file located at `$XDG_CONFIG_HOME/fleche/caches.toml` (or `~/.config/fleche/caches.toml` if `$XDG_CONFIG_HOME` is not set).
 
 ## Reserved Cache Names
 

--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar, Union
 from . import digest
 from .call import Call
 from .metadata import MetaData, Tags
-from .cache import Cache, Rejected
+from .caches import Cache, Rejected
 from .config import load_cache_config, load_default_metadata
 
 _T = TypeVar("_T")

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from copy import copy, deepcopy
-from typing import Self, Any
+from typing import Self, Iterable
 
-from .digest import digest
+from .digest import digest, Digest
 from .metadata import MetaDB
 from . import storage
 from .call import Call
@@ -48,17 +48,82 @@ class BaseCache(ABC):
         return MetaCache(self, metadb)
 
 
+class Digested(ABC):
+    @abstractmethod
+    def underlying(self):
+        ...
+
+    # mess with our hash to ensure that we are referentially transparent with respect to the underlying list.
+    # For the replacement of the 'real' list with the 'digested' list to be invisible to caches, they must hash to the
+    # same values.
+    def __digest__(self):
+        return digest(self.underlying())
+
+
+@dataclass
+class DigestedIterable(Digested):
+    items: Iterable
+
+    def underlying(self):
+        return self.items
+
+
+@dataclass
+class DigestedDict(Digested):
+    items: dict
+
+    def underlying(self):
+        return self.items
+
+
 @dataclass
 class Cache(BaseCache):
     values: storage.Storage
     calls: storage.Storage
 
+    def _recursive_value_save(self, value):
+        match value:
+            case list() | tuple():
+                return self.values.save(
+                        DigestedIterable(type(value)(self._recursive_value_save(v) for v in value))
+                )
+            case dict():
+                return self.values.save(
+                        DigestedDict(
+                            {self._recursive_value_save(k): self._recursive_value_save(v)
+                                for k, v in value.items()}
+                        )
+                )
+            case _:
+                return self.values.save(value)
+
+    def _recursive_value_load(self, key):
+        if not isinstance(key, Digest):
+            return key
+        value = self.values.load(key)
+        match value:
+            case DigestedIterable(items=items):
+                value = type(items)(self._recursive_value_load(v) for v in items)
+            case DigestedDict(items=items):
+                value = {
+                        self._recursive_value_load(k): self._recursive_value_load(v)
+                        for k, v in value.items.items()
+                }
+        return value
+
     def save(self, inv: Call) -> str:
+        # for arguments saving is not critical, substitute digest and move on
+        def save_or_digest(v):
+            try:
+                return self._recursive_value_save(v)
+            except storage.SaveError:
+                print("WARNING NO ARG SAVE:", v)
+                return digest(v)
         inv = copy(inv)
         try:
-            inv.result = self.values.save(inv.result)
-            inv.args = tuple(self.values.save(a) for a in inv.args)
-            inv.kwargs = {k: self.values.save(v) for k, v in inv.kwargs.items()}
+            inv.result = self._recursive_value_save(inv.result)
+            inv.args = tuple(save_or_digest(a) for a in inv.args)
+            inv.kwargs = {k: save_or_digest(v) for k, v in inv.kwargs.items()}
         except storage.SaveError as e:
             raise Rejected(e)
 
@@ -66,7 +131,7 @@ class Cache(BaseCache):
 
     def load(self, key: str) -> Call:
         inv = deepcopy(self.calls.load(key))
-        inv.result = self.values.load(inv.result)
+        inv.result = self._recursive_value_load(inv.result)
         return inv
 
 

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -31,7 +31,7 @@ import os
 from typing import Any
 
 from . import storage, metadata
-from .cache import Cache
+from .caches import Cache
 
 _live_caches: dict[str, Cache] = {}
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,8 +4,8 @@ import tempfile
 
 from fleche import fleche, cache
 from fleche.digest import digest
+from fleche.caches import Cache, ReadOnlyCache, CacheStack
 from fleche.call import Call
-from fleche.cache import Cache, ReadOnlyCache, CacheStack
 from fleche.storage import CloudpickleFile, Memory
 
 temp = tempfile.TemporaryDirectory()

--- a/tests/unit/test_caches.py
+++ b/tests/unit/test_caches.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock
 import pytest
-from fleche import fleche, cache, Cache
+from fleche import fleche, cache
 from fleche.digest import digest
-from fleche.cache import ReadOnlyCache, CacheStack, Rejected
+from fleche.caches import ReadOnlyCache, CacheStack, Rejected, Cache
 
 
 def test_cache_save():
@@ -13,9 +13,9 @@ def test_cache_save():
     metadata = Mock()
     c = Cache(values_storage, calls_storage).metadb(metadata)
 
-    inv = Call(name="test", args=(1,), kwargs={}, result="result")
-    inv.metadata = {"test": {"key": "value"}}
-    c.save(inv)
+    call = Call(name="test", args=(1,), kwargs={}, result="result")
+    call.metadata = {"test": {"key": "value"}}
+    c.save(call)
 
     # Check that the underlying cache saves values and calls
     assert values_storage.save.called
@@ -102,9 +102,9 @@ def test_base_cache_transfer():
 def test_readonly_cache_save():
     from fleche.call import Call
     c = ReadOnlyCache(Mock())
-    inv = Call(name="test", args=(1,), kwargs={}, result="result")
+    call = Call(name="test", args=(1,), kwargs={}, result="result")
     with pytest.raises(Rejected):
-        c.save(inv)
+        c.save(call)
 
 
 def test_readonly_cache_load():
@@ -119,8 +119,8 @@ def test_cache_stack_save():
     c1 = Mock()
     c2 = Mock()
     stack = CacheStack((c1, c2))
-    inv = Call(name="test", args=(1,), kwargs={}, result="result")
-    stack.save(inv)
+    call = Call(name="test", args=(1,), kwargs={}, result="result")
+    stack.save(call)
     c1.save.assert_called_once()
     c2.save.assert_not_called()
 
@@ -130,13 +130,13 @@ def test_cache_stack_load_hit():
     c1 = Mock()
     c1.load.side_effect = KeyError
     c2 = Mock()
-    inv = Call(name="test", args=(1,), kwargs={}, result="result")
-    c2.load.return_value = inv
+    call = Call(name="test", args=(1,), kwargs={}, result="result")
+    c2.load.return_value = call
     stack = CacheStack((c1, c2))
     result = stack.load("key")
     c1.load.assert_called_once_with("key")
     c2.load.assert_called_once_with("key")
-    assert result == inv
+    assert result == call
 
 
 def test_cache_stack_load_miss():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,7 @@ import pytest
 from dataclasses import dataclass
 
 from fleche import load_cache_config, storage, cache
-from fleche.cache import Cache, BaseCache
+from fleche.caches import Cache, BaseCache
 from fleche.metadata import Runtime, CallInfo
 
 

--- a/tests/unit/test_decorator_attributes.py
+++ b/tests/unit/test_decorator_attributes.py
@@ -12,11 +12,11 @@ def test_fleche_extra_attributes():
             return a + b
 
         # Test call
-        inv = add.call(1, b=2)
-        assert inv.name == "add"
-        assert inv.args == (1,)
-        assert inv.kwargs == {"b": 2}
-        assert inv.version == 1
+        call = add.call(1, b=2)
+        assert call.name == "add"
+        assert call.args == (1,)
+        assert call.kwargs == {"b": 2}
+        assert call.version == 1
 
         # Test digest
         key = add.digest(1, b=2)
@@ -41,12 +41,12 @@ def test_hash_settings():
         def func_no_version(x):
             return x
 
-        inv = func_no_version.call(1)
-        assert inv.version is None
+        call = func_no_version.call(1)
+        assert call.version is None
 
         @fleche(hash_module=False)
         def func_no_module(x):
             return x
 
-        inv = func_no_module.call(1)
-        assert inv.module is None
+        call = func_no_module.call(1)
+        assert call.module is None

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from fleche import fleche, cache, tags, project, metadata
-from fleche.cache import Cache
+from fleche.caches import Cache
 from fleche.metadata import MetaData, PandasDB, Call
 from fleche.storage import Memory
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -5,7 +5,8 @@ import tempfile
 from pathlib import Path
 
 from fleche.storage import SaveError, CloudpickleFile, Memory, BagOfHoldingH5File
-from fleche.digest import digest
+from fleche.digest import digest, Digest
+from fleche.caches import DigestedIterable
 
 
 temp = tempfile.TemporaryDirectory()
@@ -54,3 +55,13 @@ def test_storage_given_key(storage, value):
         np.testing.assert_array_equal(loaded_value, value)
     else:
         assert loaded_value == value, "value not available under given key"
+
+
+@pytest.mark.parametrize("storage", storages)
+@pytest.mark.parametrize("value", [
+    DigestedIterable([Digest("asdf"), Digest("foobar")]),
+    DigestedIterable((Digest("asdf"), Digest("foobar"))),
+])
+def test_digested(storage, value):
+    loaded_value = storage.load(storage.save(value))
+    assert loaded_value == value, "digested value not available under given key"


### PR DESCRIPTION
Instead of saving full objects as they are passed to Storages/Caches, recursive into them if they are lists, tuples or dictionaries, and store the root values and replace them with their digests in the parent structure.

Incidentally also fix an issue where saving an argument may fail, this is downgraded to a warning, since it doesn't impact cachability.