### PR TITLE
Implement entry point discovery for custom digest hooks

### DIFF
--- a/docs/custom_digests.rst
+++ b/docs/custom_digests.rst
@@ -1,0 +1,77 @@
+Customizing Digests
+===================
+
+``fleche`` uses digests to identify objects and determine if a cached result can be reused. By default, it supports many built-in Python types, numpy arrays, and dataclasses. For other types, or to customize how a digest is calculated, you can use one of the following methods.
+
+The ``__digest__`` Method
+-------------------------
+
+The simplest way to customize the digest of an object is to implement a ``__digest__`` method on its class. This method should return a string representing the object's state.
+
+.. code-block:: python
+
+   class MyType:
+       def __init__(self, value):
+           self.value = value
+
+       def __digest__(self):
+           return f"MyType:{self.value}"
+
+Using ``add_hook``
+------------------
+
+If you cannot or do not want to modify a class, you can register a custom digest function using ``fleche.digest.add_hook``.
+
+.. code-block:: python
+
+   from fleche.digest import add_hook, Hook
+
+   class ExternalType:
+       def __init__(self, data):
+           self.data = data
+
+   def external_digest(obj):
+       return f"External:{obj.data}"
+
+   add_hook(Hook(ExternalType, external_digest))
+   # Or using a tuple
+   # add_hook((ExternalType, external_digest))
+
+Hooks registered this way have the highest priority and will override any other digest logic for the given type.
+
+Registering Entry Points
+------------------------
+
+For library authors who want to provide ``fleche`` support for their types without requiring users to manually call ``add_hook``, ``fleche`` supports Python entry points.
+
+You can register your digest hooks in the ``fleche.digest`` entry point group in your ``pyproject.toml`` (or equivalent).
+
+.. code-block:: toml
+
+   [project.entry-points."fleche.digest"]
+   my_package_hooks = "my_package.hooks:get_hooks"
+
+The entry point can point to:
+* A single ``fleche.digest.Hook`` object.
+* A tuple of ``(Type, Callable)``.
+* A list containing any combination of the above.
+
+.. code-block:: python
+
+   # my_package/hooks.py
+   from fleche.digest import Hook
+
+   def get_hooks():
+       return [
+           Hook(TypeA, digest_a),
+           (TypeB, digest_b),
+       ]
+
+Lazy Loading and Retries
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To avoid unnecessary overhead, ``fleche`` loads entry points lazily. If ``digest()`` encounters an object it doesn't know how to handle (an ``Unhashable`` error), it will:
+1. Load all registered entry points.
+2. Retry the digestion.
+
+If a manual hook (via ``add_hook``) exists for a type provided by an entry point, the manual hook takes precedence and an ``INFO`` message is logged. If multiple entry points provide hooks for the same type, the first one encountered is used.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to the **Fleche** library documentation.
    installation
    helpers
    digests_as_args
+   custom_digests
    configuration
 
 Indices and tables

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -2,6 +2,7 @@ import hashlib
 import dataclasses
 import struct
 import types
+import importlib.metadata
 from collections.abc import Iterable
 from typing import Any, TypeVar, Callable
 
@@ -30,10 +31,11 @@ class Hook:
 
 
 _HOOKS = []
+_EP_HOOKS = []
 
 
 def get_hooks():
-    return _HOOKS
+    return _HOOKS + _EP_HOOKS
 
 
 def add_hook(hook: Hook | tuple[str, Callable[[T], str]]):
@@ -42,7 +44,53 @@ def add_hook(hook: Hook | tuple[str, Callable[[T], str]]):
     _HOOKS.append(hook)
 
 
+def load_entry_points():
+    _EP_HOOKS.clear()
+    eps = importlib.metadata.entry_points(group="fleche", name="digest")
+
+    seen_types = {h.type: "add_hook" for h in _HOOKS}
+
+    for ep in eps:
+        try:
+            hooks = ep.load()
+            if not isinstance(hooks, list):
+                hooks = [hooks]
+
+            for hook in hooks:
+                if isinstance(hook, tuple):
+                    hook = Hook(*hook)
+
+                if hook.type in seen_types:
+                    source = seen_types[hook.type]
+                    if source == "add_hook":
+                        print(
+                            "INFO",
+                            f"add_hook for {hook.type} overrides entry point {ep.value}",
+                        )
+                    else:
+                        for h in _EP_HOOKS:
+                            if (h.type is not hook.type) and (h.digest is not hook.digest):
+                                print(
+                                    "INFO",
+                                    f"Digest from {source} overrides later entry point {ep.value}!"
+                                )
+                    continue
+
+                _EP_HOOKS.append(hook)
+                seen_types[hook.type] = ep.value
+        except Exception as e:
+            print("ERROR", f"Failed to load entry point {ep.name}: {e}")
+
+
 def digest(value: Any) -> str:
+    try:
+        return _digest(value)
+    except Unhashable:
+        load_entry_points()
+    return _digest(value)
+
+
+def _digest(value: Any) -> str:
     """
     Generates a SHA256 digest for a given Python object.
 

--- a/tests/unit/test_entry_points.py
+++ b/tests/unit/test_entry_points.py
@@ -1,0 +1,109 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fleche.digest import digest, Unhashable, Hook, _HOOKS, load_entry_points
+
+class CustomType:
+    def __init__(self, value):
+        self.value = value
+
+def custom_digest(obj):
+    return f"custom:{obj.value}"
+
+def test_entry_point_discovery():
+    """
+    Test that entry points are automatically discovered and loaded when an
+    Unhashable error occurs.
+    """
+    # Reset hooks for testing
+    _HOOKS.clear()
+
+    obj = CustomType("test")
+
+    # Initially it should fail
+    with pytest.raises(Unhashable):
+        digest(obj)
+
+    # Mock entry point
+    mock_ep = MagicMock()
+    mock_ep.name = "custom_type"
+    mock_ep.value = "some.module:hook"
+    mock_ep.load.return_value = Hook(CustomType, custom_digest)
+
+    with patch("importlib.metadata.entry_points") as mock_entry_points:
+        mock_entry_points.return_value = [mock_ep]
+
+        # This should now succeed and discovery should have happened
+        result = digest(obj)
+        assert result == "custom:test"
+        mock_entry_points.assert_called_with(group="fleche", name="digest")
+
+def test_entry_point_list_discovery():
+    """
+    Test that entry points returning a list of Hook objects are correctly handled.
+    """
+    _HOOKS.clear()
+    obj = CustomType("test")
+
+    mock_ep = MagicMock()
+    mock_ep.load.return_value = [Hook(CustomType, custom_digest)]
+
+    with patch("importlib.metadata.entry_points") as mock_entry_points:
+        mock_entry_points.return_value = [mock_ep]
+        result = digest(obj)
+        assert result == "custom:test"
+
+def test_add_hook_priority():
+    """
+    Test that hooks manually added via add_hook take precedence over entry points,
+    and that an INFO message is logged when an entry point is overridden.
+    """
+    _HOOKS.clear()
+    from fleche.digest import add_hook
+
+    def manual_digest(obj):
+        return f"manual:{obj.value}"
+
+    add_hook(Hook(CustomType, manual_digest))
+
+    obj = CustomType("test")
+
+    mock_ep = MagicMock()
+    mock_ep.name = "ep_name"
+    mock_ep.load.return_value = Hook(CustomType, custom_digest)
+
+    with patch("importlib.metadata.entry_points") as mock_entry_points:
+        mock_entry_points.return_value = [mock_ep]
+
+        # Manually trigger loading to verify priority and logging
+        load_entry_points()
+
+        result = digest(obj)
+        assert result == "manual:test"
+
+
+def test_multiple_entry_points():
+    """
+    Test that when multiple entry points provide different hooks for the same type,
+    the first one is used.
+    """
+    _HOOKS.clear()
+
+    mock_ep1 = MagicMock()
+    mock_ep1.name = "ep1"
+    mock_ep1.load.return_value = Hook(CustomType, custom_digest)
+
+    def another_digest(obj):
+        return "another"
+
+    mock_ep2 = MagicMock()
+    mock_ep2.name = "ep2"
+    mock_ep2.load.return_value = Hook(CustomType, another_digest)
+
+    with patch("importlib.metadata.entry_points") as mock_entry_points:
+        mock_entry_points.return_value = [mock_ep1, mock_ep2]
+
+        # Manually trigger loading
+        load_entry_points()
+
+        assert digest(CustomType(4)) == custom_digest(CustomType(4))


### PR DESCRIPTION
This change allows other packages to register custom digest functions for their types using Python entry points. The discovery mechanism is lazy, triggered only when a type cannot be hashed by the built-in logic or existing hooks. It also ensures that manual registration via `add_hook` maintains the highest priority and provides helpful logging when hooks are overridden or multiple entry points conflict.

---
*PR created automatically by Jules for task [6183351316784295145](https://jules.google.com/task/6183351316784295145) started by @pmrv*