### PR TITLE
Refactor Storage.save/load to follow template method pattern

### DIFF
--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -7,24 +7,20 @@ from bagofholding import H5Bag
 
 from .file import FileStorage
 from .base import SaveError
-from ..digest import digest, Digest, DIGEST_LENGTH
+from ..digest import Digest
 
 
 @dataclass
 class BagOfHoldingH5File(FileStorage):
 
-    def save(self, value: Any, key: Digest | None = None) -> Digest:
-        if key is None:
-            key = digest(value)
+    def _save(self, value: Any, key: Digest) -> str:
         try:
             H5Bag.save(value, self._path(key))
         except (ValueError, TypeError):  # h5py choked on something, pass it along
             raise SaveError(value) from None
         return key
 
-    def load(self, key: str) -> Any:
-        if len(key) < DIGEST_LENGTH:
-            key = self.expand(key)
+    def _load(self, key: str) -> Any:
         try:
             return H5Bag(self._path(key)).load()
         except FileNotFoundError:

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -20,11 +20,21 @@ class AmbiguousDigestError(ValueError):
 class Storage(ABC):
     """Abstract base class for defining storage mechanisms."""
 
-    @abstractmethod
-    def save(self, value: Any, key: Digest | None = None) -> str: ...
+    def save(self, value: Any, key: Digest | None = None) -> str:
+        if key is None:
+            key = digest(value)
+        return self._save(value, key)
 
     @abstractmethod
-    def load(self, key: str) -> Any: ...
+    def _save(self, value: Any, key: Digest) -> str: ...
+
+    def load(self, key: str) -> Any:
+        if len(key) < DIGEST_LENGTH:
+            key = self.expand(key)
+        return self._load(key)
+
+    @abstractmethod
+    def _load(self, key: str) -> Any: ...
 
     @abstractmethod
     def list(self) -> Iterable[str]: ...

--- a/src/fleche/storage/cloudpickle_file.py
+++ b/src/fleche/storage/cloudpickle_file.py
@@ -6,7 +6,7 @@ from typing import Any
 from cloudpickle import loads, dumps
 
 from .file import FileStorage
-from ..digest import digest, Digest, DIGEST_LENGTH
+from ..digest import Digest
 
 
 @dataclass
@@ -15,15 +15,11 @@ class CloudpickleFile(FileStorage):
     Store values as files on the filesystem using cloudpickle for serialization.
     """
 
-    def save(self, value: Any, key: Digest | None = None) -> str:
-        if key is None:
-            key = digest(value)
+    def _save(self, value: Any, key: Digest) -> str:
         (self._path(key)).write_bytes(dumps(value))
         return key
 
-    def load(self, key: str) -> Any:
-        if len(key) < DIGEST_LENGTH:
-            key = self.expand(key)
+    def _load(self, key: str) -> Any:
         try:
             return loads((self._path(key)).read_bytes())
         except FileNotFoundError:

--- a/src/fleche/storage/memory.py
+++ b/src/fleche/storage/memory.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Iterable
 
 from .base import Storage, CallStorage
-from ..digest import digest, Digest, DIGEST_LENGTH
+from ..digest import Digest
 from copy import deepcopy
 
 
@@ -16,17 +16,13 @@ class Memory(CallStorage, Storage):
 
     storage: dict[str, Any]
 
-    def save(self, value: Any, key: Digest | None = None) -> str:
-        if key is None:
-            key = digest(value)
+    def _save(self, value: Any, key: Digest) -> str:
         if key in self.storage:
             return key
         self.storage[key] = deepcopy(value)
         return key
 
-    def load(self, key: str) -> Any:
-        if len(key) < DIGEST_LENGTH:
-            key = self.expand(key)
+    def _load(self, key: str) -> Any:
         return deepcopy(self.storage[key])
 
     def list(self) -> Iterable[str]:

--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from .file import FileStorage
-from ..digest import digest, Digest, DIGEST_LENGTH
+from ..digest import Digest
 
 
 @dataclass
@@ -14,15 +14,11 @@ class PickleFile(FileStorage):
     Store values as files on the filesystem using the standard pickle module for serialization.
     """
 
-    def save(self, value: Any, key: Digest | None = None) -> str:
-        if key is None:
-            key = digest(value)
+    def _save(self, value: Any, key: Digest) -> str:
         (self._path(key)).write_bytes(pickle.dumps(value))
         return key
 
-    def load(self, key: str) -> Any:
-        if len(key) < DIGEST_LENGTH:
-            key = self.expand(key)
+    def _load(self, key: str) -> Any:
         try:
             return pickle.loads((self._path(key)).read_bytes())
         except FileNotFoundError:

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -18,7 +18,7 @@ from sqlalchemy.types import JSON
 
 from .base import CallStorage, AmbiguousDigestError
 from ..call import Call
-from ..digest import digest, Digest, DIGEST_LENGTH
+from ..digest import Digest, DIGEST_LENGTH
 
 Base = declarative_base()
 
@@ -115,10 +115,7 @@ class Sql(CallStorage):
             bind=self.engine, expire_on_commit=False, future=True
         )
 
-    def save(self, value: Call, key: Digest | None = None) -> str:
-        if key is None:
-            key = digest(value)
-
+    def _save(self, value: Call, key: Digest) -> str:
         session: Session = self.Session()
         try:
             existing = session.execute(
@@ -158,10 +155,7 @@ class Sql(CallStorage):
         finally:
             session.close()
 
-    def load(self, key: str) -> Call:
-        if len(key) < DIGEST_LENGTH:
-            key = self.expand(key)
-
+    def _load(self, key: str) -> Call:
         session: Session = self.Session()
         try:
             call_model = session.execute(


### PR DESCRIPTION
This PR refactors the `Storage` abstract base class and its various implementations to centralize common logic for saving and loading.

Specifically:
- `Storage.save` is now a concrete method that handles generating a `Digest` from the value if no key is provided, then calls the new abstract `_save` method.
- `Storage.load` is now a concrete method that handles expanding short-hand digests before calling the new abstract `_load` method.
- All concrete storage implementations (`Memory`, `PickleFile`, `CloudpickleFile`, `BagOfHoldingH5File`, and `Sql`) have been updated to implement `_save` and `_load` instead of `save` and `load`, removing redundant boilerplate logic.

This change makes the `Storage` API more consistent with the existing `evict`/`_evict` pattern.

---
*PR created automatically by Jules for task [10059533322816865978](https://jules.google.com/task/10059533322816865978) started by @pmrv*