### PR TITLE
Refactor to drop the CallLookup class

### DIFF
--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -187,7 +187,7 @@ def fleche(
             cache: Cache = _CACHE.get()
             try:
                 call = get_call(*args, **kwargs)
-                key = digest.digest(call.to_lookup())
+                key = call.to_lookup_key()
             except digest.Unhashable as e:
                 print("WARNING NO HASH:", e.args[0])
                 return func(*args, **kwargs)
@@ -232,8 +232,7 @@ def fleche(
         wrapper.call = get_call
 
         def _digest_func(*args, **kwargs):
-            call = get_call(*args, **kwargs)
-            return digest.digest(call.to_lookup())
+            return get_call(*args, **kwargs).to_lookup_key()
 
         wrapper.digest = _digest_func
         wrapper.load = lambda *args, **kwargs: _CACHE.get().load(_digest_func(*args, **kwargs)).result

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -162,7 +162,7 @@ class Cache(BaseCache):
         except storage.SaveError as e:
             raise Rejected(e)
 
-        return self.calls.save(call, key=digest(call.to_lookup()))
+        return self.calls.save(call, key=call.to_lookup_key())
 
     def load(self, key: str) -> Call:
         call = self.calls.load(key)

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass, field
-from typing import Any, Iterable
+from dataclasses import dataclass, field, replace
+from typing import Any
 from inspect import signature
 
-import fleche.digest
+from . import digest
 
 
 @dataclass
@@ -35,29 +35,11 @@ class Call:
         if hasattr(func, "__module__"):
             call.module = func.__module__
         if hasattr(func, "__code__"):
-            call.code_digest = fleche.digest.digest(func.__code__)
+            call.code_digest = digest.digest(func.__code__)
         return call
 
-    def to_lookup(self):
+    def to_lookup_key(self):
         # Iterate explicitly in the preserved parameter order; do not sort
-        arg_pairs = tuple(
-            (k, fleche.digest.digest(v))
-            for k, v in self.arguments.items()
-        )
-        return CallLookup(
-            name=self.name,
-            arguments=arg_pairs,
-            module=self.module,
-            version=self.version,
-            code_digest=self.code_digest,
-        )
-
-
-@dataclass(frozen=True)
-class CallLookup:
-    """Subset of :class:`.Call` to be used as a lookup key """
-    name: str
-    arguments: tuple[tuple[str, str], ...]
-    module: str | None = None
-    version: int | None = None
-    code_digest: str | None = None
+        arg_pairs = tuple(self.arguments.items())
+        call = replace(self, arguments=arg_pairs, metadata=None, result=None)
+        return digest.digest(call)

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from copy import deepcopy
-from pathlib import Path
 from typing import Iterable, Any
 
 from ..digest import digest, Digest, DIGEST_LENGTH

--- a/tests/unit/test_fleche.py
+++ b/tests/unit/test_fleche.py
@@ -2,8 +2,6 @@
 from unittest.mock import Mock, MagicMock
 
 from fleche import fleche, Cache, _CACHE, cache
-from fleche.digest import digest
-from fleche.call import Call
 from fleche.storage import Memory
 
 
@@ -83,7 +81,7 @@ def test_fleche_with_version_argument():
         return storage_content[k]
 
     def save_to_storage(v, key=None):
-        k = digest(v.to_lookup())
+        k = v.to_lookup_key()
         storage_content[k] = v
         return k
 


### PR DESCRIPTION
Since it was only used to be digested straight away, the digest is now inlined into the (Renamed) to_lookup_key method.