### PR TITLE
Fix numpy array hashing to include dtype and shape

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -138,6 +138,8 @@ def _digest(value: Any) -> str:
                 m.update(digest(k).encode())
                 m.update(digest(v).encode())
         case np.ndarray():
+            m.update(digest(value.dtype.str).encode())
+            m.update(digest(value.shape).encode())
             m.update(value.tobytes())
         case types.CodeType():
             # captured properties for behavior stability

--- a/tests/unit/digest/test_numpy_digest.py
+++ b/tests/unit/digest/test_numpy_digest.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+from hypothesis import given, strategies as st
+from hypothesis.extra import numpy as hnp
+from fleche.digest import digest
+
+@given(st.data())
+def test_numpy_array_hashes_distinctly(data):
+    # Generate two arrays
+    arr1 = data.draw(hnp.arrays(dtype=hnp.scalar_dtypes(), shape=hnp.array_shapes()))
+    arr2 = data.draw(hnp.arrays(dtype=hnp.scalar_dtypes(), shape=hnp.array_shapes()))
+
+    # Check for distinctions in dtype, shape, or bytes content
+    # Note: np.dtype objects can be compared directly for equality.
+    # We use .str to be sure we are looking at the string representation if needed,
+    # but the requirement says "if any of the following are distinct: dtype, shape, bytes content".
+    distinct_dtype = arr1.dtype != arr2.dtype
+    distinct_shape = arr1.shape != arr2.shape
+    distinct_content = arr1.tobytes() != arr2.tobytes()
+
+    if distinct_dtype or distinct_shape or distinct_content:
+        assert digest(arr1) != digest(arr2), (
+            f"Arrays should hash differently but didn't.\n"
+            f"arr1: shape={arr1.shape}, dtype={arr1.dtype}, digest={digest(arr1)}\n"
+            f"arr2: shape={arr2.shape}, dtype={arr2.dtype}, digest={digest(arr2)}\n"
+            f"Differences: dtype={distinct_dtype}, shape={distinct_shape}, content={distinct_content}"
+        )
+    else:
+        # If they are same in all three, they MUST hash the same
+        assert digest(arr1) == digest(arr2)
+
+def test_numpy_explicit_cases():
+    # Explicitly test the cases that were failing
+
+    # Same content, different dtype
+    a = np.array([0], dtype='int32')
+    b = np.array([0], dtype='float32')
+    assert a.tobytes() == b.tobytes()
+    assert a.dtype != b.dtype
+    assert digest(a) != digest(b)
+
+    # Same content, different shape
+    c = np.array([1, 2, 3, 4], dtype='int64')
+    d = np.array([[1, 2], [3, 4]], dtype='int64')
+    assert c.tobytes() == d.tobytes()
+    assert c.shape != d.shape
+    assert digest(c) != digest(d)


### PR DESCRIPTION
This change fixes a bug where `numpy` arrays with different shapes or dtypes could result in the same cache key if their underlying byte content was identical. For example, `np.array([0], dtype='int32')` and `np.array([0], dtype='float32')` would previously hash to the same value.

I have:
1. Created a property-based test using `hypothesis` that verifies arrays hash differently if `dtype`, `shape`, or content are distinct.
2. Modified `src/fleche/digest.py` to include `value.dtype.str` and `value.shape` in the hashing process for `np.ndarray`.
3. Verified that the new tests pass and no regressions were introduced in the existing test suite.


---
*PR created automatically by Jules for task [11333971441961714750](https://jules.google.com/task/11333971441961714750) started by @pmrv*