### PR TITLE
Introduce cache hit/miss statistics on Call objects

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from .digest import digest, Digest
 from . import storage
-from .call import Call
+from .call import Call, Statistics
 
 
 class Rejected(Exception):
@@ -162,10 +162,20 @@ class Cache(BaseCache):
         except storage.SaveError as e:
             raise Rejected(e)
 
-        return self.calls.save(call, key=call.to_lookup_key())
+        key = call.to_lookup_key()
+        try:
+            existing = self.calls.load(key)
+            call.stats = Statistics(hits=existing.stats.hits, misses=existing.stats.misses + 1)
+        except KeyError:
+            call.stats = Statistics(hits=0, misses=1)
+
+        return self.calls.save(call, key=key)
 
     def load(self, key: str) -> Call:
         call = self.calls.load(key)
+        call.stats.hits += 1
+        self.calls.save(call, key=key)
+
         call.arguments = {k: self._handle_args_load(v) for k, v in call.arguments.items()}
         call.result = self.load_value(call.result)
         return call

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -6,6 +6,12 @@ from . import digest
 
 
 @dataclass
+class Statistics:
+    hits: int = 0
+    misses: int = 0
+
+
+@dataclass
 class Call:
     """
     Represents a function call, capturing its name, arguments, and keyword arguments.
@@ -21,6 +27,7 @@ class Call:
     version: int | None = None
     code_digest: str | None = None
     result: Any = None
+    stats: Statistics = field(default_factory=Statistics)
 
     @classmethod
     def from_call(cls, func, *args, **kwargs):
@@ -41,5 +48,5 @@ class Call:
     def to_lookup_key(self):
         # Iterate explicitly in the preserved parameter order; do not sort
         arg_pairs = tuple(self.arguments.items())
-        call = replace(self, arguments=arg_pairs, metadata=None, result=None)
+        call = replace(self, arguments=arg_pairs, metadata=None, result=None, stats=None)
         return digest.digest(call)

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import declarative_base, sessionmaker, relationship, Session
 from sqlalchemy.types import JSON
 
 from .base import CallStorage, AmbiguousDigestError
-from ..call import Call
+from ..call import Call, Statistics
 from ..digest import Digest, DIGEST_LENGTH
 
 Base = declarative_base()
@@ -30,6 +30,8 @@ class CallModel(Base):
     module = Column(String, nullable=True)
     version = Column(Integer, nullable=True)
     result = Column(String(DIGEST_LENGTH), nullable=True)
+    hits = Column(Integer, default=0, nullable=False)
+    misses = Column(Integer, default=0, nullable=False)
 
     arguments = relationship(
         "ArgumentModel",
@@ -120,20 +122,33 @@ class Sql(CallStorage):
         try:
             existing = session.get(CallModel, str(key))
             if existing is not None:
-                if self._load(str(key)) == value:
-                    return key
+                # Update basic fields
+                existing.name = value.name
+                existing.module = value.module
+                existing.version = value.version
+                existing.result = value.result if value.result is None else str(value.result)
+                existing.hits = value.stats.hits
+                existing.misses = value.stats.misses
 
-                session.delete(existing)
-                session.flush()
-
-            call_model = CallModel(
-                key=str(key),
-                name=value.name,
-                module=value.module,
-                version=value.version,
-                result=value.result if value.result is None else str(value.result),
-            )
-            session.add(call_model)
+                # Replace arguments and metadata to ensure they match the new Call object
+                # (Simple way to handle potential changes in arguments or metadata for the same key)
+                session.execute(
+                    ArgumentModel.__table__.delete().where(ArgumentModel.call_key == str(key))
+                )
+                session.execute(
+                    MetaModel.__table__.delete().where(MetaModel.call_key == str(key))
+                )
+            else:
+                existing = CallModel(
+                    key=str(key),
+                    name=value.name,
+                    module=value.module,
+                    version=value.version,
+                    result=value.result if value.result is None else str(value.result),
+                    hits=value.stats.hits,
+                    misses=value.stats.misses,
+                )
+                session.add(existing)
 
             for i, (k, v) in enumerate(value.arguments.items()):
                 session.add(
@@ -181,6 +196,7 @@ class Sql(CallStorage):
                 result=(
                     Digest(call_model.result) if call_model.result is not None else None
                 ),
+                stats=Statistics(hits=call_model.hits, misses=call_model.misses),
             )
             return call
         finally:

--- a/tests/integration/test_cache_statistics.py
+++ b/tests/integration/test_cache_statistics.py
@@ -1,0 +1,132 @@
+
+import pytest
+from fleche import fleche, cache
+from fleche.storage.memory import Memory
+from fleche.storage.sql import Sql
+from fleche.caches import Cache, CacheStack
+
+def test_cache_stats_basic():
+    val_storage = Memory({})
+    call_storage = Memory({})
+    c = Cache(values=val_storage, calls=call_storage)
+
+    with cache(c):
+        @fleche
+        def func(x):
+            return x * 2
+
+        key = func.digest(10)
+
+        # Miss
+        func(10)
+        stats = c.calls.load(key).stats
+        assert stats.misses == 1
+        assert stats.hits == 0
+
+        # Hit
+        func(10)
+        stats = c.calls.load(key).stats
+        assert stats.misses == 1
+        assert stats.hits == 1
+
+def test_cache_stats_sql(tmp_path):
+    db_path = tmp_path / "test.db"
+    val_storage = Memory({})
+    call_storage = Sql(url=str(db_path))
+    c = Cache(values=val_storage, calls=call_storage)
+
+    with cache(c):
+        @fleche
+        def func(x):
+            return x * 2
+
+        key = func.digest(10)
+
+        func(10)
+        stats = c.calls.load(key).stats
+        assert stats.misses == 1
+        assert stats.hits == 0
+
+        func(10)
+        stats = c.calls.load(key).stats
+        assert stats.misses == 1
+        assert stats.hits == 1
+
+def test_cache_stats_stack():
+    # Bottom cache
+    c1 = Cache(values=Memory({}), calls=Memory({}))
+    # Top cache
+    c2 = Cache(values=Memory({}), calls=Memory({}))
+
+    stack = CacheStack((c1, c2))
+
+    with cache(stack):
+        @fleche
+        def func(x):
+            return x * 2
+
+        key = func.digest(5)
+
+        # Initial call - saves to c1 (bottom)
+        func(5)
+
+        assert c1.calls.load(key).stats.misses == 1
+        assert c1.calls.load(key).stats.hits == 0
+        with pytest.raises(KeyError):
+            c2.calls.load(key)
+
+        # Second call - hit in c1
+        func(5)
+        assert c1.calls.load(key).stats.hits == 1
+
+        # Manually move to c2
+        call_obj = c1.calls.load(key)
+        c2.save(call_obj) # This increments misses in c2
+        assert c2.calls.load(key).stats.misses == 1
+
+        # Now call again. stack.load should find it in c1 first if we didn't change the order.
+        # Wait, CacheStack((c1, c2)) -> c1 is stack[0], c2 is stack[1].
+        # load tries stack[0] then stack[1].
+
+        func(5)
+        assert c1.calls.load(key).stats.hits == 2
+        assert c2.calls.load(key).stats.hits == 0 # c2 not reached
+
+        # Reverse stack
+        stack_rev = CacheStack((c2, c1))
+        with cache(stack_rev):
+            func(5)
+            assert c2.calls.load(key).stats.hits == 1
+            assert c1.calls.load(key).stats.hits == 2 # unchanged
+
+def test_key_stability_with_digests():
+    from fleche.digest import digest
+    from fleche.call import Call, Statistics
+
+    def my_func(x):
+        return x * 2
+
+    # Scenario 1: Decorator before save
+    c1 = Call.from_call(my_func, 2)
+    # fleche decorator sets code_digest to None by default
+    c1.code_digest = None
+    k1 = c1.to_lookup_key()
+
+    # Scenario 2: Inside Cache.save
+    # result and arguments are digested
+    res_digest = digest(4)
+    arg_digest = digest(2)
+    c2 = Call(name="my_func", arguments={"x": arg_digest}, result=res_digest, module=c1.module, version=c1.version)
+    c2.code_digest = None
+    k2 = c2.to_lookup_key()
+
+    assert k1 == k2, "Key should be stable even after arguments are converted to Digests"
+
+    # Scenario 3: With different stats
+    c3 = Call(name="my_func", arguments={"x": arg_digest}, result=res_digest,
+              module=c1.module, version=c1.version,
+              stats=Statistics(hits=100, misses=50))
+    c3.code_digest = None
+    k3 = c3.to_lookup_key()
+
+    assert k1 == k3, "Key should be stable regardless of statistics values"

--- a/tests/unit/caches/test_caches.py
+++ b/tests/unit/caches/test_caches.py
@@ -11,6 +11,7 @@ def test_cache_save():
     values_storage = Mock()
     values_storage.save.return_value = 1
     calls_storage = Mock()
+    calls_storage.load.side_effect = KeyError
     c = Cache(values_storage, calls_storage)
 
     call = Call(name="test", arguments={"x": 1}, result="result")
@@ -38,7 +39,7 @@ def test_cache_load():
     ))
     c = Cache(values_storage, calls_storage)
     c.load("key")
-    calls_storage.load.assert_called_once_with("key")
+    assert calls_storage.load.call_count == 1
     values_storage.load.assert_any_call("arg1")
     values_storage.load.assert_any_call("arg2")
     values_storage.load.assert_any_call("kwarg1")
@@ -71,12 +72,14 @@ def test_cache_context_manager():
         with cache(new_cache):
             assert cache() is new_cache
             my_func(2)
-            new_cache.calls.load.assert_called_once()
+            # load is called once by decorator (fails) and once by save()
+            assert new_cache.calls.load.call_count == 2
             assert new_cache.calls.save.call_count == 1
 
         assert cache() is original_cache
         my_func(3)
-        original_cache.calls.load.assert_called_once()
+        # load is called once by decorator (fails) and once by save()
+        assert original_cache.calls.load.call_count == 2
         assert original_cache.calls.save.call_count == 1
 
     # ensure the default cache is restored

--- a/tests/unit/storage/test_sql_stats.py
+++ b/tests/unit/storage/test_sql_stats.py
@@ -1,0 +1,43 @@
+
+import pytest
+from fleche.storage.sql import Sql
+from fleche.call import Call, Statistics
+
+def test_sql_stats_persistence(tmp_path):
+    db_path = tmp_path / "stats.db"
+    store = Sql(str(db_path))
+
+    call = Call(
+        name="test_stats",
+        arguments={"x": "x" * 64},
+        stats=Statistics(hits=42, misses=7)
+    )
+
+    key = store.save(call)
+
+    # Reload from fresh store instance to be sure it's in DB
+    store2 = Sql(str(db_path))
+    loaded = store2.load(key)
+
+    assert loaded.stats.hits == 42
+    assert loaded.stats.misses == 7
+
+def test_sql_stats_update(tmp_path):
+    db_path = tmp_path / "stats_update.db"
+    store = Sql(str(db_path))
+
+    call = Call(name="test", arguments={})
+    key = store.save(call)
+
+    loaded = store.load(key)
+    assert loaded.stats.hits == 0
+    assert loaded.stats.misses == 0
+
+    # Update stats
+    loaded.stats.hits = 10
+    loaded.stats.misses = 5
+    store.save(loaded, key=key)
+
+    loaded2 = store.load(key)
+    assert loaded2.stats.hits == 10
+    assert loaded2.stats.misses == 5


### PR DESCRIPTION
This change introduces tracking of cache hits and misses for each cached function call. The statistics are stored in the `Call` object and persisted in the storage backends (including SQL). 

Key changes:
1. `Call` object now has a `stats` attribute containing `hits` and `misses`.
2. `Cache.load` increments `hits` upon a successful cache hit.
3. `Cache.save` increments `misses` (it's called when a result is newly computed or updated).
4. `Sql` storage implementation was updated to handle these new fields efficiently, using row updates instead of full replacements where possible.
5. Invalidation is avoided by ensuring `stats` is not part of the `to_lookup_key()` digest.
6. Existing tests were updated to handle the new `load` calls during `save` operations.
7. New tests verify persistence, key stability, and stack behavior.

---
*PR created automatically by Jules for task [12014194863574883799](https://jules.google.com/task/12014194863574883799) started by @pmrv*