### PR TITLE
Disentangle CallStorage from Storage

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -18,7 +18,7 @@ class Rejected(Exception):
 class BaseCache(ABC):
 
     @abstractmethod
-    def save(self, value) -> str:
+    def save(self, call: Call) -> str:
         ...
 
     @abstractmethod
@@ -103,7 +103,11 @@ class DigestedDict(Digested):
 @dataclass
 class Cache(BaseCache):
     values: storage.Storage
-    calls: storage.CallStorage
+    calls: storage.CallStorage | storage.Storage
+
+    def __post_init__(self):
+        if isinstance(self.calls, storage.Storage):
+            self.calls = storage.CallStorageAdapter(self.calls)
 
     def _recursive_value_save(self, value):
         match value:
@@ -162,7 +166,7 @@ class Cache(BaseCache):
         except storage.SaveError as e:
             raise Rejected(e)
 
-        return self.calls.save(call, key=call.to_lookup_key())
+        return self.calls.save(call)
 
     def load(self, key: str) -> Call:
         call = self.calls.load(key)
@@ -207,7 +211,7 @@ class CacheStack(BaseCache):
 
     Saving will always hit the lowest level, while loading will traverse up.
     """
-    stack: tuple[Cache]
+    stack: tuple[Cache, ...]
 
     def save(self, call: Call):
         self.stack[0].save(call)

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -82,7 +82,7 @@ def load_entry_points():
             print("ERROR", f"Failed to load entry point {ep.name}: {e}")
 
 
-def digest(value: Any) -> str:
+def digest(value: Any) -> Digest:
     try:
         return _digest(value)
     except Unhashable:
@@ -90,7 +90,7 @@ def digest(value: Any) -> str:
     return _digest(value)
 
 
-def _digest(value: Any) -> str:
+def _digest(value: Any) -> Digest:
     """
     Generates a SHA256 digest for a given Python object.
 

--- a/src/fleche/storage/__init__.py
+++ b/src/fleche/storage/__init__.py
@@ -4,7 +4,7 @@ This module re-exports the primary storage interfaces and implementations
 for backward compatibility with `from fleche.storage import ...` imports.
 """
 
-from .base import SaveError, AmbiguousDigestError, Storage, CallStorage
+from .base import SaveError, AmbiguousDigestError, Storage, CallStorage, CallStorageAdapter
 from .memory import Memory
 from .file import FileStorage
 from .cloudpickle_file import CloudpickleFile
@@ -17,6 +17,7 @@ __all__ = [
     "AmbiguousDigestError",
     "Storage",
     "CallStorage",
+    "CallStorageAdapter",
     "Memory",
     "FileStorage",
     "CloudpickleFile",

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass
 
 from abc import ABC, abstractmethod
 from typing import Iterable, Any, Callable
@@ -15,36 +16,22 @@ class AmbiguousDigestError(ValueError):
     pass
 
 
-class Storage(ABC):
-    """Abstract base class for defining storage mechanisms."""
-
-    def save(self, value: Any, key: Digest | None = None) -> str:
-        if key is None:
-            key = digest(value)
-        return self._save(value, key)
+class StorageBase(ABC):
+    """Shared functionality between value and call storages."""
 
     @abstractmethod
-    def _save(self, value: Any, key: Digest) -> str: ...
+    def list(self) -> Iterable[Digest]: ...
 
-    def load(self, key: str) -> Any:
-        if len(key) < DIGEST_LENGTH:
-            key = self.expand(key)
-        return self._load(key)
-
-    @abstractmethod
-    def _load(self, key: str) -> Any: ...
-
-    @abstractmethod
-    def list(self) -> Iterable[str]: ...
-
-    def evict(self, key: str) -> None:
+    def evict(self, key: Digest | str) -> None:
         """Removes the entry corresponding to the key from the storage."""
         if len(key) < DIGEST_LENGTH:
             key = self.expand(key)
+        else:
+            key = Digest(key)
         self._evict(key)
 
     @abstractmethod
-    def _evict(self, key: str) -> None: ...
+    def _evict(self, key: Digest) -> None: ...
 
     def expand(self, key: Digest | str) -> Digest:
         """Expands a short-hand digest to the full length one."""
@@ -83,8 +70,57 @@ class Storage(ABC):
         )
 
 
-class CallStorage(Storage):
+class Storage(StorageBase):
+    """Abstract base class for defining storage mechanisms."""
+
+    def save(self, value: Any, key: Digest | None = None) -> Digest:
+        if key is None:
+            key = digest(value)
+        return self._save(value, key)
+
+    @abstractmethod
+    def _save(self, value: Any, key: Digest) -> Digest: ...
+
+    def load(self, key: Digest | str) -> Any:
+        if len(key) < DIGEST_LENGTH:
+            key = self.expand(key)
+        else:
+            key = Digest(key)
+        return self._load(key)
+
+    @abstractmethod
+    def _load(self, key: Digest) -> Any: ...
+
+    def redigest(self):
+        """
+        Loads all values and verifies storage key and digest match, save again if not and evict old value.
+        """
+        for key in self.list():
+            value = self.load(key)
+            new_key = digest(value)
+            if new_key != key:
+                self.save(value)
+                self.evict(key)
+
+
+class CallStorage(StorageBase):
     """Special storage for saving :class:`Call` instances."""
+
+    def save(self, call: Call) -> Digest:
+        return self._save(call)
+
+    @abstractmethod
+    def _save(self, call: Call) -> Digest: ...
+
+    def load(self, key: str) -> Call:
+        if len(key) < DIGEST_LENGTH:
+            key = self.expand(key)
+        else:
+            key = Digest(key)
+        return self._load(key)
+
+    @abstractmethod
+    def _load(self, key: Digest) -> Call: ...
 
     def transform(self, func: Callable[[Call], Call] | None = None) -> None:
         """
@@ -103,13 +139,31 @@ class CallStorage(Storage):
             new_call = func(call) if func is not None else call
             new_key = new_call.to_lookup_key()
             if new_key != k:
-                self.save(new_call, key=new_key)
+                self.save(new_call)
                 self.evict(k)
             else:
-                self.save(new_call, key=k)
+                self.save(new_call)
 
     def redigest(self) -> None:
         """
         Re-calculates lookup keys for all Call objects in the storage.
         """
         self.transform(None)
+
+
+@dataclass(frozen=True, slots=True)
+class CallStorageAdapter(CallStorage):
+    """Implement a CallStorage from a generic Storage."""
+    storage: Storage
+
+    def _save(self, call: Call) -> Digest:
+        return self.storage.save(call, call.to_lookup_key())
+
+    def _load(self, key: Digest) -> Call:
+        return self.storage.load(key)
+
+    def _evict(self, key: Digest) -> None:
+        self.storage.evict(key)
+
+    def list(self) -> Iterable[Digest]:
+        return self.storage.list()

--- a/src/fleche/storage/cloudpickle_file.py
+++ b/src/fleche/storage/cloudpickle_file.py
@@ -15,11 +15,11 @@ class CloudpickleFile(FileStorage):
     Store values as files on the filesystem using cloudpickle for serialization.
     """
 
-    def _save(self, value: Any, key: Digest) -> str:
+    def _save(self, value: Any, key: Digest) -> Digest:
         (self._path(key)).write_bytes(dumps(value))
         return key
 
-    def _load(self, key: str) -> Any:
+    def _load(self, key: Digest) -> Any:
         try:
             return loads((self._path(key)).read_bytes())
         except FileNotFoundError:

--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from typing import Iterable
 
 from .base import CallStorage, Storage
+from ..digest import Digest
 
 
 @dataclass
-class FileStorage(CallStorage, Storage):
+class FileStorage(Storage):
     """File-based storage backend using pickle.
 
     Stores objects on the filesystem.
@@ -22,9 +23,9 @@ class FileStorage(CallStorage, Storage):
         self.root.mkdir(parents=True, exist_ok=True)
         return self.root / key
 
-    def list(self) -> Iterable[str]:
+    def list(self) -> Iterable[Digest]:
         self.root.mkdir(parents=True, exist_ok=True)
-        return (p.name for p in self.root.iterdir())
+        return (Digest(p.name) for p in self.root.iterdir())
 
-    def _evict(self, key: str) -> None:
+    def _evict(self, key: Digest) -> None:
         self._path(key).unlink(missing_ok=True)

--- a/src/fleche/storage/memory.py
+++ b/src/fleche/storage/memory.py
@@ -3,28 +3,28 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable
 
-from .base import Storage, CallStorage
+from .base import Storage
 from ..digest import Digest
 from copy import deepcopy
 
 
 @dataclass
-class Memory(CallStorage, Storage):
+class Memory(Storage):
     """
     A concrete implementation of Storage that stores values in an in-memory dictionary.
     """
 
-    storage: dict[str, Any]
+    storage: dict[Digest, Any]
 
-    def _save(self, value: Any, key: Digest) -> str:
+    def _save(self, value: Any, key: Digest) -> Digest:
         self.storage[key] = deepcopy(value)
         return key
 
-    def _load(self, key: str) -> Any:
+    def _load(self, key: Digest) -> Any:
         return deepcopy(self.storage[key])
 
-    def list(self) -> Iterable[str]:
-        return self.storage.keys()
+    def list(self) -> Iterable[Digest]:
+        return tuple(self.storage.keys())
 
-    def _evict(self, key: str) -> None:
+    def _evict(self, key: Digest) -> None:
         self.storage.pop(key, None)

--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -14,11 +14,11 @@ class PickleFile(FileStorage):
     Store values as files on the filesystem using the standard pickle module for serialization.
     """
 
-    def _save(self, value: Any, key: Digest) -> str:
+    def _save(self, value: Any, key: Digest) -> Digest:
         (self._path(key)).write_bytes(pickle.dumps(value))
         return key
 
-    def _load(self, key: str) -> Any:
+    def _load(self, key: Digest) -> Any:
         try:
             return pickle.loads((self._path(key)).read_bytes())
         except FileNotFoundError:

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -115,12 +115,13 @@ class Sql(CallStorage):
             bind=self.engine, expire_on_commit=False, future=True
         )
 
-    def _save(self, value: Call, key: Digest) -> str:
+    def _save(self, call: Call) -> Digest:
+        key = call.to_lookup_key()
         session: Session = self.Session()
         try:
             existing = session.get(CallModel, str(key))
             if existing is not None:
-                if self._load(str(key)) == value:
+                if self.load(key) == call:
                     return key
 
                 session.delete(existing)
@@ -128,23 +129,23 @@ class Sql(CallStorage):
 
             call_model = CallModel(
                 key=str(key),
-                name=value.name,
-                module=value.module,
-                version=value.version,
-                result=value.result if value.result is None else str(value.result),
+                name=call.name,
+                module=call.module,
+                version=call.version,
+                result=call.result if call.result is None else str(call.result),
             )
             session.add(call_model)
 
-            for i, (k, v) in enumerate(value.arguments.items()):
+            for i, (k, v) in enumerate(call.arguments.items()):
                 session.add(
                     ArgumentModel(call_key=str(key), position=i, name=str(k), value=str(v))
                 )
 
-            if value.metadata:
+            if call.metadata:
                 session.add_all(
                     [
                         MetaModel(call_key=str(key), name=name, data=data)
-                        for name, data in value.metadata.items()
+                        for name, data in call.metadata.items()
                     ]
                 )
             session.commit()
@@ -186,7 +187,7 @@ class Sql(CallStorage):
         finally:
             session.close()
 
-    def list(self) -> Iterable[str]:
+    def list(self) -> Iterable[Digest]:
         session: Session = self.Session()
         try:
             # Return Digest instances for keys

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -115,7 +115,8 @@ def test_load_cache_config_default(monkeypatch, config_file):
 
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.calls, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.CallStorageAdapter)
+    assert isinstance(cache_obj.calls.storage, storage.Memory)
 
 
 def test_load_cache_config_explicit_default(monkeypatch, config_file_explicit_default):
@@ -125,7 +126,8 @@ def test_load_cache_config_explicit_default(monkeypatch, config_file_explicit_de
 
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.calls, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.CallStorageAdapter)
+    assert isinstance(cache_obj.calls.storage, storage.Memory)
 
 
 def test_load_cache_config_specific(monkeypatch, config_file):
@@ -136,8 +138,8 @@ def test_load_cache_config_specific(monkeypatch, config_file):
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.CloudpickleFile)
     assert cache_obj.values.root == Path(".fleche/values").absolute()
-    assert isinstance(cache_obj.calls, storage.CloudpickleFile)
-    assert cache_obj.calls.root == Path(".fleche/calls").absolute()
+    assert isinstance(cache_obj.calls.storage, storage.CloudpickleFile)
+    assert cache_obj.calls.storage.root == Path(".fleche/calls").absolute()
 
 
 def test_load_cache_config_no_file(monkeypatch):
@@ -145,7 +147,8 @@ def test_load_cache_config_no_file(monkeypatch):
     cache_obj = load_cache_config()
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.calls, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.CallStorageAdapter)
+    assert isinstance(cache_obj.calls.storage, storage.Memory)
 
 
 def test_load_cache_config_no_default(monkeypatch, config_file_no_default):
@@ -153,7 +156,8 @@ def test_load_cache_config_no_default(monkeypatch, config_file_no_default):
     cache_obj = load_cache_config()
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.Memory)
-    assert isinstance(cache_obj.calls, storage.Memory)
+    assert isinstance(cache_obj.calls, storage.CallStorageAdapter)
+    assert isinstance(cache_obj.calls.storage, storage.Memory)
 
 
 def test_cache_function_loads_by_name(monkeypatch, config_file):
@@ -216,10 +220,10 @@ def test_load_default_cache(monkeypatch, config_file):
     assert isinstance(cache_obj, BaseCache)
     if hasattr(cache_obj, "values"):
         assert isinstance(cache_obj.values, storage.Memory)
-        assert isinstance(cache_obj.calls, storage.Memory)
+        assert isinstance(cache_obj.calls.storage, storage.Memory)
     else:
         assert isinstance(cache_obj.cache.values, storage.Memory)
-        assert isinstance(cache_obj.cache.calls, storage.Memory)
+        assert isinstance(cache_obj.cache.calls.storage, storage.Memory)
 
 
 def test_tags_disallowed(monkeypatch, config_file_with_tags):
@@ -239,7 +243,7 @@ def test_load_cache_config_memory_special_case(monkeypatch, config_file):
 
     assert isinstance(cache1, Cache)
     assert isinstance(cache1.values, storage.Memory)
-    assert isinstance(cache1.calls, storage.Memory)
+    assert isinstance(cache1.calls.storage, storage.Memory)
 
     # Should be a singleton
     cache2 = load_cache_config("memory")

--- a/tests/unit/storage/test_sql_digest_types.py
+++ b/tests/unit/storage/test_sql_digest_types.py
@@ -47,6 +47,7 @@ def test_sql_find_by_metadata_returns_digests(tmp_path):
     store = Sql(str(tmp_path / "calls.db"))
     c1 = make_call()
     c2 = make_call()
+    c1.name = "g"
     # Slightly vary metadata so queries can differentiate
     c2.metadata["tags"]["project"] = "beta"
     k1 = store.save(c1)

--- a/tests/unit/storage/test_transform.py
+++ b/tests/unit/storage/test_transform.py
@@ -1,42 +1,42 @@
 import pytest
+from unittest.mock import patch
 from dataclasses import replace
-from fleche.storage import Memory, Sql, PickleFile, CloudpickleFile, BagOfHoldingH5File
+from fleche.storage import Memory, Sql, PickleFile, CloudpickleFile, BagOfHoldingH5File, CallStorageAdapter
 from fleche.call import Call
 from fleche.digest import Digest
 
 @pytest.fixture(params=["memory", "cloudpickle", "pickle", "h5", "sql"])
 def storage(request, tmp_path):
     if request.param == "memory":
-        return Memory({})
+        return CallStorageAdapter(Memory({}))
     elif request.param == "cloudpickle":
-        return CloudpickleFile(tmp_path / "cloudpickle")
+        return CallStorageAdapter(CloudpickleFile(tmp_path / "cloudpickle"))
     elif request.param == "pickle":
-        return PickleFile(tmp_path / "pickle")
+        return CallStorageAdapter(PickleFile(tmp_path / "pickle"))
     elif request.param == "h5":
-        return BagOfHoldingH5File(tmp_path / "h5")
+        return CallStorageAdapter(BagOfHoldingH5File(tmp_path / "h5"))
     elif request.param == "sql":
         return Sql(tmp_path / "calls.db")
 
 def test_transform_basic(storage):
-    c1 = Call(name="f1", arguments={"a": Digest("a" * 64)}, metadata={"m": 1}, result=Digest("r" * 64))
-    k1 = c1.to_lookup_key()
-    storage.save(c1, key=k1)
+    c1 = Call(name="f1", arguments={"a": Digest("a" * 64)}, metadata={"table": {"m": 1}}, result=Digest("r" * 64))
+    storage.save(c1)
 
     # Transform: update metadata, keep same key
     def update_metadata(call):
-        return replace(call, metadata={"m": 2})
+        return replace(call, metadata={"table": {"m": 2}})
 
     storage.transform(update_metadata)
 
     assert len(list(storage.list())) == 1
+    k1 = c1.to_lookup_key()
     loaded = storage.load(k1)
-    assert loaded.metadata == {"m": 2}
+    assert loaded.metadata == {"table": {"m": 2}}
     assert str(loaded.result) == "r" * 64
 
 def test_transform_key_change(storage):
-    c1 = Call(name="f1", arguments={"a": Digest("a" * 64)}, metadata={"m": 1}, result=Digest("r" * 64))
-    k1 = c1.to_lookup_key()
-    storage.save(c1, key=k1)
+    c1 = Call(name="f1", arguments={"a": Digest("a" * 64)}, metadata={}, result=Digest("r" * 64))
+    storage.save(c1)
 
     # Transform: change argument, change key
     def change_arg(call):
@@ -46,7 +46,7 @@ def test_transform_key_change(storage):
 
     all_keys = list(storage.list())
     assert len(all_keys) == 1
-    assert k1 not in all_keys
+    assert c1.to_lookup_key() not in all_keys
 
     new_c = replace(c1, arguments={"a": Digest("b" * 64)})
     new_k = new_c.to_lookup_key()
@@ -55,16 +55,20 @@ def test_transform_key_change(storage):
     assert str(loaded.arguments["a"]) == "b" * 64
 
 def test_redigest(storage):
-    c1 = Call(name="f1", arguments={"a": Digest("a" * 64)}, metadata={"m": 1}, result=Digest("r" * 64))
+    c1 = Call(name="f1", arguments={"a": Digest("a" * 64)}, metadata={}, result=Digest("r" * 64))
     # Save with a WRONG key
-    wrong_key = "f" * 64
-    storage.save(c1, key=wrong_key)
+    with patch('fleche.call.Call.to_lookup_key') as mock:
+        mock.return_value = Digest("f" * 64)
+        key = c1.to_lookup_key()
+        storage.save(c1)
 
-    assert wrong_key in list(storage.list())
+    assert key in list(storage.list())
+
+    # force a different key, to check that redigest updates
 
     storage.redigest()
 
     all_keys = list(storage.list())
     assert len(all_keys) == 1
-    assert wrong_key not in all_keys
+    assert key not in all_keys
     assert c1.to_lookup_key() in all_keys


### PR DESCRIPTION
Instead of a subclass it is a sibling now.  Both share a parent for common operations, but since save/load operate on distinct types they are setup in the new sibling classes.

A nice advantage is that CallStorage.save does not need the key parameter anymore, thought in another step it maybe possible to bring them together again by pulling this difference in a "key map" function.

Fixed a few type hints along the way.