### PR TITLE
Translate print statements to structured logging

### DIFF
--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -1,5 +1,6 @@
 """lru_cache on 'roids."""
 import os
+import logging
 from dataclasses import replace
 import tempfile
 import contextlib
@@ -13,6 +14,8 @@ from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Union
 from . import digest
 from .digest import Digest
 from .call import Call
+
+logger = logging.getLogger("fleche")
 
 
 def D(d: str) -> Digest:
@@ -182,20 +185,22 @@ def fleche(
             else:
                 required_args = require
             if any(r not in kwargs for r in required_args):
-                print(f"WARNING MISSING REQUIRED ARG: {required_args}")
+                logger.warning("Missing required argument: %s", required_args)
                 return func(*args, **kwargs)
             cache: Cache = _CACHE.get()
             try:
                 call = get_call(*args, **kwargs)
                 key = call.to_lookup_key()
             except digest.Unhashable as e:
-                print("WARNING NO HASH:", e.args[0])
+                logger.warning("No hash for argument: %s", e.args[0])
                 return func(*args, **kwargs)
 
             try:
-                return cache.load(key).result
+                result = cache.load(key).result
+                logger.debug("Cache hit for %s with key %s", func.__name__, key)
+                return result
             except KeyError:
-                pass
+                logger.debug("Cache miss for %s with key %s", func.__name__, key)
 
             def _run_and_cache():
                 active_meta = _METADATA.get() + tuple(meta)
@@ -208,15 +213,16 @@ def fleche(
 
                 call.result: _T = func(*expanded_args, **expanded_kwargs)
                 if call.result is None:
-                    print("WARNING NO VALUE")
+                    logger.warning("Function returned None, not caching")
                     return None
                 for m in active_meta:
                     metadata[m.name] |= m.post(metadata[m.name], replace(call, metadata={}))
                 try:
                     call.metadata = metadata
+                    logger.debug("Saving result for %s with key %s", func.__name__, key)
                     cache.save(call)
                 except Rejected as e:
-                    print("WARNING NO SAVE:", *e.args)
+                    logger.warning("Cache rejected save: %s", e.args)
                 return call.result
 
             if isolate:
@@ -250,8 +256,7 @@ def fleche(
             """
             call = get_call(*args, **kwargs)
             if "metadata" in call.arguments:
-                print("WARNING: the function you're querying has an argument 'metadata' getting shadowed by the same "
-                      "argument to query.")
+                logger.warning("Function argument 'metadata' shadowed by query argument")
             call.metadata = metadata
             return _CACHE.get().query(call)
 

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import logging
 from dataclasses import dataclass, asdict
 from copy import copy
 from typing import Self, Iterable, Any
@@ -9,6 +10,8 @@ from . import digest as _digest
 from .digest import Digest  # type hint convenience
 from . import storage
 from .call import Call
+
+logger = logging.getLogger("fleche.cache")
 
 
 class Rejected(Exception):
@@ -174,7 +177,7 @@ class Cache(BaseCache):
         try:
             return self._recursive_value_save(value)
         except storage.SaveError:
-            print("WARNING NO ARG SAVE:", value)
+            logger.warning("Failed to save argument: %s", value)
             return _digest.digest(value)
 
     def _handle_args_load(self, key):

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -26,12 +26,15 @@ calls.root = "~/.fleche/calls"
 """
 
 import tomllib
+import logging
 from pathlib import Path
 import os
 from typing import Any
 
 from . import storage, metadata
 from .caches import Cache
+
+logger = logging.getLogger("fleche.config")
 
 _live_caches: dict[str, Cache] = {}
 
@@ -40,7 +43,7 @@ def _get_config_path() -> Path | None:
     path = Path("fleche.toml")
     if path.exists():
         return path.absolute()
-    print(f"LOGGING INFO: local config {path} does not exist, trying global")
+    logger.info("Local config %s does not exist, trying global", path)
 
     if "XDG_CONFIG_HOME" in os.environ:
         path = Path(os.environ["XDG_CONFIG_HOME"]) / "fleche" / "cache.toml"
@@ -51,7 +54,7 @@ def _get_config_path() -> Path | None:
 
     if path.exists():
         return path
-    print(f"LOGGING INFO: global config {path} does not exist")
+    logger.info("Global config %s does not exist", path)
 
 
 def load_default_metadata():
@@ -113,7 +116,7 @@ def load_cache_config(name: str | None = None) -> Cache:
     """
     path = _get_config_path()
     if path is None or not path.exists():
-        print("Warning: No config file found. Using default memory cache.")
+        logger.warning("No config file found. Using default memory cache.")
         return Cache(storage.Memory({}), storage.Memory({}))
 
     with open(path, "rb") as f:
@@ -124,7 +127,7 @@ def load_cache_config(name: str | None = None) -> Cache:
 
     if cache_name is None:
         if "default" not in config or "cache" not in config["default"]:
-            print("Warning: No default cache configured. Using default memory cache.")
+            logger.warning("No default cache configured. Using default memory cache.")
             return Cache(storage.Memory({}), storage.Memory({}))
 
         default_cache = config["default"]["cache"]

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import dataclasses
 from numbers import Number
 import types
@@ -8,6 +9,8 @@ from typing import Any, TypeVar, Callable
 import math
 
 import numpy as np
+
+logger = logging.getLogger("fleche.digest")
 
 
 class Unhashable(Exception):
@@ -64,23 +67,21 @@ def load_entry_points():
                 if hook.type in seen_types:
                     source = seen_types[hook.type]
                     if source == "add_hook":
-                        print(
-                            "INFO",
-                            f"add_hook for {hook.type} overrides entry point {ep.value}",
-                        )
+                        logger.info("add_hook for %s overrides entry point %s", hook.type, ep.value)
                     else:
                         for h in _EP_HOOKS:
                             if (h.type is not hook.type) and (h.digest is not hook.digest):
-                                print(
-                                    "INFO",
-                                    f"Digest from {source} overrides later entry point {ep.value}!"
+                                logger.info(
+                                    "Digest from %s overrides later entry point %s!",
+                                    source,
+                                    ep.value,
                                 )
                     continue
 
                 _EP_HOOKS.append(hook)
                 seen_types[hook.type] = ep.value
         except Exception as e:
-            print("ERROR", f"Failed to load entry point {ep.name}: {e}")
+            logger.error("Failed to load entry point %s: %s", ep.name, e)
 
 
 def digest(value: Any) -> Digest:

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 from dataclasses import dataclass
 
 from abc import ABC, abstractmethod
@@ -6,6 +7,8 @@ from typing import Iterable, Any, Callable
 
 from ..digest import digest, Digest, DIGEST_LENGTH
 from ..call import Call
+
+logger = logging.getLogger("fleche.storage")
 
 
 class SaveError(Exception):
@@ -76,6 +79,7 @@ class Storage(StorageBase):
     def save(self, value: Any, key: Digest | None = None) -> Digest:
         if key is None:
             key = digest(value)
+        logger.debug("Saving value with key %s", key)
         return self._save(value, key)
 
     @abstractmethod
@@ -86,6 +90,7 @@ class Storage(StorageBase):
             key = self.expand(key)
         else:
             key = Digest(key)
+        logger.debug("Loading value with key %s", key)
         return self._load(key)
 
     @abstractmethod
@@ -96,6 +101,7 @@ class CallStorage(StorageBase):
     """Special storage for saving :class:`Call` instances."""
 
     def save(self, call: Call) -> Digest:
+        logger.debug("Saving call %s", call.to_lookup_key())
         return self._save(call)
 
     @abstractmethod
@@ -106,6 +112,7 @@ class CallStorage(StorageBase):
             key = self.expand(key)
         else:
             key = Digest(key)
+        logger.debug("Loading call with key %s", key)
         return self._load(key)
 
     @abstractmethod


### PR DESCRIPTION
This change migrates all ad-hoc print statements in the `fleche` library to a well-structured logging system. 

Key changes:
- Created a hierarchy of loggers:
    - `fleche`: Root logger and decorator-related logs.
    - `fleche.cache`: Caching logic and argument handling.
    - `fleche.storage`: Data persistence and retrieval (base classes).
    - `fleche.digest`: Digest calculation and entry point loading.
    - `fleche.config`: Configuration loading and path resolution.
- Mapped previous print messages to appropriate logging levels:
    - Warnings (e.g., missing arguments, rejected saves) now use `logger.warning`.
    - Informational messages (e.g., config path resolution) now use `logger.info`.
    - Errors (e.g., failed entry point loading) now use `logger.error`.
- Enhanced observability by adding `DEBUG` logs for:
    - Cache hits and misses in the `@fleche` decorator.
    - Result saving operations.
    - Low-level storage `save` and `load` operations.

Lazy string formatting is used throughout to ensure performance when logging is disabled. All existing tests pass.

---
*PR created automatically by Jules for task [13662466443645471485](https://jules.google.com/task/13662466443645471485) started by @pmrv*