### PR TITLE
Add support for partial arguments in .query()

### DIFF
--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -159,8 +159,8 @@ def fleche(
                 return (ignore,)
             return tuple(ignore)
 
-        def get_call(*args, **kwargs):
-            call = Call.from_call(func, *args, **kwargs)
+        def get_call(*args, partial=False, **kwargs):
+            call = Call.from_call(func, *args, partial=partial, **kwargs)
             # drop ignored arguments for the saved call object to make our lives much simpler when hashing or saving it
             # if we leave them in, then Cache.save needs to know about them indirectly to ensure correct digest key
             # generation, but then we'd also have to save it somehow and that just seems bothersome in particular for
@@ -254,7 +254,7 @@ def fleche(
             Returns:
                 iterable of matching :class:`.Call`
             """
-            call = get_call(*args, **kwargs)
+            call = get_call(*args, partial=True, **kwargs)
             if "metadata" in call.arguments:
                 logger.warning("Function argument 'metadata' shadowed by query argument")
             call.metadata = metadata

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -23,13 +23,20 @@ class Call:
     result: Any = None
 
     @classmethod
-    def from_call(cls, func, *args, **kwargs):
+    def from_call(cls, func, *args, partial=False, **kwargs):
         # Normalize arguments using function signature
-        bound = signature(func).bind(*args, **kwargs)
-        bound.apply_defaults()
+        sig = signature(func)
+        if partial:
+            bound = sig.bind_partial(*args, **kwargs)
+            # missing arguments are set to None
+            arguments = {name: bound.arguments.get(name) for name in sig.parameters}
+        else:
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            arguments = dict(bound.arguments)
 
         # Preserve declared parameter order via bound.arguments (OrderedDict)
-        call = cls(func.__name__, dict(bound.arguments))
+        call = cls(func.__name__, arguments)
         if hasattr(func, "__version__"):
             call.version = func.__version__
         if hasattr(func, "__module__"):

--- a/tests/unit/fleche/test_query_partial.py
+++ b/tests/unit/fleche/test_query_partial.py
@@ -1,0 +1,40 @@
+from fleche import fleche, cache
+from fleche.caches import Cache
+from fleche.storage import Memory
+
+def test_query_partial_arguments():
+    # Setup a fresh memory cache
+    test_cache = Cache(values=Memory({}), calls=Memory({}))
+
+    with cache(test_cache):
+        @fleche
+        def bar(x, y, z=10):
+            return x + y + z
+
+        # Test that .call with partial=True works and produces None for missing
+        # We need to access the wrapper's get_call which is exposed as .call
+        call_obj = bar.call(y=5, partial=True)
+        assert call_obj.arguments == {'x': None, 'y': 5, 'z': None}
+
+        # Test that .query uses partial binding
+        bar(1, 5, 10)
+        bar(2, 5, 20)
+        bar(1, 6, 10)
+
+        # Querying for y=5 should return 2 results (x=1, z=10 and x=2, z=20)
+        results = list(bar.query(y=5))
+        assert len(results) == 2
+
+        # Querying for x=1 should return 2 results (y=5, z=10 and y=6, z=10)
+        results = list(bar.query(x=1))
+        assert len(results) == 2
+
+def test_query_preserves_order_with_partial():
+    @fleche
+    def order_func(a, b, c):
+        return a
+
+    call_obj = order_func.call(c=3, a=1, partial=True)
+    # The order of arguments should follow the function signature
+    assert list(call_obj.arguments.keys()) == ['a', 'b', 'c']
+    assert call_obj.arguments == {'a': 1, 'b': None, 'c': 3}


### PR DESCRIPTION
This change allows users to query the cache without providing all required function arguments. Omitted arguments are treated as wildcards.

---
*PR created automatically by Jules for task [1061285357462333726](https://jules.google.com/task/1061285357462333726) started by @pmrv*