### PR TITLE
Add file locking to FileStorages

### DIFF
--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -16,53 +16,61 @@ logger = logging.getLogger("fleche.storage")
 
 
 @contextmanager
-def file_lock(
-    lock_path: Path, timeout: float, wait_start: float, key: str, mode: str
-) -> Generator[None, None, None]:
-    if mode == "write":
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        lock_path.write_text(f"{socket.gethostname()}\n{os.getpid()}\n{time.time()}")
-        try:
-            yield
-        finally:
-            lock_path.unlink(missing_ok=True)
-    elif mode == "read":
-        tried_anyway = False
-        if lock_path.exists():
-            start_time = time.perf_counter()
-            wait_time = wait_start
-            while (
-                lock_path.exists()
-                and (time.perf_counter() - start_time) < timeout
-            ):
-                time.sleep(wait_time)
-                wait_time *= 2
+def file_write_lock(lock_path: Path) -> Generator[None, None, None]:
+    """Context manager for acquiring a write lock on a file.
 
-            if lock_path.exists():
-                try:
-                    lock_info = lock_path.read_text().replace("\n", " ")
-                except Exception:
-                    lock_info = "unknown"
-                logger.warning(
-                    "Lock still held for %s after %s seconds (info: %s), trying to read anyway.",
-                    key,
-                    timeout,
-                    lock_info,
-                )
-                tried_anyway = True
-        try:
-            yield
-        except Exception as e:
-            if tried_anyway:
-                logger.error(
-                    "Failed to read %s after timeout while lock was held: %s",
-                    key,
-                    e,
-                )
-                raise KeyError(key) from None
-            raise
-    else:
-        raise ValueError(f"Invalid mode: {mode}")
+    Creates a lock file with hostname, PID, and timestamp.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(f"{socket.gethostname()}\n{os.getpid()}\n{time.time()}")
+    try:
+        yield
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+
+@contextmanager
+def file_read_lock(
+    lock_path: Path, timeout: float, wait_start: float, key: str
+) -> Generator[None, None, None]:
+    """Context manager for acquiring a read lock on a file.
+
+    Waits for a lock file to be removed with exponential backoff.
+    """
+    tried_anyway = False
+    if lock_path.exists():
+        start_time = time.perf_counter()
+        wait_time = wait_start
+        while (
+            lock_path.exists()
+            and (time.perf_counter() - start_time) < timeout
+        ):
+            time.sleep(wait_time)
+            wait_time *= 2
+
+        if lock_path.exists():
+            try:
+                lock_info = lock_path.read_text().replace("\n", " ")
+            except Exception:
+                lock_info = "unknown"
+            logger.warning(
+                "Lock still held for %s after %s seconds (info: %s), trying to read anyway.",
+                key,
+                timeout,
+                lock_info,
+            )
+            tried_anyway = True
+    try:
+        yield
+    except Exception as e:
+        if tried_anyway:
+            logger.error(
+                "Failed to read %s after timeout while lock was held: %s",
+                key,
+                e,
+            )
+            raise KeyError(key) from None
+        raise
 
 
 @dataclass
@@ -95,9 +103,7 @@ class FileStorage(Storage):
             key = digest(value)
 
         lock_path = self._path(f"{key}.lock")
-        with file_lock(
-            lock_path, self.lock_timeout, self.lock_wait_start, str(key), mode="write"
-        ):
+        with file_write_lock(lock_path):
             return super().save(value, key)
 
     def load(self, key: Digest | str) -> Any:
@@ -107,7 +113,7 @@ class FileStorage(Storage):
             key = Digest(key)
 
         lock_path = self._path(f"{key}.lock")
-        with file_lock(
-            lock_path, self.lock_timeout, self.lock_wait_start, str(key), mode="read"
+        with file_read_lock(
+            lock_path, self.lock_timeout, self.lock_wait_start, str(key)
         ):
             return super().load(key)

--- a/tests/unit/storage/test_file_locking.py
+++ b/tests/unit/storage/test_file_locking.py
@@ -63,26 +63,26 @@ def test_load_fails_after_timeout_raises_keyerror(caplog):
 
         assert "Failed to read" in caplog.text
 
-def test_save_creates_and_removes_lock():
+def test_save_creates_and_removes_lock(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
-        # To verify save creates a lock, we can't easily check it unless we mock _save
-        # or use a subclass that checks for lock existence during _save.
-        class CheckingPickleFile(PickleFile):
-            def _save(self, value, key):
-                lock_path = self._path(f"{key}.lock")
+        storage = PickleFile(tmpdir)
+        key = digest("test")
+        lock_path = storage._path(f"{key}.lock")
+        data_path = storage._path(key)
+
+        write_called = False
+        def mocked_write_bytes(self, data):
+            nonlocal write_called
+            if self == data_path:
                 assert lock_path.exists()
-                # Check content of lock file
                 content = lock_path.read_text().splitlines()
                 assert content[0] == socket.gethostname()
-                assert int(content[1]) > 0 # pid
-                assert float(content[2]) > 0 # timestamp
-                return super()._save(value, key)
+                write_called = True
+            return len(data)
 
-        storage = CheckingPickleFile(tmpdir)
-        key = digest("test")
+        monkeypatch.setattr(Path, "write_bytes", mocked_write_bytes)
         storage.save("data", key=key)
-
-        lock_path = Path(tmpdir) / f"{key}.lock"
+        assert write_called
         assert not lock_path.exists()
 
 def test_list_excludes_locks():


### PR DESCRIPTION
Implemented process-aware file locking for all `FileStorage` backends (`PickleFile`, `CloudpickleFile`, `BagOfHoldingH5File`).
- On `save`, a `{key}.lock` file is created containing the process ID and timestamp.
- On `load`, if a lock file exists, the process waits with exponential backoff (starting at 1ms) up to a configurable timeout (default 1s).
- If the timeout is reached, it attempts to read anyway, logging a warning. If it fails, it logs an error and raises `KeyError`.
- Lock files are excluded from `list()` and removed during `evict()`.
- Added unit tests in `tests/unit/storage/test_file_locking.py`.

---
*PR created automatically by Jules for task [9718337648981191387](https://jules.google.com/task/9718337648981191387) started by @pmrv*