### PR TITLE
🧹 chore: remove stale comment in Sql storage

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -368,5 +368,3 @@ class Sql(CallStorage):
             c = self.load(k)
             if meta_matches(c):
                 yield c
-
-    # find_by_metadata removed; metadata filtering is supported via query(template)


### PR DESCRIPTION
This PR removes a stale comment from `src/fleche/storage/sql.py`.

🎯 **What:** Removed the commented-out note `# find_by_metadata removed; metadata filtering is supported via query(template)`.
💡 **Why:** Stale comments about removed functionality clutter the codebase and can be confusing.
✅ **Verification:** Verified the removal with `grep`. Although tests couldn't be run in the sandbox due to missing dependencies, the change is a low-risk comment removal and was reviewed as correct.
✨ **Result:** Cleaner and more maintainable code.

---
*PR created automatically by Jules for task [13812286363530597461](https://jules.google.com/task/13812286363530597461) started by @pmrv*