### PR TITLE
🧪 Improve FileStorage list filtering and add tests

### DIFF
--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -92,7 +92,13 @@ class FileStorage(Storage):
 
     def list(self) -> Iterable[Digest]:
         self.root.mkdir(parents=True, exist_ok=True)
-        return (Digest(p.name) for p in self.root.iterdir() if not p.name.endswith(".lock"))
+        return (
+            Digest(p.name)
+            for p in self.root.iterdir()
+            if not p.name.endswith(".lock")
+            and not p.name.startswith(".")
+            and p.is_file()
+        )
 
     def _evict(self, key: Digest) -> None:
         self._path(key).unlink(missing_ok=True)

--- a/tests/unit/storage/test_file.py
+++ b/tests/unit/storage/test_file.py
@@ -1,0 +1,50 @@
+
+import pytest
+from pathlib import Path
+from fleche.storage.file import FileStorage
+from fleche.digest import Digest
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass
+class ConcreteFileStorage(FileStorage):
+    def _save(self, value: Any, key: Digest) -> None:
+        pass
+
+    def _load(self, key: Digest) -> Any:
+        return None
+
+def test_file_storage_list_filtering(tmp_path):
+    storage = ConcreteFileStorage(root=tmp_path)
+
+    # Create valid files (simulating digests)
+    valid_digest1 = "a" * 64
+    valid_digest2 = "b" * 64
+
+    (tmp_path / valid_digest1).touch()
+    (tmp_path / valid_digest2).touch()
+
+    # Create lock files
+    (tmp_path / f"{valid_digest1}.lock").touch()
+    (tmp_path / "other.lock").touch()
+
+    # Create a directory (edge case)
+    (tmp_path / "subdir").mkdir()
+
+    # Create a hidden file (edge case)
+    (tmp_path / ".hidden").touch()
+
+    # Create a hidden directory (edge case)
+    (tmp_path / ".hidden_dir").mkdir()
+
+    items = list(storage.list())
+
+    assert Digest(valid_digest1) in items
+    assert Digest(valid_digest2) in items
+    assert Digest(f"{valid_digest1}.lock") not in items
+    assert Digest("other.lock") not in items
+    assert Digest("subdir") not in items
+    assert Digest(".hidden") not in items
+    assert Digest(".hidden_dir") not in items
+
+    assert len(items) == 2


### PR DESCRIPTION
This PR improves the reliability of `FileStorage.list()` by ensuring it only returns valid file digests. It now correctly excludes:
- Subdirectories
- Lock files (`*.lock`)
- Hidden files (starting with `.`)

A new unit test file `tests/unit/storage/test_file.py` was added to verify these behaviors using a concrete subclass of the abstract `FileStorage` class.


---
*PR created automatically by Jules for task [16407459791817650542](https://jules.google.com/task/16407459791817650542) started by @pmrv*