### PR TITLE
Add memory+sqlite(:memory:) configuration to integration test suite

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -10,7 +10,11 @@ from fleche.storage import CloudpickleFile, Memory
 from fleche.storage.sql import Sql
 
 temp = tempfile.TemporaryDirectory()
-storages = [Memory({}), CloudpickleFile(temp.name)]
+storages = [
+    (Memory({}), Memory({})),
+    (CloudpickleFile(temp.name), CloudpickleFile(temp.name)),
+    (Memory({}), Sql()),
+]
 
 
 @fleche
@@ -32,10 +36,10 @@ functions_to_test = [
 ]
 
 
-@pytest.mark.parametrize("storage", storages)
+@pytest.mark.parametrize("values_storage, calls_storage", storages)
 @pytest.mark.parametrize("func, arg", functions_to_test)
-def test_fleche_performance(storage, func, arg):
-    with cache(Cache(storage, storage)):
+def test_fleche_performance(values_storage, calls_storage, func, arg):
+    with cache(Cache(values=values_storage, calls=calls_storage)):
 
         start_time = time.time()
         func(arg)


### PR DESCRIPTION
This commit updates `tests/integration/test_integration.py` to test the combination of `Memory` for value storage and an in-memory SQLite database (`Sql()`) for call storage. The test parameters were refactored to explicitly separate the tuple values to initialize the `Cache` appropriately without writing a file to disk.

---
*PR created automatically by Jules for task [10587526983631161015](https://jules.google.com/task/10587526983631161015) started by @pmrv*