### PR TITLE
refactor(benchmarks): pivot benchmark result tables

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,23 +1,21 @@
-
 import subprocess
 import json
 import sys
 import os
 from typing import List, Dict
+
 try:
     import pandas as pd
 except ImportError:
     pd = None
+
 
 def run_script(script_path: str) -> List[Dict]:
     print(f"Running {script_path}...", file=sys.stderr)
     try:
         # Run the script and capture stdout
         result = subprocess.run(
-            [sys.executable, script_path],
-            capture_output=True,
-            text=True,
-            check=True
+            [sys.executable, script_path], capture_output=True, text=True, check=True
         )
         # The scripts print JSON to stdout
         return json.loads(result.stdout)
@@ -31,6 +29,7 @@ def run_script(script_path: str) -> List[Dict]:
         print(result.stdout, file=sys.stderr)
         return []
 
+
 def format_time(seconds: float) -> str:
     if seconds < 1e-6:
         return f"{seconds * 1e9:.2f} ns"
@@ -41,12 +40,13 @@ def format_time(seconds: float) -> str:
     else:
         return f"{seconds:.2f} s"
 
+
 def main():
     benchmark_dir = os.path.dirname(os.path.abspath(__file__))
     scripts = [
         "benchmark_digest.py",
         "benchmark_storage.py",
-        "benchmark_integration.py"
+        "benchmark_integration.py",
     ]
 
     all_results = []
@@ -64,26 +64,26 @@ def main():
         df = pd.DataFrame(all_results)
 
         # Format times
-        df['median'] = df['median_time'].apply(format_time)
-        if 'min_time' in df.columns:
-            df['min'] = df['min_time'].apply(format_time)
-        if 'max_time' in df.columns:
-            df['max'] = df['max_time'].apply(format_time)
-        if 'stdev_time' in df.columns:
-            df['stdev'] = df['stdev_time'].apply(format_time)
+        df["median"] = df["median_time"].apply(format_time)
+        if "min_time" in df.columns:
+            df["min"] = df["min_time"].apply(format_time)
+        if "max_time" in df.columns:
+            df["max"] = df["max_time"].apply(format_time)
+        if "stdev_time" in df.columns:
+            df["stdev"] = df["stdev_time"].apply(format_time)
 
         # Select and reorder columns
-        display_cols = ['benchmark', 'name', 'storage', 'iterations', 'median']
+        display_cols = ["benchmark", "name", "storage", "iterations", "median"]
         # 'storage' column might not exist in all results
-        if 'storage' not in df.columns:
-            df['storage'] = ""
+        if "storage" not in df.columns:
+            df["storage"] = ""
         else:
-            df['storage'] = df['storage'].fillna("")
+            df["storage"] = df["storage"].fillna("")
 
         final_df = df[[c for c in display_cols if c in df.columns]]
 
         # Sort the dataframe by raw median time before grouping to preserve order (descending: largest value on top)
-        df = df.sort_values(by='median_time', ascending=False)
+        df = df.sort_values(by="median_time", ascending=False)
         final_df = df[[c for c in display_cols if c in df.columns]]
 
         # We need the raw value to compute the color gradient, let's keep it in a parallel series
@@ -92,6 +92,7 @@ def main():
 
         def get_color(value: float, min_val: float, max_val: float) -> str:
             import math
+
             # Using a simple perceptually uniform-ish colormap (viridis-like or simple heatmap)
             # We will use HSL to create a gradient from green (fast) to red (slow)
             if max_val == min_val:
@@ -104,7 +105,9 @@ def main():
             hue = 120 - int(ratio * 120)
             return f"hsl({hue}, 70%, 50%)"
 
-        def add_color_to_cell(val_str: str, raw_val: float, min_val: float, max_val: float) -> str:
+        def add_color_to_cell(
+            val_str: str, raw_val: float, min_val: float, max_val: float
+        ) -> str:
             color = get_color(raw_val, min_val, max_val)
             # Github Markdown supports img shields or html. But wait, Github Markdown strips most style tags and raw CSS on tables!
             # Using 🟢, 🟡, 🔴 emojis as a fallback gradient is safer for Github markdown.
@@ -129,7 +132,11 @@ def main():
         def get_storage_color(storage_name):
             if pd.isna(storage_name) or storage_name == "":
                 return ""
-            backend = str(storage_name).split('/')[0] if '/' in str(storage_name) else str(storage_name)
+            backend = (
+                str(storage_name).split("/")[0]
+                if "/" in str(storage_name)
+                else str(storage_name)
+            )
             colors = {
                 "Memory": "🟣",
                 "Memory+Sqlite(:memory:)": "🟤",
@@ -144,28 +151,31 @@ def main():
             }
             return colors.get(backend, "⚪️")
 
-        # Split out call storage (which only uses "Sql/calls") from value storage
+        # Split out call storage (which only uses "/calls") from value storage
         is_call_storage = df['storage'].str.endswith('/calls', na=False)
 
-        # Group categories using raw dataframe to keep avg_time for coloring
-        categories_raw = {
-            "Digest Benchmarks": df[df['benchmark'] == 'digest'],
-            "Storage Load": df[(df['benchmark'] == 'storage_load') & ~is_call_storage],
-            "Storage Save": df[(df['benchmark'] == 'storage_save') & ~is_call_storage],
-            "Storage Evict": df[(df['benchmark'] == 'storage_evict') & ~is_call_storage],
-            "Call Storage Load": df[(df['benchmark'] == 'storage_load') & is_call_storage],
-            "Call Storage Save": df[(df['benchmark'] == 'storage_save') & is_call_storage],
-            "Call Storage Evict": df[(df['benchmark'] == 'storage_evict') & is_call_storage],
-            "Integration Hit": df[df['benchmark'] == 'integration_hit'],
-            "Integration Miss": df[df['benchmark'] == 'integration_miss']
-        }
-
-        # Parent categories for folding
+        # Group categories using raw dataframe
         parent_categories = {
-            "Digest Benchmarks": ["Digest Benchmarks"],
-            "Value Storage Benchmarks": ["Storage Load", "Storage Save", "Storage Evict"],
-            "Call Storage Benchmarks": ["Call Storage Load", "Call Storage Save", "Call Storage Evict"],
-            "Integration Benchmarks": ["Integration Hit", "Integration Miss"]
+            "Digest Benchmarks": {
+                "data": df[df["benchmark"] == "digest"],
+                "index": "name",
+            },
+            "Value Storage Benchmarks": {
+                "data": df[
+                    df["benchmark"].str.startswith("storage_") & ~is_call_storage
+                ],
+                "index": "storage",
+            },
+            "Call Storage Benchmarks": {
+                "data": df[
+                    df["benchmark"].str.startswith("storage_") & is_call_storage
+                ],
+                "index": "storage",
+            },
+            "Integration Benchmarks": {
+                "data": df[df["benchmark"].str.startswith("integration_")],
+                "index": "name",
+            },
         }
 
         def to_markdown_table(df):
@@ -178,66 +188,77 @@ def main():
 
             table = [header_row, separator_row]
             for row in rows:
-                table.append("| " + " | ".join(str(r) if pd.notna(r) else "" for r in row) + " |")
+                table.append(
+                    "| " + " | ".join(str(r) if pd.notna(r) else "" for r in row) + " |"
+                )
 
             return "\n".join(table)
 
         print()
-        for parent_title, child_keys in parent_categories.items():
-            # Check if any child has data
-            if not any(not categories_raw[k].empty for k in child_keys):
+        for parent_title, info in parent_categories.items():
+            sub_df = info["data"]
+            if sub_df.empty:
                 continue
+
+            index_col = info["index"]
 
             print(f"<details>")
             print(f"<summary><b>{parent_title}</b></summary>\n")
             print('<div style="overflow-x: auto;">\n')
 
-            for title in child_keys:
-                raw_df = categories_raw[title]
-                if raw_df.empty:
-                    continue
+            # For Digest benchmarks, we might just want a simple table without pivoting since 'benchmark' is just 'digest'
+            if parent_title == "Digest Benchmarks":
+                pivoted = sub_df.set_index(index_col)[["median_time"]]
+                pivoted.columns = ["digest"]
+                # Sort by time
+                pivoted = pivoted.sort_values(by="digest", ascending=False)
+            else:
+                pivoted = sub_df.pivot(
+                    index=index_col, columns="benchmark", values="median_time"
+                )
+                # Sort rows by sum
+                pivoted["sum_time"] = pivoted.sum(axis=1)
+                pivoted = pivoted.sort_values(by="sum_time", ascending=False)
+                pivoted = pivoted.drop(columns=["sum_time"])
 
-                print(f"### {title}\n")
+            if pivoted.empty:
+                print("</div>")
+                print("</details>\n")
+                continue
 
-                # Prepare formatted slice
-                sub_df = final_df.loc[raw_df.index].copy()
+            # Format the dataframe
+            formatted = pd.DataFrame(index=pivoted.index)
 
-                # Add emoji gradient to median
-                min_val = raw_df['median_time'].min()
-                max_val = raw_df['median_time'].max()
+            # Keep track of color for the index if it has storage info
+            formatted[index_col] = pivoted.index
+            if index_col == "storage" or (
+                index_col == "name" and parent_title == "Integration Benchmarks"
+            ):
+                formatted[index_col] = [
+                    f"{get_storage_color(s)} {s}" if pd.notna(s) and s != "" else s
+                    for s in formatted[index_col]
+                ]
 
-                sub_df['median'] = [add_color_to_cell(a, r, min_val, max_val) for a, r in zip(sub_df['median'], raw_df['median_time'])]
+            for col in pivoted.columns:
+                min_val = pivoted[col].min()
+                max_val = pivoted[col].max()
 
-                # Apply storage color
-                if 'storage' in sub_df.columns:
-                    sub_df['storage'] = [f"{get_storage_color(s)} {s}" if pd.notna(s) and s != "" else s for s in sub_df['storage']]
+                formatted[col] = [
+                    (
+                        add_color_to_cell(format_time(val), val, min_val, max_val)
+                        if pd.notna(val)
+                        else ""
+                    )
+                    for val in pivoted[col]
+                ]
 
-                # We can also color 'name' column if it encodes storage, but integration tests encode it in 'name'
-                if title.startswith('Integration'):
-                    if 'name' in sub_df.columns:
-                        sub_df['name'] = [f"{get_storage_color(s)} {s}" if pd.notna(s) and s != "" else s for s in sub_df['name']]
+            try:
+                print(formatted.to_markdown(index=False))
+            except ImportError:
+                print(to_markdown_table(formatted))
+            print("\n")
 
-                # Drop empty columns
-                for col in sub_df.columns:
-                    # pandas replaces empty string with NaN sometimes, or if all are empty string
-                    if (sub_df[col] == "").all() or sub_df[col].isna().all():
-                        sub_df = sub_df.drop(columns=[col])
-
-                # Drop iterations as requested
-                if 'iterations' in sub_df.columns:
-                    sub_df = sub_df.drop(columns=['iterations'])
-
-                # Drop benchmark column since it's redundant with the child title
-                if 'benchmark' in sub_df.columns:
-                    sub_df = sub_df.drop(columns=['benchmark'])
-
-                try:
-                    print(sub_df.to_markdown(index=False))
-                except ImportError:
-                    print(to_markdown_table(sub_df))
-                print("\n")
-
-            print('</div>')
+            print("</div>")
             print("</details>\n")
 
         # Also save to CSV
@@ -250,6 +271,7 @@ def main():
         print("```json")
         print(json.dumps(all_results, indent=2))
         print("```")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR pivots the markdown tables generated by `benchmarks/run_benchmarks.py`. It consolidates multiple tables representing individual operations (like save, load, evict) into a single table with those operations as columns, making it much easier to compare the overall performance of different storage backends or integration targets. The rows within the pivoted tables are sorted by the sum of median times across all operations to easily identify the overall fastest/slowest.

---
*PR created automatically by Jules for task [10503241079670784181](https://jules.google.com/task/10503241079670784181) started by @pmrv*