### PR TITLE
Restore Call Storages benchmark testing for SqlFile and SqlMemory

### DIFF
--- a/benchmarks/benchmark_storage.py
+++ b/benchmarks/benchmark_storage.py
@@ -180,61 +180,68 @@ def main():
         print(f"Failed Sql/calls: {e}", file=sys.stderr)
 
     # Let's do Sql benchmark separately
-    sql_results = []
     tmp_dir = tempfile.mkdtemp()
     try:
-        storage = Sql(f"sqlite:///{tmp_dir}/db.sqlite")
+        for storage_label, url in [
+            ("SqlFile/calls", f"sqlite:///{tmp_dir}/db.sqlite"),
+            ("SqlMemory/calls", "sqlite:///:memory:")
+        ]:
+            sql_results = []
+            try:
+                storage = Sql(url)
 
-        save_times = []
-        keys = []
-        for c in calls_data:
-            timer = timeit.Timer(partial(storage.save, c))
-            number = 10
-            times = timer.repeat(repeat=3, number=number)
-            save_times.extend([t / number for t in times])
-            keys.append(digest(c)) # Call keys are their digest
+                save_times = []
+                keys = []
+                for c in calls_data:
+                    timer = timeit.Timer(partial(storage.save, c))
+                    number = 10
+                    times = timer.repeat(repeat=3, number=number)
+                    save_times.extend([t / number for t in times])
+                    keys.append(c.to_lookup_key()) # Call keys are their lookup key
 
-        sql_results.append({
-            "benchmark": "storage_save",
-            "storage": "Sql/calls",
-            "iterations": len(calls_data) * 30,
-            "median_time": statistics.median(save_times)
-        })
+                sql_results.append({
+                    "benchmark": "storage_save",
+                    "storage": storage_label,
+                    "iterations": len(calls_data) * 30,
+                    "median_time": statistics.median(save_times)
+                })
 
-        load_times = []
-        for key in keys:
-            timer = timeit.Timer(partial(storage.load, key))
-            number = 10
-            times = timer.repeat(repeat=3, number=number)
-            load_times.extend([t / number for t in times])
+                load_times = []
+                for key in keys:
+                    timer = timeit.Timer(partial(storage.load, key))
+                    number = 10
+                    times = timer.repeat(repeat=3, number=number)
+                    load_times.extend([t / number for t in times])
 
-        sql_results.append({
-            "benchmark": "storage_load",
-            "storage": "Sql/calls",
-            "iterations": len(keys) * 30,
-            "median_time": statistics.median(load_times)
-        })
+                sql_results.append({
+                    "benchmark": "storage_load",
+                    "storage": storage_label,
+                    "iterations": len(keys) * 30,
+                    "median_time": statistics.median(load_times)
+                })
 
-        # Sql supports evict(key)
-        evict_times = []
-        for key in keys:
-            # Single run for eviction
-            start = time.perf_counter()
-            storage.evict(key)
-            end = time.perf_counter()
-            evict_times.append(end - start)
+                # Sql supports evict(key)
+                evict_times = []
+                for key in keys:
+                    # Single run for eviction
+                    start = time.perf_counter()
+                    storage.evict(key)
+                    end = time.perf_counter()
+                    evict_times.append(end - start)
 
-        sql_results.append({
-            "benchmark": "storage_evict",
-            "storage": "Sql/calls",
-            "iterations": len(evict_times),
-            "median_time": statistics.median(evict_times)
-        })
+                sql_results.append({
+                    "benchmark": "storage_evict",
+                    "storage": storage_label,
+                    "iterations": len(evict_times),
+                    "median_time": statistics.median(evict_times)
+                })
 
-        all_results.extend(sql_results)
+                all_results.extend(sql_results)
 
-    except Exception as e:
-        print(f"Failed Sql/calls: {e}", file=sys.stderr)
+            except Exception as e:
+                import traceback
+                print(f"Failed {storage_label}: {e}", file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
     finally:
         shutil.rmtree(tmp_dir)
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -136,13 +136,15 @@ def main():
                 "CloudpickleFile": "🔵",
                 "BagOfHoldingH5File": "🟠",
                 "Sql": "🔴",
+                "SqlFile": "🔴",
+                "SqlMemory": "🔴",
                 "Pickle+Sql": "🟢",
                 "H5+Sql": "🟠",
             }
             return colors.get(backend, "⚪️")
 
         # Split out call storage (which only uses "Sql/calls") from value storage
-        is_call_storage = df['storage'] == "Sql/calls"
+        is_call_storage = df['storage'].str.endswith('/calls', na=False)
 
         # Group categories using raw dataframe to keep avg_time for coloring
         categories_raw = {


### PR DESCRIPTION
Restored the missing "Call Storage Benchmarks" section in `benchmarks/run_benchmarks.py`. Added specific benchmarks for CallStorage backends by configuring loop testing over both `SqlFile/calls` (using a temporary `sqlite://` file database) and `SqlMemory/calls` (using `sqlite:///:memory:`). Also updated the `benchmark_storage.py` to calculate valid `to_lookup_key()` calls during timing events to prevent `KeyError` failures on save.

---
*PR created automatically by Jules for task [17467382995763122801](https://jules.google.com/task/17467382995763122801) started by @pmrv*