### PR TITLE
Optimize BaseCache.contains using storage backends

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -234,6 +234,9 @@ class Cache(BaseCache):
         call = self.calls.load(key)
         return self._decode_call(call, lazy)
 
+    def contains(self, key: str) -> bool:
+        return self.calls.contains(key)
+
     def shrink(self, key: Digest | str) -> Digest:
         return self.calls.shrink(key)
 
@@ -259,6 +262,7 @@ class Cache(BaseCache):
             Call | LazyCall: Matching calls with arguments and result decoded from digests
             where possible.
         """
+
         # Delegate to underlying call storage, but first expand possible value digests and decode any digested
         # arguments/results before yielding to the caller (same semantics as load()).
         def maybe_expand(value):
@@ -297,6 +301,7 @@ class Cache(BaseCache):
 @dataclass(frozen=True)
 class ReadOnlyCache(BaseCache):
     """A cache that can only be read from."""
+
     cache: BaseCache
 
     def save(self, call: Call):
@@ -310,6 +315,9 @@ class ReadOnlyCache(BaseCache):
 
     def load_value(self, key):
         return self.cache.load_value(key)
+
+    def contains(self, key: str) -> bool:
+        return self.cache.contains(key)
 
     @overload
     def query(self, call: Call, lazy: bool = False) -> Iterable[Call]: ...
@@ -362,6 +370,7 @@ class CacheStack(BaseCache):
 
     Saving will always hit the lowest level, while loading will traverse up.
     """
+
     stack: tuple[BaseCache, ...]
 
     def save(self, call: Call):
@@ -385,6 +394,8 @@ class CacheStack(BaseCache):
         else:
             raise KeyError(key)
 
+    def contains(self, key: str) -> bool:
+        return any(cache.contains(key) for cache in self.stack)
 
     def push(self, cache: BaseCache) -> "CacheStack":
         return CacheStack((cache, *self.stack))

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -72,6 +72,19 @@ class StorageBase(ABC):
             f"Digest {key} cannot be shrunk without becoming ambigious!"
         )
 
+    def contains(self, key: Digest | str) -> bool:
+        if len(key) < DIGEST_LENGTH:
+            try:
+                key = self.expand(key)
+            except KeyError:
+                return False
+        else:
+            key = Digest(key)
+        return self._contains(key)
+
+    @abstractmethod
+    def _contains(self, key: Digest) -> bool: ...
+
 
 class Storage(StorageBase):
     """Abstract base class for defining storage mechanisms."""
@@ -96,6 +109,12 @@ class Storage(StorageBase):
     @abstractmethod
     def _load(self, key: Digest) -> Any: ...
 
+    def _contains(self, key: Digest) -> bool:
+        try:
+            self._load(key)
+            return True
+        except KeyError:
+            return False
 
 class Digested(ABC):
     @abstractmethod
@@ -153,6 +172,9 @@ class DestructuringStorage(Storage):
                 return {self.load(k): self.load(v) for k, v in items.items()}
             case _:
                 return value
+
+    def _contains(self, key: Digest) -> bool:
+        return self.storage.contains(key)
 
     def _evict(self, key: Digest) -> None:
         self.storage.evict(key)
@@ -240,6 +262,13 @@ class CallStorage(StorageBase):
             if fits(call):
                 yield call
 
+    def _contains(self, key: Digest) -> bool:
+        try:
+            self._load(key)
+            return True
+        except KeyError:
+            return False
+
 
 @dataclass(frozen=True, slots=True)
 class CallStorageAdapter(CallStorage):
@@ -252,6 +281,9 @@ class CallStorageAdapter(CallStorage):
 
     def _load(self, key: Digest) -> Call:
         return self.storage.load(key)
+
+    def _contains(self, key: Digest) -> bool:
+        return self.storage.contains(key)
 
     def _evict(self, key: Digest) -> None:
         self.storage.evict(key)

--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -119,3 +119,6 @@ class FileStorage(Storage):
             lock_path, self.lock_timeout, self.lock_wait_start, str(key)
         ):
             return super().load(key)
+
+    def _contains(self, key: Digest) -> bool:
+        return self._path(key).exists()

--- a/src/fleche/storage/memory.py
+++ b/src/fleche/storage/memory.py
@@ -21,6 +21,9 @@ class Memory(Storage):
     def _load(self, key: Digest) -> Any:
         return deepcopy(self.storage[key])
 
+    def _contains(self, key: Digest) -> bool:
+        return key in self.storage
+
     def list(self) -> Iterable[Digest]:
         return tuple(self.storage.keys())
 

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -6,6 +6,7 @@ from ..digest import Digest, DIGEST_LENGTH, digest
 
 from pyiron_snippets.import_alarm import ImportAlarm
 
+
 with ImportAlarm(
     "Sql requires 'sqlalchemy' to be installed. "
     "Install it with `pip install fleche[sqlalchemy]`.",
@@ -204,6 +205,18 @@ class Sql(CallStorage):
                 ),
             )
             return call
+        finally:
+            session.close()
+
+    def _contains(self, key: Digest) -> bool:
+        session = self.Session()
+        try:
+            return (
+                session.execute(
+                    select(CallModel.key).where(CallModel.key == str(key))
+                ).first()
+                is not None
+            )
         finally:
             session.close()
 

--- a/src/fleche/storage/void.py
+++ b/src/fleche/storage/void.py
@@ -22,3 +22,6 @@ class Void(Storage):
 
     def _evict(self, key: Digest) -> None:
         pass
+
+    def _contains(self, key: Digest) -> bool:
+        return False


### PR DESCRIPTION
Implemented a dedicated `contains` method in the storage backends, which prevents `BaseCache.contains` from having to load metadata or data to perform an existence check. Optimized `_contains` are provided for file storage, memory, and SQL backends.