### PR TITLE
Fix benchmark scripts by updating storage backend API usage

### DIFF
--- a/benchmarks/benchmark_digest.py
+++ b/benchmarks/benchmark_digest.py
@@ -1,4 +1,3 @@
-
 import time
 import sys
 import os
@@ -15,6 +14,7 @@ from utils import st_nested_values, st_base_values, st_nested_values, generate_e
 import timeit
 from functools import partial
 
+
 def benchmark(name, strategy):
     try:
         digest(generate_examples(strategy))
@@ -23,12 +23,13 @@ def benchmark(name, strategy):
         return None
 
     timer = timeit.Timer(
-            stmt='digest(value)', setup='value = generate_examples(strategy)',
-            globals={
-                "generate_examples": generate_examples,
-                "strategy": strategy,
-                'digest': digest
-                }
+        stmt="digest(value)",
+        setup="value = generate_examples(strategy)",
+        globals={
+            "generate_examples": generate_examples,
+            "strategy": strategy,
+            "digest": digest,
+        },
     )
 
     # Determine a good number of iterations automatically
@@ -47,8 +48,9 @@ def benchmark(name, strategy):
         "benchmark": "digest",
         "name": name,
         "iterations": number * repeats,
-        "time": median(times_per_call)
+        "time": median(times_per_call),
     }
+
 
 def main():
     results = []
@@ -63,21 +65,38 @@ def main():
     results.append(benchmark("None", st.none()))
 
     # Complex types
-    results.append(benchmark("List (integers, len<100)", st.lists(st.integers(), max_size=100)))
-    results.append(benchmark("List (integers, len>100)", st.lists(st.integers(), min_size=100)))
-    results.append(benchmark("Dict (small)", st.dictionaries(st.text(max_size=10), st.text(max_size=10))))
+    results.append(
+        benchmark("List (integers, len<100)", st.lists(st.integers(), max_size=100))
+    )
+    results.append(
+        benchmark("List (integers, len>100)", st.lists(st.integers(), min_size=100))
+    )
+    results.append(
+        benchmark(
+            "Dict (small)", st.dictionaries(st.text(max_size=10), st.text(max_size=10))
+        )
+    )
 
     # Numpy
-    results.append(benchmark("Numpy (integers, len<100)",
-                             st_arrays(int, st.integers(min_value=0, max_value=100))))
-    results.append(benchmark("Numpy (integers, len>100)",
-                             st_arrays(int, st.integers(min_value=100, max_value=10_000))))
+    results.append(
+        benchmark(
+            "Numpy (integers, len<100)",
+            st_arrays(int, st.integers(min_value=0, max_value=100)),
+        )
+    )
+    results.append(
+        benchmark(
+            "Numpy (integers, len>100)",
+            st_arrays(int, st.integers(min_value=100, max_value=10_000)),
+        )
+    )
     results.append(benchmark("Nested (Random Hypothesis)", st_nested_values))
 
     # Filter None results
     results = [r for r in results if r is not None]
 
     print(json.dumps(results, indent=2))
+
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/benchmark_integration.py
+++ b/benchmarks/benchmark_integration.py
@@ -1,4 +1,3 @@
-
 import time
 import sys
 import os
@@ -14,10 +13,12 @@ from fleche import fleche, cache
 from fleche.caches import Cache
 from fleche.storage import Memory, PickleFile, Sql, BagOfHoldingH5File
 
+
 # Define some test functions
 @fleche
 def lightweight_func(x):
     return x * 2
+
 
 @fleche
 def compute_heavy_func(n):
@@ -25,10 +26,12 @@ def compute_heavy_func(n):
     time.sleep(0.01)
     return n * n
 
+
 @fleche
 def data_heavy_func(n):
     # Returns a large numpy array
     return np.random.rand(n, n)
+
 
 def benchmark_integration(name, cache_obj, func, args, iterations=10):
     results = []
@@ -66,12 +69,14 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         # we ran the same arguments in the same order.
         miss_overhead_times.append(max(0, (end - start) - base_times[i]))
 
-    results.append({
-        "benchmark": "integration_miss",
-        "name": name,
-        "iterations": iterations,
-        "time": min(miss_overhead_times)
-    })
+    results.append(
+        {
+            "benchmark": "integration_miss",
+            "name": name,
+            "iterations": iterations,
+            "time": min(miss_overhead_times),
+        }
+    )
 
     # 2. Second Call (Hit)
     hit_times = []
@@ -85,14 +90,17 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         end = time.perf_counter()
         hit_times.append(end - start)
 
-    results.append({
-        "benchmark": "integration_hit",
-        "name": name,
-        "iterations": iterations,
-        "time": min(hit_times)
-    })
+    results.append(
+        {
+            "benchmark": "integration_hit",
+            "name": name,
+            "iterations": iterations,
+            "time": min(hit_times),
+        }
+    )
 
     return results
+
 
 def main():
     print("Running Integration Benchmarks...", file=sys.stderr)
@@ -105,13 +113,33 @@ def main():
         configs = [
             ("Memory", Cache(Memory({}), Memory({}))),
             ("Memory+Sqlite(:memory:)", Cache(Memory({}), Sql())),
-            ("Pickle+Sql", Cache(PickleFile(os.path.join(tmp_dir, "pickle")), Sql(f"sqlite:///{tmp_dir}/db.sqlite"))),
-            ("H5+Sql", Cache(BagOfHoldingH5File(os.path.join(tmp_dir, "h5")), Sql(f"sqlite:///{tmp_dir}/db_h5.sqlite")))
+            (
+                "Pickle+Sql",
+                Cache(
+                    PickleFile.with_pickle(root=os.path.join(tmp_dir, "pickle")),
+                    Sql(f"sqlite:///{tmp_dir}/db.sqlite"),
+                ),
+            ),
+            (
+                "H5+Sql",
+                Cache(
+                    BagOfHoldingH5File(root=os.path.join(tmp_dir, "h5")),
+                    Sql(f"sqlite:///{tmp_dir}/db_h5.sqlite"),
+                ),
+            ),
         ]
 
         for config_name, cache_inst in configs:
             # Lightweight
-            all_results.extend(benchmark_integration(f"{config_name}/lightweight", cache_inst, lightweight_func, list(range(20)), iterations=20))
+            all_results.extend(
+                benchmark_integration(
+                    f"{config_name}/lightweight",
+                    cache_inst,
+                    lightweight_func,
+                    list(range(20)),
+                    iterations=20,
+                )
+            )
 
             # Compute Heavy
             # We subtract the sleep time to see overhead? No, total time is what matters for user usually,
@@ -119,16 +147,33 @@ def main():
             # Or just accept that "miss" time includes execution time.
             # Ideally we compare "miss time" vs "raw execution time".
             # But here we just compare different storage backends for the same function.
-            all_results.extend(benchmark_integration(f"{config_name}/compute_heavy", cache_inst, compute_heavy_func, list(range(20)), iterations=20))
+            all_results.extend(
+                benchmark_integration(
+                    f"{config_name}/compute_heavy",
+                    cache_inst,
+                    compute_heavy_func,
+                    list(range(20)),
+                    iterations=20,
+                )
+            )
 
             # Data Heavy
             # args are size N
-            all_results.extend(benchmark_integration(f"{config_name}/data_heavy", cache_inst, data_heavy_func, [100] * 20, iterations=20)) # 100x100 array
+            all_results.extend(
+                benchmark_integration(
+                    f"{config_name}/data_heavy",
+                    cache_inst,
+                    data_heavy_func,
+                    [100] * 20,
+                    iterations=20,
+                )
+            )  # 100x100 array
 
     finally:
         shutil.rmtree(tmp_dir)
 
     print(json.dumps(all_results, indent=2))
+
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/benchmark_storage.py
+++ b/benchmarks/benchmark_storage.py
@@ -1,4 +1,3 @@
-
 import time
 import sys
 import os
@@ -9,12 +8,13 @@ import gc
 from pathlib import Path
 from typing import Any
 
-from fleche.storage import Memory, PickleFile, CloudpickleFile, Sql, BagOfHoldingH5File
+from fleche.storage import Memory, PickleFile, Sql, BagOfHoldingH5File
 from fleche.digest import digest
 from fleche.call import Call
 import numpy as np
 import timeit
 from functools import partial
+
 
 def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
     results = []
@@ -33,7 +33,9 @@ def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
                 print(f"Error digesting for {storage_name}: {e}", file=sys.stderr)
                 keys.append(None)
 
-        valid_items = [(val, k) for val, k in zip(values_to_store, keys) if k is not None]
+        valid_items = [
+            (val, k) for val, k in zip(values_to_store, keys) if k is not None
+        ]
 
         if not valid_items:
             return []
@@ -48,12 +50,14 @@ def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
             save_times.extend([t / number for t in times])
 
         if save_times:
-            results.append({
-                "benchmark": "storage_save",
-                "storage": storage_name,
-                "iterations": len(valid_items) * 30,
-                "time": min(save_times)
-            })
+            results.append(
+                {
+                    "benchmark": "storage_save",
+                    "storage": storage_name,
+                    "iterations": len(valid_items) * 30,
+                    "time": min(save_times),
+                }
+            )
 
         # Benchmark Load
         load_times = []
@@ -68,12 +72,14 @@ def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
                 continue
 
         if load_times:
-            results.append({
-                "benchmark": "storage_load",
-                "storage": storage_name,
-                "iterations": len(load_times),
-                "time": min(load_times)
-            })
+            results.append(
+                {
+                    "benchmark": "storage_load",
+                    "storage": storage_name,
+                    "iterations": len(load_times),
+                    "time": min(load_times),
+                }
+            )
 
         # Benchmark Evict
         evict_times = []
@@ -90,21 +96,24 @@ def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
             except NotImplementedError:
                 break
             except Exception as e:
-                 print(f"Error evicting from {storage_name}: {e}", file=sys.stderr)
-                 continue
+                print(f"Error evicting from {storage_name}: {e}", file=sys.stderr)
+                continue
 
         if evict_times:
-             results.append({
-                "benchmark": "storage_evict",
-                "storage": storage_name,
-                "iterations": len(evict_times),
-                "time": min(evict_times)
-            })
+            results.append(
+                {
+                    "benchmark": "storage_evict",
+                    "storage": storage_name,
+                    "iterations": len(evict_times),
+                    "time": min(evict_times),
+                }
+            )
 
     finally:
         shutil.rmtree(tmp_dir)
 
     return results
+
 
 def main():
     print("Running Storage Benchmarks...", file=sys.stderr)
@@ -114,27 +123,27 @@ def main():
 
     # Generate some complex nested structures
     from utils import st_nested_values
+
     try:
         nested_data = [st_nested_values.example() for _ in range(50)]
     except Exception as e:
         print(f"Failed to generate nested data: {e}", file=sys.stderr)
         nested_data = [{"a": 1, "b": [2, 3], "c": {"d": "test"}}] * 50
 
-    workloads = [
-        ("small_strings", small_data),
-        ("nested_structures", nested_data)
-    ]
+    workloads = [("small_strings", small_data), ("nested_structures", nested_data)]
 
     if np:
-        large_data = [np.random.rand(100, 100) for _ in range(20)] # 20 large arrays
+        large_data = [np.random.rand(100, 100) for _ in range(20)]  # 20 large arrays
         workloads.append(("numpy_arrays", large_data))
 
     factories = {
         "Memory": lambda path: Memory({}),
-        "PickleFile": lambda path: PickleFile(path),
-        "CloudpickleFile": lambda path: CloudpickleFile(path),
+        "PickleFile": lambda path: PickleFile.with_pickle(root=path),
+        "CloudpickleFile": lambda path: PickleFile.with_cloudpickle(root=path),
         # Sql is a CallStorage, skipped for general values
-        "BagOfHoldingH5File": lambda path: BagOfHoldingH5File(path) # removed project arg
+        "BagOfHoldingH5File": lambda path: BagOfHoldingH5File(
+            root=path
+        ),  # removed project arg
     }
 
     all_results = []
@@ -145,7 +154,9 @@ def main():
             try:
                 # Force GC to minimize interference
                 gc.collect()
-                results = benchmark_storage_ops(f"{storage_name}/{workload_name}", factory, data)
+                results = benchmark_storage_ops(
+                    f"{storage_name}/{workload_name}", factory, data
+                )
                 all_results.extend(results)
             except Exception as e:
                 print(f"Failed {storage_name}/{workload_name}: {e}", file=sys.stderr)
@@ -161,7 +172,7 @@ def main():
     try:
         for storage_label, url in [
             ("SqlFile/calls", f"sqlite:///{tmp_dir}/db.sqlite"),
-            ("SqlMemory/calls", "sqlite:///:memory:")
+            ("SqlMemory/calls", "sqlite:///:memory:"),
         ]:
             sql_results = []
             try:
@@ -174,14 +185,16 @@ def main():
                     number = 10
                     times = timer.repeat(repeat=3, number=number)
                     save_times.extend([t / number for t in times])
-                    keys.append(c.to_lookup_key()) # Call keys are their lookup key
+                    keys.append(c.to_lookup_key())  # Call keys are their lookup key
 
-                sql_results.append({
-                    "benchmark": "storage_save",
-                    "storage": storage_label,
-                    "iterations": len(calls_data) * 30,
-                    "time": min(save_times)
-                })
+                sql_results.append(
+                    {
+                        "benchmark": "storage_save",
+                        "storage": storage_label,
+                        "iterations": len(calls_data) * 30,
+                        "time": min(save_times),
+                    }
+                )
 
                 load_times = []
                 for key in keys:
@@ -190,12 +203,14 @@ def main():
                     times = timer.repeat(repeat=3, number=number)
                     load_times.extend([t / number for t in times])
 
-                sql_results.append({
-                    "benchmark": "storage_load",
-                    "storage": storage_label,
-                    "iterations": len(keys) * 30,
-                    "time": min(load_times)
-                })
+                sql_results.append(
+                    {
+                        "benchmark": "storage_load",
+                        "storage": storage_label,
+                        "iterations": len(keys) * 30,
+                        "time": min(load_times),
+                    }
+                )
 
                 # Sql supports evict(key)
                 evict_times = []
@@ -206,23 +221,27 @@ def main():
                     end = time.perf_counter()
                     evict_times.append(end - start)
 
-                sql_results.append({
-                    "benchmark": "storage_evict",
-                    "storage": storage_label,
-                    "iterations": len(evict_times),
-                    "time": min(evict_times)
-                })
+                sql_results.append(
+                    {
+                        "benchmark": "storage_evict",
+                        "storage": storage_label,
+                        "iterations": len(evict_times),
+                        "time": min(evict_times),
+                    }
+                )
 
                 all_results.extend(sql_results)
 
             except Exception as e:
                 import traceback
+
                 print(f"Failed {storage_label}: {e}", file=sys.stderr)
                 traceback.print_exc(file=sys.stderr)
     finally:
         shutil.rmtree(tmp_dir)
 
     print(json.dumps(all_results, indent=2))
+
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -122,7 +122,7 @@ def main():
             return colors.get(backend, "⚪️")
 
         # Split out call storage (which only uses "/calls") from value storage
-        is_call_storage = df['storage'].str.endswith('/calls', na=False)
+        is_call_storage = df["storage"].str.endswith("/calls", na=False)
 
         # Group categories using raw dataframe
         parent_categories = {

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,9 +1,9 @@
-
 from hypothesis import strategies as st
 import string
 import keyword
 from dataclasses import make_dataclass, fields, is_dataclass
 from fleche.call import Call
+
 try:
     import numpy as np
 except ImportError:
@@ -11,13 +11,25 @@ except ImportError:
 
 # Copied and adapted from tests/unit/digest/test_digest.py
 
+
 @st.composite
 def dataclasses(draw, field_types, frozen=None):
     if frozen is None:
         frozen = draw(st.booleans())
-    fields = draw(st.dictionaries(st.text(string.ascii_letters, min_size=3, max_size=3).filter(lambda s: not keyword.iskeyword(s)), field_types, min_size=1, max_size=5))
+    fields = draw(
+        st.dictionaries(
+            st.text(string.ascii_letters, min_size=3, max_size=3).filter(
+                lambda s: not keyword.iskeyword(s)
+            ),
+            field_types,
+            min_size=1,
+            max_size=5,
+        )
+    )
     clsname = draw(st.text(string.ascii_letters, min_size=3, max_size=3))
-    cls = make_dataclass(clsname, [(k, type(v)) for k, v in fields.items()], frozen=frozen)
+    cls = make_dataclass(
+        clsname, [(k, type(v)) for k, v in fields.items()], frozen=frozen
+    )
     return cls(*fields)
 
 
@@ -29,9 +41,11 @@ def calls(value_types):
         arguments=st.dictionaries(
             st.text(string.ascii_letters, min_size=1, max_size=5),
             value_types,
-            max_size=6
+            max_size=6,
         ),
-        module=st.one_of(st.none(), st.text(string.ascii_letters, min_size=1, max_size=10)),
+        module=st.one_of(
+            st.none(), st.text(string.ascii_letters, min_size=1, max_size=10)
+        ),
         version=st.one_of(st.none(), st.integers(min_value=0, max_value=100)),
     )
 
@@ -56,15 +70,16 @@ st_key_values = st.one_of(*key_strategies)  # Only hashable values for dict keys
 
 
 st_nested_values = st.recursive(
-        st_base_values,
-        lambda children: st.one_of(
-            (st_l := st.lists(children, max_size=6)),
-            st.composite(lambda draw: tuple(draw(st_l)))(),
-            st.dictionaries(st_key_values, children, max_size=6),  # Use only hashable keys
-            dataclasses(children),
-        ),
-        max_leaves=10,
-    )
+    st_base_values,
+    lambda children: st.one_of(
+        (st_l := st.lists(children, max_size=6)),
+        st.composite(lambda draw: tuple(draw(st_l)))(),
+        st.dictionaries(st_key_values, children, max_size=6),  # Use only hashable keys
+        dataclasses(children),
+    ),
+    max_leaves=10,
+)
+
 
 def generate_examples(strategy, count=100):
     """Generate a list of examples from a strategy."""


### PR DESCRIPTION
Fix benchmark scripts by updating storage backend API usage

Updated `benchmarks/benchmark_storage.py` and `benchmarks/benchmark_integration.py`
to correctly instantiate `PickleFile` and `BagOfHoldingH5File` using the
new keyword-only argument `root` and the updated classmethods `with_pickle()`
and `with_cloudpickle()`. Also removed the obsolete `CloudpickleFile` import.
This resolves exceptions that were preventing these benchmarks from running
and printing their timing results in CI.

---
*PR created automatically by Jules for task [6594891299430822352](https://jules.google.com/task/6594891299430822352) started by @pmrv*