### PR TITLE
🧹 Remove unused `annotations` import in `file.py`

### DIFF
--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import os
 import socket
@@ -41,10 +39,7 @@ def file_read_lock(
     if lock_path.exists():
         start_time = time.perf_counter()
         wait_time = wait_start
-        while (
-            lock_path.exists()
-            and (time.perf_counter() - start_time) < timeout
-        ):
+        while lock_path.exists() and (time.perf_counter() - start_time) < timeout:
             time.sleep(wait_time)
             wait_time *= 2
 
@@ -79,6 +74,7 @@ class FileStorage(Storage):
 
     Stores objects on the filesystem.
     """
+
     root: Path
     lock_timeout: float = 1.0
     lock_wait_start: float = 0.001


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` import from `src/fleche/storage/file.py` and ran black for formatting.
💡 **Why:** The `annotations` import was unused. Removing it reduces clutter and improves code health. Code formatting changes ensure it complies with the project's formatting requirements.
✅ **Verification:** Verified by running the entire test suite via `uv run` to ensure no functionality is broken. No related issues or failures occurred. Extraneous cache files were deleted before submitting to keep the working tree clean.
✨ **Result:** Improved maintainability by eliminating an unnecessary import and adhering to auto-formatting standards.

---
*PR created automatically by Jules for task [5574922350139328360](https://jules.google.com/task/5574922350139328360) started by @pmrv*