### PR TITLE
🧹 Remove unused `annotations` import in `bagofholding_file.py`

### DIFF
--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 import logging


### PR DESCRIPTION
🎯 **What:** Removed `from __future__ import annotations` from `src/fleche/storage/bagofholding_file.py`.
💡 **Why:** It was an unused import, and its removal simplifies the imports section and adheres to better code health practices.
✅ **Verification:** Ran the full test suite (`pytest tests/`) and ran `git status` to ensure only the intended file was modified and not committed along with test artifacts.
✨ **Result:** Cleaned up unused import with no impact on functionality.

---
*PR created automatically by Jules for task [18244698705499781784](https://jules.google.com/task/18244698705499781784) started by @pmrv*