### PR TITLE
🧹 Remove unused __future__ annotations import in void.py

### DIFF
--- a/src/fleche/storage/void.py
+++ b/src/fleche/storage/void.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Iterable
 


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` from `src/fleche/storage/void.py`.
💡 **Why:** To improve code maintainability and cleanliness by removing dead code. Python 3.11+ is already the baseline for this project, and this specific file did not require `annotations`.
✅ **Verification:** Verified via `black`, `ruff`, and `mypy`. Ran the full test suite (`uv run --with numpy --with hypothesis --with cloudpickle --with dill --with bagofholding --with sqlalchemy --with pytest --with jupyter --with nbconvert pytest tests/`) to ensure no functionality is broken.
✨ **Result:** Improved code health without modifying existing functionality.

---
*PR created automatically by Jules for task [14102459213967950198](https://jules.google.com/task/14102459213967950198) started by @pmrv*