### PR TITLE
🧹 Remove unused CallStorage import from file.py

### DIFF
--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Any, Generator
 
-from .base import CallStorage, Storage, DIGEST_LENGTH
+from .base import Storage, DIGEST_LENGTH
 from ..digest import Digest, digest
 
 logger = logging.getLogger("fleche.storage")
@@ -41,10 +41,7 @@ def file_read_lock(
     if lock_path.exists():
         start_time = time.perf_counter()
         wait_time = wait_start
-        while (
-            lock_path.exists()
-            and (time.perf_counter() - start_time) < timeout
-        ):
+        while lock_path.exists() and (time.perf_counter() - start_time) < timeout:
             time.sleep(wait_time)
             wait_time *= 2
 
@@ -79,6 +76,7 @@ class FileStorage(Storage):
 
     Stores objects on the filesystem.
     """
+
     root: Path
     lock_timeout: float = 1.0
     lock_wait_start: float = 0.001


### PR DESCRIPTION
🎯 **What:** Removed an unused `CallStorage` import from `src/fleche/storage/file.py`.
💡 **Why:** To improve code maintainability and readability by eliminating unnecessary imports that clutter the file.
✅ **Verification:** Verified by running the test suite (`pytest tests/`) and reviewing the modified code directly. Tests passed, and the removal had no unintended side effects. Formatted with `black`.
✨ **Result:** A cleaner `file.py` file with slightly improved code health.

---
*PR created automatically by Jules for task [18028552774353805318](https://jules.google.com/task/18028552774353805318) started by @pmrv*