### PR TITLE
🧹 refactor: Remove unused `asdict` import from `src/fleche/caches.py`

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import logging
-from dataclasses import dataclass, asdict, replace
+from dataclasses import dataclass, replace
 from copy import copy
 from typing import Self, Iterable, Any, Callable
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `asdict` import from the `dataclasses` module in `src/fleche/caches.py`.
💡 **Why:** This resolves a static analysis warning about an unused import, simplifying the code slightly and adhering to cleaner code practices without impacting any behavior.
✅ **Verification:** Ran `black` and `ruff check`, confirming the static analysis finding is resolved and formatting is correct. Then, ran the full `pytest tests/` test suite with all optional dependencies to verify that no regressions were introduced.
✨ **Result:** A slightly cleaner source file in `src/fleche/caches.py` that conforms to linting standards, leading to better overall code health.

---
*PR created automatically by Jules for task [1422812429120737908](https://jules.google.com/task/1422812429120737908) started by @pmrv*