### PR TITLE
🧹 code health: Remove unused `Engine` import in `sql.py`

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -22,7 +22,6 @@ with ImportAlarm(
         select,
         and_,
     )
-    from sqlalchemy.engine import Engine
     from sqlalchemy import event
     from sqlalchemy.orm import declarative_base, sessionmaker, relationship, Session, aliased
     from sqlalchemy.types import JSON


### PR DESCRIPTION
🎯 **What:** Removed the unused `from sqlalchemy.engine import Engine` import from `src/fleche/storage/sql.py`.
💡 **Why:** `Engine` was imported but not used, causing code bloat and potential confusion.
✅ **Verification:** Ran `pytest tests/` locally to verify removing the import didn't cause any regressions. Ensured I didn't introduce unneeded generated cache files (`.dill_cache`) or `uv.lock`.
✨ **Result:** Improved code readability and maintainability by removing unused imports.

---
*PR created automatically by Jules for task [13552589008295243137](https://jules.google.com/task/13552589008295243137) started by @pmrv*