### PR TITLE
🧪 Add test for FileNotFound path in Pickle storage

### DIFF
--- a/tests/unit/storage/test_pickle_file.py
+++ b/tests/unit/storage/test_pickle_file.py
@@ -1,0 +1,21 @@
+import pytest
+from fleche.storage.pickle_file import PickleFile
+from fleche.digest import Digest
+
+
+def test_load_file_not_found(tmp_path):
+    """
+    Test that PickleFile._load raises KeyError when the file is not found.
+    This triggers the FileNotFoundError exception path in _load.
+    """
+    storage = PickleFile.with_pickle(root=tmp_path)
+    # Use a valid full-length digest key that doesn't exist in the storage
+    non_existent_key = Digest("a" * 64)
+
+    # Verify that attempting to load a non-existent file raises KeyError
+    # We call _load directly to bypass expansion/lock logic and target the specific code path
+    with pytest.raises(KeyError) as exc_info:
+        storage._load(non_existent_key)
+
+    # Ensure the correct key is in the exception
+    assert str(exc_info.value) == f"'{non_existent_key}'"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
I've implemented a unit test for the `FileNotFoundError` exception path in the `PickleFile._load` method. This path was previously untested and is responsible for converting a filesystem `FileNotFoundError` into a fleche-specific `KeyError` when a requested digest is not found on disk.

📊 **Coverage:** What scenarios are now tested
- Loading a non-existent value using a full-length digest key: Verified that `PickleFile._load` correctly raises a `KeyError` containing the missing key.

✨ **Result:** The improvement in test coverage
This change increases the reliability of the `PickleFile` storage backend by ensuring that missing files are handled gracefully and consistently with the expected `KeyError` interface of the `Storage` class. It specifically covers lines that were previously missed in the exception handling logic of `_load`.

---
*PR created automatically by Jules for task [15397441162836581652](https://jules.google.com/task/15397441162836581652) started by @pmrv*