### PR TITLE
fix: Update benchmark orchestrator for new column names

### DIFF
--- a/benchmarks/results.csv
+++ b/benchmarks/results.csv
@@ -1,180 +1,180 @@
 topic,configuration,workload,function,time
-Digest,,"List (integers, len>100)",digest,61 ms
+Digest,,"List (integers, len>100)",digest,66 ms
 Digest,,"Numpy (integers, len>100)",digest,13 ms
-Integration,H5+Sql,compute_heavy,miss,8.8 ms
-Integration,H5+Sql,lightweight,miss,7.8 ms
-Integration,H5+Sql,data_heavy,miss,6.6 ms
-Integration,H5+Sql,compute_heavy,hit,6.5 ms
-Digest,,Nested (Random Hypothesis),digest,6.5 ms
-Integration,H5+Sql,data_heavy,hit,6.4 ms
-Integration,H5+Sql,lightweight,hit,6.2 ms
-Call Storage,SqlFile,calls,save,5.6 ms
-Integration,Pickle+Sql,compute_heavy,miss,5.2 ms
-Digest,,Dict (small),digest,4.9 ms
-Integration,Pickle+Sql,lightweight,miss,4.8 ms
-Call Storage,SqlFile,calls,evict,3.7 ms
-Call Storage,SqlMemory,calls,save,3.4 ms
-Value Storage,BagOfHoldingH5File,numpy_arrays,load,2.8 ms
-Integration,Memory+Sqlite(:memory:),compute_heavy,miss,2.6 ms
-Value Storage,BagOfHoldingH5File,numpy_arrays,contains_hit,2.6 ms
-Value Storage,BagOfHoldingH5File,numpy_arrays,save,2.5 ms
-Integration,Memory+Sqlite(:memory:),lightweight,miss,2.4 ms
-Value Storage,BagOfHoldingH5File,small_strings,load,2.4 ms
-Value Storage,BagOfHoldingH5File,small_strings,contains_hit,2.4 ms
-Digest,,"List (integers, len<100)",digest,2 ms
-Integration,Pickle+Sql,compute_heavy,hit,1.9 ms
-Digest,,"Numpy (integers, len<100)",digest,1.8 ms
-Value Storage,BagOfHoldingH5File,nested_structures,contains_hit,1.8 ms
-Integration,Pickle+Sql,data_heavy,hit,1.8 ms
-Value Storage,BagOfHoldingH5File,nested_structures,load,1.8 ms
-Value Storage,BagOfHoldingH5File,small_strings,save,1.7 ms
-Integration,Pickle+Sql,data_heavy,miss,1.7 ms
-Integration,Pickle+Sql,lightweight,hit,1.7 ms
-Integration,H5+Sql,data_heavy,contains_hit,1.6 ms
-Value Storage,BagOfHoldingH5File,nested_structures,save,1.6 ms
-Integration,Pickle+Sql,compute_heavy,contains_hit,1.5 ms
-Integration,H5+Sql,compute_heavy,contains_hit,1.5 ms
-Integration,Memory+Sqlite(:memory:),lightweight,contains_hit,1.4 ms
-Integration,Memory+Sqlite(:memory:),lightweight,hit,1.4 ms
-Integration,Memory+Sqlite(:memory:),data_heavy,contains_hit,1.4 ms
-Integration,Pickle+Sql,lightweight,contains_hit,1.4 ms
-Integration,H5+Sql,lightweight,contains_hit,1.4 ms
-Call Storage,SqlMemory,calls,evict,1.4 ms
-Integration,Memory+Sqlite(:memory:),compute_heavy,hit,1.4 ms
-Integration,Memory+Sqlite(:memory:),compute_heavy,contains_hit,1.4 ms
-Integration,Memory+Sqlite(:memory:),data_heavy,hit,1.4 ms
-Integration,Pickle+Sql,data_heavy,contains_hit,1.4 ms
-Integration,Memory+Sqlite(:memory:),data_heavy,miss,1.3 ms
-Call Storage,SqlFile,calls,contains_hit,1.2 ms
-Call Storage,SqlFile,calls,load,1.2 ms
-Call Storage,SqlMemory,calls,load,1.1 ms
-Call Storage,SqlMemory,calls,contains_hit,1.1 ms
-Value Storage,DillFile_Signed,numpy_arrays,save,930 µs
-Integration,H5+Sql,data_heavy,contains_miss,800 µs
-Value Storage,CloudpickleFile_Signed,numpy_arrays,save,740 µs
-Value Storage,DillFile,numpy_arrays,save,720 µs
-Value Storage,PickleFile_Signed,numpy_arrays,save,690 µs
-Integration,H5+Sql,compute_heavy,contains_miss,680 µs
-Integration,Pickle+Sql,compute_heavy,contains_miss,670 µs
-Integration,Pickle+Sql,lightweight,contains_miss,670 µs
-Integration,Pickle+Sql,data_heavy,contains_miss,670 µs
-Integration,H5+Sql,lightweight,contains_miss,660 µs
-Integration,Memory+Sqlite(:memory:),compute_heavy,contains_miss,640 µs
-Integration,Memory+Sqlite(:memory:),lightweight,contains_miss,630 µs
-Integration,Memory+Sqlite(:memory:),data_heavy,contains_miss,630 µs
-Value Storage,PickleFile,numpy_arrays,save,570 µs
-Digest,,String (len>100),digest,540 µs
-Integration,Memory,compute_heavy,miss,530 µs
-Digest,,Float,digest,520 µs
-Value Storage,CloudpickleFile,numpy_arrays,save,500 µs
-Call Storage,SqlFile,calls,contains_miss,500 µs
-Value Storage,DillFile_Signed,small_strings,save,500 µs
-Value Storage,DillFile_Signed,nested_structures,save,490 µs
-Value Storage,DillFile,small_strings,save,490 µs
-Value Storage,DillFile,nested_structures,save,470 µs
-Integration,Memory,lightweight,miss,470 µs
-Value Storage,CloudpickleFile,nested_structures,save,450 µs
-Value Storage,CloudpickleFile_Signed,nested_structures,save,440 µs
-Call Storage,SqlMemory,calls,contains_miss,410 µs
-Value Storage,DillFile_Signed,numpy_arrays,load,370 µs
-Value Storage,DillFile_Signed,numpy_arrays,contains_hit,370 µs
-Value Storage,CloudpickleFile_Signed,numpy_arrays,load,370 µs
-Value Storage,CloudpickleFile_Signed,numpy_arrays,contains_hit,350 µs
-Value Storage,PickleFile_Signed,numpy_arrays,contains_hit,350 µs
-Value Storage,PickleFile_Signed,numpy_arrays,load,340 µs
-Value Storage,CloudpickleFile_Signed,small_strings,save,330 µs
-Value Storage,PickleFile_Signed,small_strings,save,330 µs
-Digest,,None,digest,320 µs
-Value Storage,CloudpickleFile,small_strings,save,310 µs
-Digest,,Integer,digest,310 µs
-Value Storage,PickleFile,small_strings,save,310 µs
-Digest,,String (len<100),digest,260 µs
-Integration,Memory,lightweight,contains_hit,250 µs
-Integration,Memory,data_heavy,hit,250 µs
-Integration,Memory,lightweight,hit,250 µs
-Integration,Memory,compute_heavy,contains_hit,240 µs
-Integration,Memory,compute_heavy,hit,240 µs
-Integration,Memory,data_heavy,contains_hit,230 µs
-Integration,Memory,lightweight,contains_miss,190 µs
-Integration,Memory,compute_heavy,contains_miss,190 µs
-Value Storage,BagOfHoldingH5File,nested_structures,contains_miss,180 µs
-Integration,Memory,data_heavy,contains_miss,180 µs
-Value Storage,BagOfHoldingH5File,numpy_arrays,contains_miss,180 µs
-Value Storage,BagOfHoldingH5File,small_strings,contains_miss,180 µs
-Integration,Memory,data_heavy,miss,130 µs
-Value Storage,DillFile,numpy_arrays,contains_hit,120 µs
-Value Storage,DillFile,numpy_arrays,load,120 µs
-Value Storage,PickleFile,numpy_arrays,load,110 µs
-Value Storage,PickleFile,numpy_arrays,contains_hit,110 µs
-Value Storage,CloudpickleFile,numpy_arrays,contains_hit,110 µs
-Value Storage,DillFile_Signed,small_strings,contains_hit,110 µs
-Value Storage,CloudpickleFile,numpy_arrays,load,110 µs
-Value Storage,DillFile_Signed,nested_structures,load,100 µs
-Value Storage,DillFile_Signed,small_strings,load,100 µs
-Value Storage,DillFile_Signed,nested_structures,contains_hit,100 µs
-Value Storage,PickleFile,numpy_arrays,evict,100 µs
+Integration,H5+Sql,compute_heavy,miss,11 ms
+Integration,H5+Sql,lightweight,miss,10 ms
+Integration,H5+Sql,data_heavy,hit,8.1 ms
+Integration,H5+Sql,lightweight,hit,7.9 ms
+Integration,H5+Sql,compute_heavy,hit,7.8 ms
+Integration,H5+Sql,data_heavy,miss,7.5 ms
+Integration,Pickle+Sql,compute_heavy,miss,7.1 ms
+Integration,Pickle+Sql,lightweight,miss,6.4 ms
+Call Storage,SqlFile,calls,save,6.2 ms
+Digest,,Nested (Random Hypothesis),digest,5.8 ms
+Digest,,Dict (small),digest,4.6 ms
+Call Storage,SqlFile,calls,evict,4.2 ms
+Call Storage,SqlMemory,calls,save,3.7 ms
+Integration,Memory+Sqlite(:memory:),compute_heavy,miss,3.5 ms
+Value Storage,BagOfHoldingH5File,numpy_arrays,load,2.9 ms
+Value Storage,BagOfHoldingH5File,numpy_arrays,save,2.9 ms
+Value Storage,BagOfHoldingH5File,numpy_arrays,contains_hit,2.9 ms
+Integration,Memory+Sqlite(:memory:),lightweight,miss,2.8 ms
+Value Storage,BagOfHoldingH5File,small_strings,load,2.7 ms
+Value Storage,BagOfHoldingH5File,small_strings,contains_hit,2.7 ms
+Integration,Pickle+Sql,data_heavy,hit,2.2 ms
+Integration,Pickle+Sql,compute_heavy,hit,2.1 ms
+Integration,Pickle+Sql,data_heavy,miss,2.1 ms
+Integration,Pickle+Sql,lightweight,hit,2.1 ms
+Digest,,"List (integers, len<100)",digest,2.1 ms
+Value Storage,BagOfHoldingH5File,small_strings,save,2 ms
+Value Storage,BagOfHoldingH5File,nested_structures,contains_hit,2 ms
+Value Storage,BagOfHoldingH5File,nested_structures,load,2 ms
+Integration,H5+Sql,data_heavy,contains_hit,1.9 ms
+Digest,,"Numpy (integers, len<100)",digest,1.9 ms
+Value Storage,BagOfHoldingH5File,nested_structures,save,1.8 ms
+Integration,Pickle+Sql,compute_heavy,contains_hit,1.8 ms
+Integration,Pickle+Sql,data_heavy,contains_hit,1.8 ms
+Integration,H5+Sql,compute_heavy,contains_hit,1.8 ms
+Integration,H5+Sql,lightweight,contains_hit,1.7 ms
+Integration,Pickle+Sql,lightweight,contains_hit,1.7 ms
+Integration,Memory+Sqlite(:memory:),compute_heavy,contains_hit,1.7 ms
+Integration,Memory+Sqlite(:memory:),lightweight,contains_hit,1.6 ms
+Integration,Memory+Sqlite(:memory:),data_heavy,hit,1.6 ms
+Integration,Memory+Sqlite(:memory:),data_heavy,contains_hit,1.6 ms
+Call Storage,SqlMemory,calls,evict,1.6 ms
+Integration,Memory+Sqlite(:memory:),compute_heavy,hit,1.6 ms
+Integration,Memory+Sqlite(:memory:),lightweight,hit,1.6 ms
+Integration,Memory+Sqlite(:memory:),data_heavy,miss,1.6 ms
+Call Storage,SqlFile,calls,load,1.4 ms
+Call Storage,SqlFile,calls,contains_hit,1.3 ms
+Call Storage,SqlMemory,calls,load,1.2 ms
+Call Storage,SqlMemory,calls,contains_hit,1.2 ms
+Value Storage,DillFile_Signed,numpy_arrays,save,1 ms
+Integration,Pickle+Sql,data_heavy,contains_miss,870 µs
+Value Storage,CloudpickleFile,numpy_arrays,save,850 µs
+Integration,H5+Sql,data_heavy,contains_miss,840 µs
+Value Storage,CloudpickleFile_Signed,numpy_arrays,save,820 µs
+Integration,H5+Sql,lightweight,contains_miss,820 µs
+Integration,H5+Sql,compute_heavy,contains_miss,800 µs
+Value Storage,DillFile,numpy_arrays,save,780 µs
+Integration,Pickle+Sql,lightweight,contains_miss,780 µs
+Integration,Memory+Sqlite(:memory:),lightweight,contains_miss,770 µs
+Value Storage,PickleFile_Signed,numpy_arrays,save,760 µs
+Integration,Memory+Sqlite(:memory:),compute_heavy,contains_miss,760 µs
+Integration,Pickle+Sql,compute_heavy,contains_miss,760 µs
+Integration,Memory+Sqlite(:memory:),data_heavy,contains_miss,750 µs
+Integration,Memory,compute_heavy,miss,740 µs
+Value Storage,DillFile_Signed,small_strings,save,620 µs
+Digest,,String (len>100),digest,590 µs
+Digest,,Float,digest,580 µs
+Integration,Memory,lightweight,miss,520 µs
+Value Storage,DillFile,small_strings,save,500 µs
+Value Storage,PickleFile,numpy_arrays,save,490 µs
+Call Storage,SqlFile,calls,contains_miss,490 µs
+Value Storage,CloudpickleFile,nested_structures,save,480 µs
+Value Storage,PickleFile,small_strings,save,470 µs
+Call Storage,SqlMemory,calls,contains_miss,440 µs
+Value Storage,DillFile_Signed,numpy_arrays,contains_hit,430 µs
+Value Storage,DillFile_Signed,numpy_arrays,load,430 µs
+Value Storage,CloudpickleFile_Signed,numpy_arrays,load,420 µs
+Value Storage,CloudpickleFile_Signed,numpy_arrays,contains_hit,420 µs
+Value Storage,PickleFile_Signed,small_strings,save,420 µs
+Value Storage,CloudpickleFile_Signed,nested_structures,save,410 µs
+Value Storage,PickleFile_Signed,numpy_arrays,contains_hit,410 µs
+Value Storage,PickleFile_Signed,numpy_arrays,load,410 µs
+Value Storage,CloudpickleFile,small_strings,save,410 µs
+Value Storage,DillFile_Signed,nested_structures,save,400 µs
+Value Storage,DillFile,nested_structures,save,380 µs
+Value Storage,CloudpickleFile_Signed,small_strings,save,370 µs
+Digest,,None,digest,360 µs
+Digest,,Integer,digest,350 µs
+Digest,,String (len<100),digest,320 µs
+Integration,Memory,data_heavy,hit,300 µs
+Integration,Memory,compute_heavy,hit,290 µs
+Integration,Memory,compute_heavy,contains_hit,290 µs
+Integration,Memory,data_heavy,contains_hit,280 µs
+Integration,Memory,lightweight,contains_hit,280 µs
+Value Storage,BagOfHoldingH5File,nested_structures,contains_miss,280 µs
+Integration,Memory,lightweight,hit,280 µs
+Integration,Memory,compute_heavy,contains_miss,220 µs
+Integration,Memory,lightweight,contains_miss,220 µs
+Integration,Memory,data_heavy,contains_miss,220 µs
+Integration,Memory,data_heavy,miss,220 µs
+Value Storage,BagOfHoldingH5File,small_strings,contains_miss,220 µs
+Value Storage,BagOfHoldingH5File,numpy_arrays,contains_miss,210 µs
+Value Storage,CloudpickleFile,numpy_arrays,contains_hit,170 µs
+Value Storage,CloudpickleFile,numpy_arrays,load,150 µs
+Value Storage,DillFile,numpy_arrays,contains_hit,150 µs
+Value Storage,DillFile,numpy_arrays,load,150 µs
+Value Storage,PickleFile,numpy_arrays,contains_hit,130 µs
+Value Storage,PickleFile,numpy_arrays,load,130 µs
+Value Storage,DillFile_Signed,nested_structures,contains_hit,120 µs
+Value Storage,DillFile_Signed,small_strings,contains_hit,120 µs
+Value Storage,DillFile,small_strings,load,120 µs
+Value Storage,PickleFile_Signed,small_strings,contains_hit,110 µs
+Value Storage,DillFile_Signed,small_strings,load,110 µs
+Value Storage,CloudpickleFile_Signed,small_strings,load,110 µs
+Value Storage,DillFile,nested_structures,contains_hit,110 µs
+Value Storage,CloudpickleFile_Signed,nested_structures,load,110 µs
+Value Storage,DillFile_Signed,nested_structures,load,110 µs
+Value Storage,CloudpickleFile_Signed,nested_structures,contains_hit,110 µs
+Value Storage,DillFile,nested_structures,load,110 µs
 Value Storage,PickleFile_Signed,small_strings,load,100 µs
-Value Storage,CloudpickleFile_Signed,small_strings,load,99 µs
-Value Storage,PickleFile_Signed,small_strings,contains_hit,99 µs
-Value Storage,PickleFile,small_strings,contains_hit,96 µs
-Value Storage,DillFile,small_strings,contains_hit,96 µs
-Value Storage,CloudpickleFile_Signed,small_strings,contains_hit,95 µs
-Value Storage,PickleFile,small_strings,load,93 µs
-Value Storage,DillFile,small_strings,load,92 µs
-Value Storage,CloudpickleFile_Signed,nested_structures,contains_hit,91 µs
-Value Storage,BagOfHoldingH5File,numpy_arrays,evict,91 µs
-Value Storage,CloudpickleFile_Signed,nested_structures,load,90 µs
-Value Storage,CloudpickleFile_Signed,numpy_arrays,evict,88 µs
-Value Storage,DillFile,nested_structures,load,86 µs
-Value Storage,DillFile,nested_structures,contains_hit,86 µs
-Value Storage,CloudpickleFile,small_strings,contains_hit,83 µs
-Value Storage,CloudpickleFile,nested_structures,contains_hit,82 µs
-Value Storage,CloudpickleFile,numpy_arrays,evict,82 µs
-Value Storage,PickleFile_Signed,numpy_arrays,evict,81 µs
-Value Storage,CloudpickleFile,nested_structures,load,81 µs
-Value Storage,PickleFile,small_strings,evict,80 µs
-Value Storage,DillFile_Signed,numpy_arrays,evict,80 µs
-Value Storage,CloudpickleFile,small_strings,load,78 µs
-Value Storage,PickleFile_Signed,small_strings,evict,78 µs
-Value Storage,DillFile,numpy_arrays,evict,78 µs
-Value Storage,DillFile,small_strings,evict,78 µs
-Value Storage,CloudpickleFile,small_strings,evict,74 µs
-Value Storage,DillFile_Signed,small_strings,evict,74 µs
-Value Storage,CloudpickleFile_Signed,small_strings,evict,72 µs
-Value Storage,PickleFile,small_strings,contains_miss,71 µs
-Value Storage,PickleFile_Signed,small_strings,contains_miss,68 µs
-Value Storage,BagOfHoldingH5File,small_strings,evict,66 µs
-Value Storage,DillFile_Signed,small_strings,contains_miss,66 µs
-Value Storage,CloudpickleFile_Signed,small_strings,contains_miss,64 µs
-Value Storage,CloudpickleFile,small_strings,contains_miss,64 µs
-Value Storage,CloudpickleFile,numpy_arrays,contains_miss,64 µs
-Value Storage,DillFile,small_strings,contains_miss,63 µs
-Value Storage,CloudpickleFile_Signed,numpy_arrays,contains_miss,62 µs
-Value Storage,CloudpickleFile_Signed,nested_structures,contains_miss,61 µs
-Value Storage,CloudpickleFile,nested_structures,contains_miss,61 µs
-Value Storage,PickleFile_Signed,numpy_arrays,contains_miss,61 µs
-Value Storage,DillFile,numpy_arrays,contains_miss,61 µs
-Value Storage,DillFile_Signed,nested_structures,contains_miss,60 µs
-Value Storage,DillFile_Signed,numpy_arrays,contains_miss,60 µs
-Value Storage,DillFile,nested_structures,contains_miss,60 µs
-Value Storage,PickleFile,numpy_arrays,contains_miss,59 µs
-Value Storage,BagOfHoldingH5File,nested_structures,evict,52 µs
-Value Storage,CloudpickleFile_Signed,nested_structures,evict,51 µs
-Value Storage,CloudpickleFile,nested_structures,evict,48 µs
-Value Storage,DillFile_Signed,nested_structures,evict,47 µs
-Value Storage,DillFile,nested_structures,evict,47 µs
-Value Storage,Memory,numpy_arrays,load,6.5 µs
-Value Storage,Memory,numpy_arrays,contains_hit,6.5 µs
-Value Storage,Memory,numpy_arrays,save,6 µs
-Value Storage,Memory,small_strings,contains_miss,1.5 µs
-Value Storage,Memory,nested_structures,contains_miss,1.4 µs
-Value Storage,Memory,numpy_arrays,contains_miss,1.4 µs
+Value Storage,CloudpickleFile_Signed,small_strings,contains_hit,100 µs
+Value Storage,DillFile,small_strings,contains_hit,100 µs
+Value Storage,PickleFile_Signed,numpy_arrays,evict,100 µs
+Value Storage,CloudpickleFile,numpy_arrays,evict,97 µs
+Value Storage,CloudpickleFile_Signed,numpy_arrays,evict,97 µs
+Value Storage,CloudpickleFile,nested_structures,contains_hit,96 µs
+Value Storage,DillFile_Signed,numpy_arrays,evict,95 µs
+Value Storage,CloudpickleFile,nested_structures,load,95 µs
+Value Storage,PickleFile,small_strings,load,94 µs
+Value Storage,CloudpickleFile,small_strings,contains_hit,94 µs
+Value Storage,CloudpickleFile,small_strings,load,94 µs
+Value Storage,DillFile,numpy_arrays,evict,93 µs
+Value Storage,BagOfHoldingH5File,numpy_arrays,evict,93 µs
+Value Storage,PickleFile,numpy_arrays,evict,93 µs
+Value Storage,PickleFile,small_strings,contains_hit,91 µs
+Value Storage,PickleFile,small_strings,evict,82 µs
+Value Storage,CloudpickleFile,small_strings,evict,81 µs
+Value Storage,CloudpickleFile_Signed,small_strings,evict,81 µs
+Value Storage,DillFile,small_strings,evict,81 µs
+Value Storage,BagOfHoldingH5File,small_strings,evict,80 µs
+Value Storage,DillFile_Signed,small_strings,evict,79 µs
+Value Storage,PickleFile_Signed,small_strings,evict,79 µs
+Value Storage,CloudpickleFile,numpy_arrays,contains_miss,78 µs
+Value Storage,PickleFile_Signed,numpy_arrays,contains_miss,72 µs
+Value Storage,CloudpickleFile_Signed,numpy_arrays,contains_miss,72 µs
+Value Storage,DillFile,numpy_arrays,contains_miss,72 µs
+Value Storage,PickleFile,numpy_arrays,contains_miss,72 µs
+Value Storage,DillFile_Signed,numpy_arrays,contains_miss,72 µs
+Value Storage,DillFile,small_strings,contains_miss,71 µs
+Value Storage,CloudpickleFile_Signed,nested_structures,contains_miss,71 µs
+Value Storage,DillFile,nested_structures,contains_miss,71 µs
+Value Storage,CloudpickleFile,small_strings,contains_miss,70 µs
+Value Storage,PickleFile,small_strings,contains_miss,70 µs
+Value Storage,DillFile_Signed,small_strings,contains_miss,70 µs
+Value Storage,PickleFile_Signed,small_strings,contains_miss,69 µs
+Value Storage,CloudpickleFile,nested_structures,contains_miss,69 µs
+Value Storage,DillFile_Signed,nested_structures,contains_miss,68 µs
+Value Storage,CloudpickleFile_Signed,small_strings,contains_miss,68 µs
+Value Storage,CloudpickleFile,nested_structures,evict,56 µs
+Value Storage,BagOfHoldingH5File,nested_structures,evict,55 µs
+Value Storage,DillFile,nested_structures,evict,55 µs
+Value Storage,DillFile_Signed,nested_structures,evict,54 µs
+Value Storage,CloudpickleFile_Signed,nested_structures,evict,53 µs
+Value Storage,Memory,numpy_arrays,contains_hit,7.4 µs
+Value Storage,Memory,numpy_arrays,load,7.2 µs
+Value Storage,Memory,numpy_arrays,save,6.9 µs
+Value Storage,Memory,small_strings,contains_miss,1.9 µs
+Value Storage,Memory,nested_structures,contains_miss,1.7 µs
+Value Storage,Memory,numpy_arrays,contains_miss,1.7 µs
+Value Storage,Memory,small_strings,load,1.4 µs
+Value Storage,Memory,small_strings,contains_hit,1.4 µs
+Value Storage,Memory,nested_structures,contains_hit,1.3 µs
+Value Storage,Memory,numpy_arrays,evict,1.3 µs
 Value Storage,Memory,nested_structures,load,1.2 µs
-Value Storage,Memory,nested_structures,contains_hit,1.1 µs
-Value Storage,Memory,small_strings,load,1.1 µs
-Value Storage,Memory,small_strings,contains_hit,1.1 µs
-Value Storage,Memory,numpy_arrays,evict,990 ns
-Value Storage,Memory,nested_structures,save,790 ns
-Value Storage,Memory,nested_structures,evict,780 ns
-Value Storage,Memory,small_strings,save,740 ns
-Value Storage,Memory,small_strings,evict,610 ns
+Value Storage,Memory,small_strings,save,930 ns
+Value Storage,Memory,nested_structures,save,840 ns
+Value Storage,Memory,small_strings,evict,710 ns
+Value Storage,Memory,nested_structures,evict,680 ns

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -226,17 +226,41 @@ def main():
         # Compare with old_df to find significant changes
         if old_df is not None and not old_df.empty:
             try:
-                # Ensure merge columns are strings to match safely
-                merge_cols = ["benchmark", "name", "storage"]
+                # In parsed_df and the updated old_df format, the columns have changed.
+                # old_df represents a previous run, but if the CSV was already overwritten with the new format,
+                # it uses the new columns. To match safely between current parsed_df and old_df:
+                merge_cols = ["topic", "configuration", "workload", "function"]
                 for col in merge_cols:
-                    if col in final_df.columns:
-                        final_df[col] = final_df[col].fillna("").astype(str)
+                    if col in parsed_df.columns:
+                        parsed_df[col] = parsed_df[col].fillna("").astype(str)
                     if col in old_df.columns:
                         old_df[col] = old_df[col].fillna("").astype(str)
 
                 compare_df = pd.merge(
-                    final_df, old_df, on=merge_cols, suffixes=("_new", "_old")
+                    parsed_df, old_df, on=merge_cols, suffixes=("_new", "_old")
                 )
+
+                # We need to process the formatted time strings back into floats for comparison.
+                def extract_time(t_str):
+                    if pd.isna(t_str):
+                        return 0.0
+                    t_str = str(t_str)
+                    try:
+                        val = float(t_str.split()[0])
+                        if " ns" in t_str:
+                            return val * 1e-9
+                        if " µs" in t_str:
+                            return val * 1e-6
+                        if " ms" in t_str:
+                            return val * 1e-3
+                        if " s" in t_str:
+                            return val
+                        return val
+                    except (ValueError, IndexError):
+                        return 0.0
+
+                compare_df["time_old"] = compare_df["time_old"].apply(extract_time)
+                compare_df["time_new"] = compare_df["time_new"].apply(extract_time)
                 # Filter out those where old time is 0 to avoid division by zero
                 compare_df = compare_df[compare_df["time_old"] > 0].copy()
                 compare_df["% Change"] = (
@@ -271,9 +295,10 @@ def main():
                     ].apply(format_time)
 
                     display_cols = [
-                        "benchmark",
-                        "name",
-                        "storage",
+                        "topic",
+                        "configuration",
+                        "workload",
+                        "function",
                         "Old Time",
                         "New Time",
                         "% Change",
@@ -294,55 +319,35 @@ def main():
             except Exception as e:
                 print(f"Error computing significant changes: {e}", file=sys.stderr)
 
-        for parent_title, info in parent_categories.items():
-            sub_df = info["data"]
-            if sub_df.empty:
+        topics = parsed_df["topic"].unique()
+        for topic in topics:
+            if pd.isna(topic) or topic == "":
                 continue
 
-            index_col = info["index"]
-
             print("<details>")
-            print(f"<summary><b>{parent_title}</b></summary>\n")
+            print(f"<summary><b>{topic} Benchmarks</b></summary>\n")
             print('<div style="overflow-x: auto;">\n')
 
-            if parent_title == "Value Storage Benchmarks":
-                # Split storage column by '/'
-                sub_df = sub_df.copy()
-                sub_df[["storage_backend", "workload"]] = sub_df["storage"].str.split(
-                    "/", n=1, expand=True
-                )
+            topic_df = parsed_df[parsed_df["topic"] == topic].copy()
+            workloads = topic_df["workload"].unique()
 
-                workloads = sub_df["workload"].unique()
-                for workload in workloads:
-                    if pd.isna(workload):
-                        continue
+            for workload in workloads:
+                if pd.isna(workload):
+                    continue
 
+                if workload != "":
                     print(f"<h4>Workload: {workload}</h4>\n")
-                    workload_df = sub_df[sub_df["workload"] == workload].copy()
-                    workload_df["storage"] = workload_df["storage_backend"]
-                    render_table(workload_df, index_col, parent_title)
-            elif parent_title == "Integration Benchmarks":
-                # Split name column by '/'
-                sub_df = sub_df.copy()
-                sub_df[["storage_backend", "workload"]] = sub_df["name"].str.split(
-                    "/", n=1, expand=True
-                )
 
-                workloads = sub_df["workload"].unique()
-                for workload in workloads:
-                    if pd.isna(workload):
-                        continue
+                workload_df = topic_df[topic_df["workload"] == workload].copy()
 
-                    print(f"<h4>Workload: {workload}</h4>\n")
-                    workload_df = sub_df[sub_df["workload"] == workload].copy()
-                    workload_df["name"] = workload_df["storage_backend"]
-                    render_table(workload_df, index_col, parent_title)
-            elif parent_title == "Call Storage Benchmarks":
-                sub_df = sub_df.copy()
-                sub_df["storage"] = sub_df["storage"].str.replace("/calls", "")
-                render_table(sub_df, index_col, parent_title)
-            else:
-                render_table(sub_df, index_col, parent_title)
+                # We can drop topic and workload columns since they are in the headers
+                display_df = workload_df.drop(columns=["topic", "workload"])
+
+                try:
+                    print(display_df.to_markdown(index=False))
+                except ImportError:
+                    print(to_markdown_table(display_df))
+                print("\n")
 
             print("</div>")
             print("</details>\n")


### PR DESCRIPTION
Fixes the benchmark orchestrator script (`benchmarks/run_benchmarks.py`) to properly handle the updated schema resulting from recent dataframe refactors. Restores the logic to print hierarchical HTML tables per workload and properly calculate significant time changes against past runs.

---
*PR created automatically by Jules for task [5883675738605646732](https://jules.google.com/task/5883675738605646732) started by @pmrv*