### PR TITLE
Fix code_digest persistence in SQL storage

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -34,6 +34,7 @@ with ImportAlarm(
         name: Mapped[str] = mapped_column(String, nullable=False)
         module: Mapped[str] = mapped_column(String, nullable=True)
         version: Mapped[int] = mapped_column(Integer, nullable=True)
+        code_digest: Mapped[str] = mapped_column(String(DIGEST_LENGTH), nullable=True)
         result: Mapped[str] = mapped_column(String(DIGEST_LENGTH), nullable=True)
 
         arguments = relationship(
@@ -142,6 +143,7 @@ class Sql(CallStorage):
                 name=call.name,
                 module=call.module,
                 version=call.version,
+                code_digest=call.code_digest,
                 result=call.result if call.result is None else str(call.result),
             )
             session.add(call_model)
@@ -189,6 +191,7 @@ class Sql(CallStorage):
                 metadata={row.name: (row.data or {}) for row in meta_rows},
                 module=call_model.module,
                 version=call_model.version,
+                code_digest=call_model.code_digest,
                 result=(
                     Digest(call_model.result) if call_model.result is not None else None
                 ),

--- a/tests/integration/test_sql_table_uniqueness.py
+++ b/tests/integration/test_sql_table_uniqueness.py
@@ -1,0 +1,34 @@
+
+import pytest
+from fleche.storage.sql import Sql
+from fleche.storage.memory import Memory
+from fleche.caches import Cache
+from fleche import fleche, cache, tags
+
+def test_sql_table_uniqueness(tmp_path):
+    """Integration test to verify that cache.table() does not contain more items than cache.calls.list()
+    when using a SQL backend, even with joins.
+    """
+    db_path = tmp_path / "test.db"
+    sql_storage = Sql(str(db_path))
+    val_storage = Memory(storage={})
+    c = Cache(values=val_storage, _calls=sql_storage)
+
+    with cache(c):
+        @fleche
+        def my_func(a, b):
+            return a + b
+
+        # Use multiple tags to ensure multiple rows in metadata table if not distinct
+        with tags(t1="v1", t2="v2"):
+            my_func(1, 2)
+
+        # Use multiple arguments to ensure multiple rows in arguments table if not distinct
+        my_func(a=3, b=4)
+
+        # Check counts
+        num_calls = len(list(c.calls.list()))
+        table_df = c.table()
+
+        assert len(table_df) == num_calls, "Table should have exactly one row per call"
+        assert table_df.index.is_unique, "Table index must be unique"

--- a/tests/unit/storage/test_sql_query.py
+++ b/tests/unit/storage/test_sql_query.py
@@ -248,3 +248,27 @@ def test_sql_query_by_result(store):
     assert keys(got) == slow_query_keys(
         store, tpl
     ), "Result filter must match baseline-selected keys by digest"
+
+
+def test_sql_call_digest_persistence(store):
+    """A call saved to SQL must retain the same digest before and after loading.
+
+    Regression test: ensures code_digest and other key-relevant fields are
+    persisted and correctly re-loaded so that to_lookup_key() remains stable.
+    """
+    original = Call(
+        name="test_func",
+        arguments={"a": digest(1)},
+        metadata={"m": {"k": "v"}},
+        module="mod",
+        version=42,
+        code_digest="some_code_digest",
+        result=digest(3)
+    )
+
+    key = store.save(original)
+    loaded = store.load(key)
+
+    assert loaded.code_digest == "some_code_digest"
+    assert loaded.to_lookup_key() == original.to_lookup_key()
+    assert loaded == original


### PR DESCRIPTION
The SQL storage backend was failing to persist the `code_digest` field of `Call` objects. This resulted in `Call` objects having a different `to_lookup_key()` after being loaded from the database, which caused issues with cache consistency and deduplication.

I have updated the `CallModel` to include a `code_digest` column and modified the `_save` and `_load` methods in `Sql` storage to handle this field.

I also verified that `Sql.query()` correctly uses `.distinct()` to avoid duplicate rows from joins and that `BaseCache.table()` deduplicates by lookup key.

Fixes #77

---
*PR created automatically by Jules for task [16942242522553011969](https://jules.google.com/task/16942242522553011969) started by @pmrv*