### PR TITLE
🧪 test: add missing tests for CacheStack.push method

### DIFF
--- a/tests/unit/caches/test_caches.py
+++ b/tests/unit/caches/test_caches.py
@@ -313,3 +313,24 @@ def test_cache_load_restores_complex_arguments_and_result():
     loaded = cache.load(key)
     assert loaded.arguments["arg"] == [1, 2, 3]
     assert loaded.result == [4, 5, 6]
+
+def test_cache_stack_push():
+    c1 = Mock()
+    c2 = Mock()
+    stack = CacheStack((c1,))
+
+    new_stack = stack.push(c2)
+
+    assert isinstance(new_stack, CacheStack)
+    assert new_stack.stack == (c2, c1)
+
+def test_cache_push():
+    values = Mock()
+    calls = Mock()
+    c1 = Cache(values, calls)
+    c2 = Cache(values, calls)
+
+    stack = c1.push(c2)
+
+    assert isinstance(stack, CacheStack)
+    assert stack.stack == (c2, c1)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing unit test coverage for the `push` methods in `CacheStack` and `BaseCache` classes in `src/fleche/caches.py`. These methods are relatively straightforward but crucial for compositing multiple caching layers correctly.

📊 **Coverage:** What scenarios are now tested
- Pushing a new cache onto an existing `CacheStack`.
- Pushing a new cache onto a base `Cache` (which produces a new `CacheStack`).
- In both cases, asserting that the new cache is prepended to the stack's tuple correctly, forming a composite caching stack.

✨ **Result:** The improvement in test coverage
We've added deterministic and isolated tests to `tests/unit/caches/test_caches.py`, ensuring that cache composition correctly creates and manages stack states without regression.

---
*PR created automatically by Jules for task [9294954478561995119](https://jules.google.com/task/9294954478561995119) started by @pmrv*