### PR TITLE
🧹 Remove unused `__future__` import in base.py

### DIFF
--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
@@ -115,6 +114,7 @@ class Storage(StorageBase):
             return True
         except KeyError:
             return False
+
 
 class Digested(ABC):
     @abstractmethod


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `src/fleche/storage/base.py`.

💡 **Why:** This improves code health by removing an extraneous import that was not strictly necessary for the file, reducing clutter.

✅ **Verification:** Verified that linting with `ruff check`, formatting with `black`, type checking with `ty check src`, and the full test suite via `pytest` all pass without regressions.

✨ **Result:** Cleaned up `base.py` by removing an unused import while maintaining code correctness and full test coverage.

---
*PR created automatically by Jules for task [6199132255334012871](https://jules.google.com/task/6199132255334012871) started by @pmrv*