### PR TITLE
docs: document the new rerun method

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -28,6 +28,11 @@ Attempts to load the result of a specific call from the cache. If the result is 
 
 Returns ``True`` if the result for the given call is already present in the cache, ``False`` otherwise.
 
+``.rerun(*args, **kwargs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Forces the function to re-execute, even if its result is already present in the cache, and saves the newly computed result to the cache. This forces reevaluation recursively for any nested `@fleche` calls as well.
+
 Accessing the Original Function
 -------------------------------
 

--- a/notebooks/ExtraMethods.ipynb
+++ b/notebooks/ExtraMethods.ipynb
@@ -14,10 +14,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:46.864481Z",
-     "iopub.status.busy": "2026-03-18T22:57:46.864307Z",
-     "iopub.status.idle": "2026-03-18T22:57:47.349484Z",
-     "shell.execute_reply": "2026-03-18T22:57:47.348704Z"
+     "iopub.execute_input": "2026-03-20T00:35:34.829393Z",
+     "iopub.status.busy": "2026-03-20T00:35:34.828797Z",
+     "iopub.status.idle": "2026-03-20T00:35:37.081025Z",
+     "shell.execute_reply": "2026-03-20T00:35:37.079076Z"
     }
    },
    "outputs": [
@@ -39,10 +39,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:47.351575Z",
-     "iopub.status.busy": "2026-03-18T22:57:47.351286Z",
-     "iopub.status.idle": "2026-03-18T22:57:47.354509Z",
-     "shell.execute_reply": "2026-03-18T22:57:47.353667Z"
+     "iopub.execute_input": "2026-03-20T00:35:37.134044Z",
+     "iopub.status.busy": "2026-03-20T00:35:37.133276Z",
+     "iopub.status.idle": "2026-03-20T00:35:37.140315Z",
+     "shell.execute_reply": "2026-03-20T00:35:37.138620Z"
     }
    },
    "outputs": [],
@@ -68,10 +68,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:47.356255Z",
-     "iopub.status.busy": "2026-03-18T22:57:47.356073Z",
-     "iopub.status.idle": "2026-03-18T22:57:47.359990Z",
-     "shell.execute_reply": "2026-03-18T22:57:47.358909Z"
+     "iopub.execute_input": "2026-03-20T00:35:37.143786Z",
+     "iopub.status.busy": "2026-03-20T00:35:37.143474Z",
+     "iopub.status.idle": "2026-03-20T00:35:37.150154Z",
+     "shell.execute_reply": "2026-03-20T00:35:37.148507Z"
     }
    },
    "outputs": [
@@ -106,10 +106,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:47.361743Z",
-     "iopub.status.busy": "2026-03-18T22:57:47.361569Z",
-     "iopub.status.idle": "2026-03-18T22:57:47.365467Z",
-     "shell.execute_reply": "2026-03-18T22:57:47.364499Z"
+     "iopub.execute_input": "2026-03-20T00:35:37.153939Z",
+     "iopub.status.busy": "2026-03-20T00:35:37.153585Z",
+     "iopub.status.idle": "2026-03-20T00:35:37.160002Z",
+     "shell.execute_reply": "2026-03-20T00:35:37.157919Z"
     }
    },
    "outputs": [
@@ -140,10 +140,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:47.367204Z",
-     "iopub.status.busy": "2026-03-18T22:57:47.367032Z",
-     "iopub.status.idle": "2026-03-18T22:57:48.372107Z",
-     "shell.execute_reply": "2026-03-18T22:57:48.371216Z"
+     "iopub.execute_input": "2026-03-20T00:35:37.163407Z",
+     "iopub.status.busy": "2026-03-20T00:35:37.163024Z",
+     "iopub.status.idle": "2026-03-20T00:35:38.172249Z",
+     "shell.execute_reply": "2026-03-20T00:35:38.170181Z"
     }
    },
    "outputs": [
@@ -185,10 +185,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:48.374035Z",
-     "iopub.status.busy": "2026-03-18T22:57:48.373856Z",
-     "iopub.status.idle": "2026-03-18T22:57:48.378363Z",
-     "shell.execute_reply": "2026-03-18T22:57:48.377580Z"
+     "iopub.execute_input": "2026-03-20T00:35:38.176189Z",
+     "iopub.status.busy": "2026-03-20T00:35:38.175855Z",
+     "iopub.status.idle": "2026-03-20T00:35:38.183532Z",
+     "shell.execute_reply": "2026-03-20T00:35:38.181591Z"
     }
    },
    "outputs": [
@@ -215,9 +215,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. `.__wrapped__`\n",
+    "## 5. `.rerun(*args, **kwargs)`\n",
     "\n",
-    "Because `fleche` uses `functools.wraps`, the original undecorated function is always available via the `.__wrapped__` attribute. This is useful if you want to bypass the cache entirely."
+    "The `.rerun` method allows you to force a re-execution of the function, even if the result is already in the cache. It will save the new result to the cache, and recursively force any nested `@fleche` calls to re-execute as well."
    ]
   },
   {
@@ -225,10 +225,53 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-18T22:57:48.380208Z",
-     "iopub.status.busy": "2026-03-18T22:57:48.380040Z",
-     "iopub.status.idle": "2026-03-18T22:57:49.384144Z",
-     "shell.execute_reply": "2026-03-18T22:57:49.383078Z"
+     "iopub.execute_input": "2026-03-20T00:35:38.187368Z",
+     "iopub.status.busy": "2026-03-20T00:35:38.187006Z",
+     "iopub.status.idle": "2026-03-20T00:35:39.196375Z",
+     "shell.execute_reply": "2026-03-20T00:35:39.194733Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rerun Result: 30 (took 1.00 seconds forcing execution)\n",
+      "Normal call Result: 30 (took 0.00 seconds)\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time.time()\n",
+    "res = slow_add.rerun(10, b=20)\n",
+    "end = time.time()\n",
+    "print(f\"Rerun Result: {res} (took {end - start:.2f} seconds forcing execution)\")\n",
+    "\n",
+    "# subsequent calls will be fast again\n",
+    "start = time.time()\n",
+    "res2 = slow_add(10, b=20)\n",
+    "end = time.time()\n",
+    "print(f\"Normal call Result: {res2} (took {end - start:.2f} seconds)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. `.__wrapped__`\n",
+    "\n",
+    "Because `fleche` uses `functools.wraps`, the original undecorated function is always available via the `.__wrapped__` attribute. This is useful if you want to bypass the cache entirely.  Unlike `.rerun`, calling the `.__wrapped__` function does *not* save the result to the cache, nor does it force nested cached functions to re-execute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-20T00:35:39.200013Z",
+     "iopub.status.busy": "2026-03-20T00:35:39.199628Z",
+     "iopub.status.idle": "2026-03-20T00:35:40.206202Z",
+     "shell.execute_reply": "2026-03-20T00:35:40.204641Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
Updates docs/helpers.rst and notebooks/ExtraMethods.ipynb to include documentation and examples for the new .rerun() method available on @fleche decorated functions.

---
*PR created automatically by Jules for task [9298200763322617174](https://jules.google.com/task/9298200763322617174) started by @pmrv*