### PR TITLE
docs: Include integration notebooks in Sphinx documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,10 @@ extensions = [
     'sphinx.ext.viewcode',
     'autoapi.extension',
     'sphinx_rtd_theme',
+    'nbsphinx',
 ]
+
+nbsphinx_execute = 'never'
 
 autoapi_dirs = ['../src']
 autoapi_ignore = ['*fleche/_version.py']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,16 @@ Welcome to the **Fleche** library documentation.
    query
    security
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Notebooks:
+
+   notebooks/GettingStarted
+   notebooks/ExtraMethods
+   notebooks/StorageBackends
+   notebooks/SecureStorage
+   notebooks/CacheStack
+
 Indices and tables
 ==================
 

--- a/docs/notebooks/CacheStack.ipynb
+++ b/docs/notebooks/CacheStack.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/CacheStack.ipynb

--- a/docs/notebooks/ExtraMethods.ipynb
+++ b/docs/notebooks/ExtraMethods.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/ExtraMethods.ipynb

--- a/docs/notebooks/GettingStarted.ipynb
+++ b/docs/notebooks/GettingStarted.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/GettingStarted.ipynb

--- a/docs/notebooks/SecureStorage.ipynb
+++ b/docs/notebooks/SecureStorage.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/SecureStorage.ipynb

--- a/docs/notebooks/StorageBackends.ipynb
+++ b/docs/notebooks/StorageBackends.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/StorageBackends.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ docs = [
     "sphinx",
     "sphinx-rtd-theme",
     "sphinx-autoapi",
+    "nbsphinx",
 ]
 cloudpickle = [
     "cloudpickle",


### PR DESCRIPTION
Symlinks the existing Jupyter notebooks located in `notebooks/` into a new `docs/notebooks/` folder so they can be rendered as part of the Sphinx documentation. 

The `nbsphinx` extension is configured with `nbsphinx_execute = 'never'` to prevent Sphinx from executing the notebooks during the build, which fulfills the user requirement. The `nbsphinx` package has also been added to the `docs` optional dependencies in `pyproject.toml`.

---
*PR created automatically by Jules for task [11245084515142668671](https://jules.google.com/task/11245084515142668671) started by @pmrv*