### PR TITLE
Add executorlib SingleNodeExecutor integration tests

### DIFF
--- a/notebooks/ConcurrentExecution.ipynb
+++ b/notebooks/ConcurrentExecution.ipynb
@@ -3,16 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Concurrent Execution with Fleche\n",
-    "\n",
-    "This notebook shows how to use `@fleche`-decorated functions with Python's two standard executor pools:\n",
-    "\n",
-    "| Executor | Cache context propagation | How |\n",
-    "|---|---|---|\n",
-    "| `ThreadPoolExecutor` | ✅ Yes (with one trick) | `contextvars.copy_context().run` |\n",
-    "| `ProcessPoolExecutor` | ⚠️ Manual setup required | Re-create cache inside each worker |"
-   ]
+   "source": "# Concurrent Execution with Fleche\n\nThis notebook shows how to use `@fleche`-decorated functions with Python's three executor types:\n\n| Executor | Cache context propagation | How |\n|---|---|---|\n| `ThreadPoolExecutor` | ✅ Yes (with one trick) | `contextvars.copy_context().run` |\n| `ProcessPoolExecutor` | ⚠️ Manual setup required | Re-create cache inside each worker |\n| `SingleNodeExecutor` (executorlib) | ⚠️ Manual setup required | File-backed storage + re-create cache in worker |"
   },
   {
    "cell_type": "code",
@@ -235,21 +226,50 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ky1m64wquxm",
+   "source": "---\n## 3. executorlib.SingleNodeExecutor\n\n[executorlib](https://github.com/pyiron/executorlib) is a third-party library for submitting tasks to HPC schedulers and local process pools. Its `SingleNodeExecutor` uses *process-based* workers with the same isolation semantics as `ProcessPoolExecutor`.\n\n> **Note:** `executorlib` is an optional dependency. Install it with `pip install executorlib`.\n\n`@fleche`-decorated functions are picklable (they are module-level names), so they can be submitted to `SingleNodeExecutor` directly:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "p643mxgcnj",
+   "source": "from executorlib import SingleNodeExecutor\n\n@fleche\ndef cube_sne(x):\n    return x ** 3\n\nwith SingleNodeExecutor() as executor:\n    future = executor.submit(cube_sne, 4)\n    result = future.result()\n\nprint(\"Result:\", result)  # 64",
    "metadata": {},
-   "source": [
-    "### Summary\n",
-    "\n",
-    "```\n",
-    "ThreadPoolExecutor\n",
-    "  Default (no ctx.run)  →  workers use the default cache, NOT your custom one\n",
-    "  With ctx.run          →  workers share the same cache as the main thread ✅\n",
-    "\n",
-    "ProcessPoolExecutor\n",
-    "  Each worker creates its own fresh cache  →  isolated per-worker caching ✅\n",
-    "  Pass a picklable cache as an argument   →  shared persistent cache ✅\n",
-    "  ctx.run                                 →  not possible (Context not picklable) ❌\n",
-    "```"
-   ]
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ibdhi1bkf4j",
+   "source": "### In-memory cache is not propagated\n\nLike `ProcessPoolExecutor`, `SingleNodeExecutor` spawns worker processes with fresh Python interpreters. An in-memory cache set in the parent is **not visible** inside the worker — results computed there are stored in the worker's own ephemeral cache and are lost when the process exits.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "yuggrvxrhz",
+   "source": "mem = Memory({})\nmy_cache = Cache(mem, mem)\n\nwith cache(my_cache):\n    with SingleNodeExecutor() as executor:\n        future = executor.submit(cube_sne, 5)\n        result = future.result()\n\nprint(\"Result:\", result)                                # 125\nprint(\"In my_cache:\", my_cache.contains(cube_sne.digest(5)))  # False — worker results don't reach the parent",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "l4oilpkkx3h",
+   "source": "### Sharing results with file-backed storage\n\nTo persist results across processes, use a **file-backed storage backend** and point the worker at the same on-disk directory. The worker sets up a fresh `Cache` around the file-backed store; results written to disk are immediately visible to any process that reads from the same path.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "vzfsqge5ltp",
+   "source": "def _sne_worker_shared(x, values_dir, calls_dir):\n    \"\"\"Worker that wires up a shared file-backed cache then calls the fleche function.\"\"\"\n    worker_cache = Cache(\n        PickleFileStorage(os.path.join(values_dir)),\n        PickleFileStorage(os.path.join(calls_dir)),\n    )\n    with cache(worker_cache):\n        return cube_sne(x)\n\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    values_dir = os.path.join(tmpdir, \"values\")\n    calls_dir  = os.path.join(tmpdir, \"calls\")\n\n    parent_cache = Cache(\n        PickleFileStorage(values_dir),\n        PickleFileStorage(calls_dir),\n    )\n\n    with SingleNodeExecutor() as executor:\n        futures = [executor.submit(_sne_worker_shared, x, values_dir, calls_dir) for x in range(5)]\n        results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\nprint(\"In parent_cache:\", parent_cache.contains(cube_sne.digest(3)))  # True",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Summary\n\n```\nThreadPoolExecutor\n  Default (no ctx.run)  →  workers use the default cache, NOT your custom one\n  With ctx.run          →  workers share the same cache as the main thread ✅\n\nProcessPoolExecutor\n  Each worker creates its own fresh cache  →  isolated per-worker caching ✅\n  Pass a picklable cache as an argument   →  shared persistent cache ✅\n  ctx.run                                 →  not possible (Context not picklable) ❌\n\nexecutorlib.SingleNodeExecutor\n  In-memory cache (parent-side)           →  not visible in worker processes ❌\n  File-backed storage (shared directory)  →  worker results visible to parent ✅\n  ctx.run                                 →  not possible (process-based) ❌\n```"
   }
  ],
  "metadata": {

--- a/notebooks/ConcurrentExecution.ipynb
+++ b/notebooks/ConcurrentExecution.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Concurrent Execution with Fleche\n\nThis notebook shows how to use `@fleche`-decorated functions with Python's three executor types:\n\n| Executor | Cache context propagation | How |\n|---|---|---|\n| `ThreadPoolExecutor` | ✅ Yes (with one trick) | `contextvars.copy_context().run` |\n| `ProcessPoolExecutor` | ⚠️ Manual setup required | Re-create cache inside each worker |\n| `SingleNodeExecutor` (executorlib) | ⚠️ Manual setup required | File-backed storage + re-create cache in worker |"
+   "source": "# Concurrent Execution with Fleche\n\nThis notebook shows how to use `@fleche`-decorated functions with Python's three executor types:\n\n| Executor | Cache context propagation | How |\n|---|---|---|\n| `ThreadPoolExecutor` | ✅ Yes (with one trick) | `contextvars.copy_context().run` |\n| `ProcessPoolExecutor` | ⚠️ Manual setup required | File-backed storage + re-create cache inside each worker |\n| `SingleNodeExecutor` (executorlib) | ⚠️ Manual setup required | File-backed storage + re-create cache in worker |"
   },
   {
    "cell_type": "code",

--- a/tests/integration/test_executorlib.py
+++ b/tests/integration/test_executorlib.py
@@ -40,6 +40,16 @@ from fleche.caches import Cache
 from fleche.storage.memory import Memory
 from fleche.storage.pickle_file import PickleFile
 
+try:
+    import executorlib  # noqa: F401
+    _executorlib_available = True
+except ImportError:
+    _executorlib_available = False
+
+_skip_no_executorlib = pytest.mark.skipif(
+    not _executorlib_available, reason="executorlib not installed"
+)
+
 
 @fleche.fleche
 def double(x):
@@ -99,15 +109,13 @@ def test_process_executor_in_memory_cache_not_propagated():
 # ---------------------------------------------------------------------------
 
 
+@_skip_no_executorlib
 def test_executorlib_returns_correct_result():
     """
     Fleche-decorated functions can be called through executorlib.SingleNodeExecutor
     and return the correct result.
     """
-    try:
-        from executorlib import SingleNodeExecutor
-    except ImportError:
-        pytest.skip("executorlib not installed")
+    from executorlib import SingleNodeExecutor
 
     with SingleNodeExecutor() as executor:
         future = executor.submit(double, 21)
@@ -116,6 +124,7 @@ def test_executorlib_returns_correct_result():
     assert result == 42, f"Expected 42, got {result}"
 
 
+@_skip_no_executorlib
 def test_executorlib_in_memory_cache_not_propagated():
     """
     An in-memory cache set in the parent is NOT visible inside executorlib workers.
@@ -123,10 +132,7 @@ def test_executorlib_in_memory_cache_not_propagated():
     Results computed by the worker are not stored in the parent's in-memory cache.
     This is expected for any process-based executor.
     """
-    try:
-        from executorlib import SingleNodeExecutor
-    except ImportError:
-        pytest.skip("executorlib not installed")
+    from executorlib import SingleNodeExecutor
 
     mem = Memory({})
     cache = Cache(mem, mem)
@@ -142,6 +148,7 @@ def test_executorlib_in_memory_cache_not_propagated():
     )
 
 
+@_skip_no_executorlib
 def test_executorlib_file_backed_cache_shared():
     """
     Minimally working configuration: use file-backed storage so that worker
@@ -151,10 +158,7 @@ def test_executorlib_file_backed_cache_shared():
     shared directory.  After the executor finishes, the parent can read back
     the cached result from the same directory.
     """
-    try:
-        from executorlib import SingleNodeExecutor
-    except ImportError:
-        pytest.skip("executorlib not installed")
+    from executorlib import SingleNodeExecutor
 
     with tempfile.TemporaryDirectory() as tmpdir:
         values_dir = f"{tmpdir}/values"

--- a/tests/integration/test_executorlib.py
+++ b/tests/integration/test_executorlib.py
@@ -1,0 +1,176 @@
+"""
+Integration tests: fleche-decorated functions submitted via executorlib's SingleNodeExecutor.
+
+Key question: can fleche wrapper functions be called through a SingleNodeExecutor from executorlib,
+and if so, does caching work?
+
+Background: Context Var propagation
+------------------------------------
+fleche uses a ``contextvars.ContextVar`` (``state._CACHE``) to track which cache
+is active.  Python's ContextVar semantics differ by execution model:
+
+* **Same thread** – ContextVars are inherited.
+* **ThreadPoolExecutor** – each task runs in a worker thread.  Whether context
+  is propagated depends on Python version; the test_threadpool.py tests cover this.
+* **ProcessPoolExecutor / executorlib workers** – worker processes are spawned
+  as independent subprocesses with a fresh Python interpreter.  ContextVars
+  revert to their *default* values.  In-memory state set in the parent is
+  completely invisible.
+
+executorlib's SingleNodeExecutor
+---------------------------------
+executorlib (https://github.com/pyiron/executorlib) is built on top of
+``concurrent.futures`` and uses *process*-based workers.  Therefore:
+
+* fleche-decorated functions **can** be called through SingleNodeExecutor and
+  return correct results.
+* However, an in-memory cache set via ``fleche.cache(...)`` in the parent process
+  is **not visible** in the worker; results are NOT stored in the parent's cache.
+* To share cached results across processes, use **file- or SQL-backed storage** and
+  pass the shared path to the worker explicitly (see
+  ``test_executorlib_file_backed_cache_shared``).
+"""
+
+import concurrent.futures
+import tempfile
+import pytest
+
+import fleche
+from fleche.caches import Cache
+from fleche.storage.memory import Memory
+from fleche.storage.pickle_file import PickleFile
+
+
+@fleche.fleche
+def double(x):
+    return x * 2
+
+
+def _worker_with_file_cache(x, values_dir, calls_dir):
+    """Worker that sets up a shared file-backed cache and runs the fleche function."""
+    values_storage = PickleFile.with_pickle(root=values_dir)
+    calls_storage = PickleFile.with_pickle(root=calls_dir)
+    worker_cache = Cache(values_storage, calls_storage)
+    with fleche.cache(worker_cache):
+        return double(x)
+
+
+# ---------------------------------------------------------------------------
+# Tests using concurrent.futures.ProcessPoolExecutor
+# (identical process-isolation semantics to executorlib.SingleNodeExecutor)
+# ---------------------------------------------------------------------------
+
+
+def test_process_executor_returns_correct_result():
+    """
+    Fleche-decorated functions can be called through a ProcessPoolExecutor and
+    return the correct result.
+    """
+    with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(double, 21)
+        result = future.result()
+
+    assert result == 42
+
+
+def test_process_executor_in_memory_cache_not_propagated():
+    """
+    An in-memory cache set in the parent is NOT visible in worker processes.
+
+    Results computed in the worker are stored in the worker's ephemeral default
+    cache and are NOT accessible from the parent's in-memory cache object.
+    """
+    mem = Memory({})
+    cache = Cache(mem, mem)
+
+    with fleche.cache(cache):
+        with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(double, 10)
+            result = future.result()
+
+    assert result == 20
+    assert not cache.contains(double.digest(10)), (
+        "In-memory cache is process-local; worker results are not visible to the parent."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests using executorlib.SingleNodeExecutor
+# ---------------------------------------------------------------------------
+
+
+def test_executorlib_returns_correct_result():
+    """
+    Fleche-decorated functions can be called through executorlib.SingleNodeExecutor
+    and return the correct result.
+    """
+    try:
+        from executorlib import SingleNodeExecutor
+    except ImportError:
+        pytest.skip("executorlib not installed")
+
+    with SingleNodeExecutor() as executor:
+        future = executor.submit(double, 21)
+        result = future.result()
+
+    assert result == 42, f"Expected 42, got {result}"
+
+
+def test_executorlib_in_memory_cache_not_propagated():
+    """
+    An in-memory cache set in the parent is NOT visible inside executorlib workers.
+
+    Results computed by the worker are not stored in the parent's in-memory cache.
+    This is expected for any process-based executor.
+    """
+    try:
+        from executorlib import SingleNodeExecutor
+    except ImportError:
+        pytest.skip("executorlib not installed")
+
+    mem = Memory({})
+    cache = Cache(mem, mem)
+
+    with fleche.cache(cache):
+        with SingleNodeExecutor() as executor:
+            future = executor.submit(double, 99)
+            result = future.result()
+
+    assert result == 198, f"Expected 198, got {result}"
+    assert not cache.contains(double.digest(99)), (
+        "In-memory cache is process-local; executorlib worker results are not visible to the parent."
+    )
+
+
+def test_executorlib_file_backed_cache_shared():
+    """
+    Minimally working configuration: use file-backed storage so that worker
+    results are persisted to a shared directory visible to the parent process.
+
+    The worker explicitly sets up a PickleFile-backed cache pointing to the
+    shared directory.  After the executor finishes, the parent can read back
+    the cached result from the same directory.
+    """
+    try:
+        from executorlib import SingleNodeExecutor
+    except ImportError:
+        pytest.skip("executorlib not installed")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        values_dir = f"{tmpdir}/values"
+        calls_dir = f"{tmpdir}/calls"
+
+        # Parent-side cache pointing at the shared directories
+        parent_values = PickleFile.with_pickle(root=values_dir)
+        parent_calls = PickleFile.with_pickle(root=calls_dir)
+        parent_cache = Cache(parent_values, parent_calls)
+
+        with SingleNodeExecutor() as executor:
+            future = executor.submit(_worker_with_file_cache, 21, values_dir, calls_dir)
+            result = future.result()
+
+        assert result == 42, f"Expected 42, got {result}"
+        assert parent_cache.contains(double.digest(21)), (
+            "With file-backed storage, results written by the worker process are "
+            "visible to the parent via the shared filesystem path."
+        )


### PR DESCRIPTION
Add tests checking that fleche wrapper functions can be called through executorlib's SingleNodeExecutor (#202), documenting in-memory cache propagation limitations and a working file-backed storage configuration.

Closes #202

Generated with [Claude Code](https://claude.ai/code)