### PR TITLE
Merge call_storage and call_storage_adapter fixtures

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,17 +12,17 @@ secret_key = [b"test_secret_key_32_bytes_long!!!!"]
 @pytest.fixture(params=["memory", "cloudpickle", "dill", "pickle", "h5", "sql"])
 def call_storage(request, tmp_path):
     if request.param == "memory":
-        return Memory({})
+        return CallStorageAdapter(Memory({}))
     elif request.param == "cloudpickle":
-        return PickleFile.with_cloudpickle(
+        return CallStorageAdapter(PickleFile.with_cloudpickle(
             tmp_path / "cloudpickle", secret_key=secret_key
-        )
+        ))
     elif request.param == "dill":
-        return PickleFile.with_dill(tmp_path / "dill", secret_key=secret_key)
+        return CallStorageAdapter(PickleFile.with_dill(tmp_path / "dill", secret_key=secret_key))
     elif request.param == "pickle":
-        return PickleFile.with_pickle(tmp_path / "pickle", secret_key=secret_key)
+        return CallStorageAdapter(PickleFile.with_pickle(tmp_path / "pickle", secret_key=secret_key))
     elif request.param == "h5":
-        return BagOfHoldingH5File(tmp_path / "h5")
+        return CallStorageAdapter(BagOfHoldingH5File(tmp_path / "h5"))
     elif request.param == "sql":
         return Sql(tmp_path / "calls.db")
 
@@ -41,10 +41,3 @@ def value_storage(request, tmp_path):
         return PickleFile.with_pickle(tmp_path / "pickle", secret_key=secret_key)
     elif request.param == "h5":
         return BagOfHoldingH5File(tmp_path / "h5")
-
-
-@pytest.fixture
-def call_storage_adapter(call_storage):
-    if isinstance(call_storage, Sql):
-        return call_storage
-    return CallStorageAdapter(call_storage)

--- a/tests/unit/storage/test_overwrite.py
+++ b/tests/unit/storage/test_overwrite.py
@@ -13,33 +13,33 @@ def create_dummy_call(name, result, metadata=None):
         result=Digest(result)
     )
 
-def test_call_storage_overwrite(call_storage_adapter):
+def test_call_storage_overwrite(call_storage):
     call1 = create_dummy_call("my_func", "1" * 64)
-    key1 = call_storage_adapter.save(call1)
+    key1 = call_storage.save(call1)
 
-    assert call_storage_adapter.load(key1).result == "1" * 64
+    assert call_storage.load(key1).result == "1" * 64
 
     # Save a call with same lookup key (name, arguments, module, version, code_digest) but different result
     call2 = create_dummy_call("my_func", "2" * 64)
-    key2 = call_storage_adapter.save(call2)
+    key2 = call_storage.save(call2)
 
     assert key1 == key2
-    assert call_storage_adapter.load(key1).result == "2" * 64
+    assert call_storage.load(key1).result == "2" * 64
 
     # We expect overwrite behavior at the storage level, which means only 1 entry should exist for the same lookup key.
-    assert len(list(call_storage_adapter.list())) == 1
+    assert len(list(call_storage.list())) == 1
 
-def test_call_storage_overwrite_differing_metadata(call_storage_adapter):
+def test_call_storage_overwrite_differing_metadata(call_storage):
     call1 = create_dummy_call("my_func", "1" * 64, metadata={"tags": {"a": 1}})
-    key1 = call_storage_adapter.save(call1)
+    key1 = call_storage.save(call1)
 
-    assert call_storage_adapter.load(key1).metadata == {"tags": {"a": 1}}
+    assert call_storage.load(key1).metadata == {"tags": {"a": 1}}
 
     # Save a call with same lookup key but different metadata
     call2 = create_dummy_call("my_func", "1" * 64, metadata={"tags": {"a": 2}})
-    key2 = call_storage_adapter.save(call2)
+    key2 = call_storage.save(call2)
 
     # Metadata is NOT part of the lookup key
     assert key1 == key2
-    assert call_storage_adapter.load(key1).metadata == {"tags": {"a": 2}}
-    assert len(list(call_storage_adapter.list())) == 1
+    assert call_storage.load(key1).metadata == {"tags": {"a": 2}}
+    assert len(list(call_storage.list())) == 1

--- a/tests/unit/storage/test_transform.py
+++ b/tests/unit/storage/test_transform.py
@@ -1,61 +1,51 @@
-import pytest
-from unittest.mock import patch
 from dataclasses import replace
-from fleche.storage import (
-    Memory,
-    Sql,
-    PickleFile,
-    BagOfHoldingH5File,
-    CallStorageAdapter,
-)
 from fleche.call import Call
 from fleche.digest import Digest
-from tests.fixtures import call_storage_adapter
 
 
-def test_transform_basic(call_storage_adapter):
+def test_transform_basic(call_storage):
     c1 = Call(
         name="f1",
         arguments={"a": Digest("a" * 64)},
         metadata={"table": {"m": 1}},
         result=Digest("r" * 64),
     )
-    call_storage_adapter.save(c1)
+    call_storage.save(c1)
 
     # Transform: update metadata, keep same key
     def update_metadata(call):
         return replace(call, metadata={"table": {"m": 2}})
 
-    call_storage_adapter.transform(update_metadata)
+    call_storage.transform(update_metadata)
 
-    assert len(list(call_storage_adapter.list())) == 1
+    assert len(list(call_storage.list())) == 1
     k1 = c1.to_lookup_key()
-    loaded = call_storage_adapter.load(k1)
+    loaded = call_storage.load(k1)
     assert loaded.metadata == {"table": {"m": 2}}
     assert str(loaded.result) == "r" * 64
 
 
-def test_transform_key_change(call_storage_adapter):
+def test_transform_key_change(call_storage):
     c1 = Call(
         name="f1",
         arguments={"a": Digest("a" * 64)},
         metadata={},
         result=Digest("r" * 64),
     )
-    call_storage_adapter.save(c1)
+    call_storage.save(c1)
 
     # Transform: change argument, change key
     def change_arg(call):
         return replace(call, arguments={"a": Digest("b" * 64)})
 
-    call_storage_adapter.transform(change_arg)
+    call_storage.transform(change_arg)
 
-    all_keys = list(call_storage_adapter.list())
+    all_keys = list(call_storage.list())
     assert len(all_keys) == 1
     assert c1.to_lookup_key() not in all_keys
 
     new_c = replace(c1, arguments={"a": Digest("b" * 64)})
     new_k = new_c.to_lookup_key()
     assert new_k in all_keys
-    loaded = call_storage_adapter.load(new_k)
+    loaded = call_storage.load(new_k)
     assert str(loaded.arguments["a"]) == "b" * 64


### PR DESCRIPTION
Inline CallStorageAdapter wrapping directly into the call_storage fixture so it always returns a CallStorage, making the secondary call_storage_adapter fixture unnecessary. Remove call_storage_adapter and update all usages.

Closes #184

Generated with [Claude Code](https://claude.ai/code)