### PR TITLE
Validate and normalize PickleFile secret_key in __post_init__

### DIFF
--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -14,6 +14,59 @@ from pyiron_snippets.import_alarm import ImportAlarm
 
 logger = logging.getLogger("fleche.storage.pickle_file")
 
+_HMAC_MIN_KEY_BYTES = 32
+
+
+def _normalize_secret_key(key) -> list[bytes]:
+    """
+    Normalize a secret key value to ``list[bytes]``.
+
+    Accepts:
+    - ``bytes``: wrapped in a list
+    - ``str``: split on ``":"`` delimiter, each part encoded to UTF-8
+    - ``list[bytes]``: each element validated for minimum length
+    - ``list[str]``: each element (or colon-delimited parts) encoded to UTF-8
+
+    Each resulting key must be at least ``_HMAC_MIN_KEY_BYTES`` bytes long.
+
+    Raises:
+        TypeError: if ``key`` or any element is not ``bytes`` or ``str``.
+        ValueError: if any resulting key is shorter than ``_HMAC_MIN_KEY_BYTES``.
+    """
+    if isinstance(key, (bytes, str)):
+        key = [key]
+
+    if not isinstance(key, list):
+        raise TypeError(
+            f"secret_key must be bytes, str, or list, got {type(key).__name__}"
+        )
+
+    result = []
+    for k in key:
+        if isinstance(k, str):
+            for part in k.split(":"):
+                encoded = part.encode("utf-8")
+                if len(encoded) < _HMAC_MIN_KEY_BYTES:
+                    raise ValueError(
+                        f"Each secret key must be at least {_HMAC_MIN_KEY_BYTES} bytes, "
+                        f"got {len(encoded)}"
+                    )
+                result.append(encoded)
+        elif isinstance(k, bytes):
+            if len(k) < _HMAC_MIN_KEY_BYTES:
+                raise ValueError(
+                    f"Each secret key must be at least {_HMAC_MIN_KEY_BYTES} bytes, "
+                    f"got {len(k)}"
+                )
+            result.append(k)
+        else:
+            raise TypeError(
+                f"Each element of secret_key must be bytes or str, "
+                f"got {type(k).__name__}"
+            )
+
+    return result
+
 with ImportAlarm(
     "PickleFile.with_cloudpickle requires 'cloudpickle' to be installed. "
     "Install it with `pip install fleche[cloudpickle]`.",
@@ -43,6 +96,8 @@ class PickleFile(FileStorage):
         super().__post_init__()
         if not self.secret_key:
             self.secret_key = get_secret_key()
+        else:
+            self.secret_key = _normalize_secret_key(self.secret_key)
 
     @classmethod
     def with_pickle(cls, *args, **kwargs):

--- a/tests/unit/storage/test_pickle_file.py
+++ b/tests/unit/storage/test_pickle_file.py
@@ -1,5 +1,5 @@
 import pytest
-from fleche.storage.pickle_file import PickleFile
+from fleche.storage.pickle_file import PickleFile, _normalize_secret_key
 from fleche.digest import Digest
 
 
@@ -40,3 +40,107 @@ def test_compression(tmp_path):
     # Load the value
     loaded_value = storage._load(key)
     assert loaded_value == value
+
+
+# --- _normalize_secret_key tests ---
+
+def test_normalize_bytes_wrapped_in_list():
+    key = b"A" * 32
+    assert _normalize_secret_key(key) == [key]
+
+
+def test_normalize_str_encoded_to_bytes():
+    key = "A" * 32
+    assert _normalize_secret_key(key) == [key.encode("utf-8")]
+
+
+def test_normalize_str_with_colon_delimiter():
+    key = "A" * 32 + ":" + "B" * 32
+    assert _normalize_secret_key(key) == [
+        ("A" * 32).encode("utf-8"),
+        ("B" * 32).encode("utf-8"),
+    ]
+
+
+def test_normalize_list_of_str():
+    keys = ["A" * 32, "B" * 32]
+    assert _normalize_secret_key(keys) == [k.encode("utf-8") for k in keys]
+
+
+def test_normalize_list_of_bytes():
+    keys = [b"A" * 32, b"B" * 32]
+    assert _normalize_secret_key(keys) == keys
+
+
+def test_normalize_list_str_with_delimiter():
+    keys = ["A" * 32 + ":" + "B" * 32]
+    assert _normalize_secret_key(keys) == [
+        ("A" * 32).encode("utf-8"),
+        ("B" * 32).encode("utf-8"),
+    ]
+
+
+def test_normalize_bytes_too_short_raises():
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        _normalize_secret_key(b"short")
+
+
+def test_normalize_str_too_short_raises():
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        _normalize_secret_key("short")
+
+
+def test_normalize_wrong_type_raises():
+    with pytest.raises(TypeError, match="secret_key must be bytes, str, or list"):
+        _normalize_secret_key(12345)
+
+
+def test_normalize_list_wrong_element_type_raises():
+    with pytest.raises(TypeError, match="Each element of secret_key must be bytes or str"):
+        _normalize_secret_key([12345])
+
+
+def test_normalize_empty_list_returns_empty():
+    # Empty list means security disabled — no normalization needed
+    assert _normalize_secret_key([]) == []
+
+
+# --- PickleFile.__post_init__ key handling tests ---
+
+def test_post_init_bytes_key(tmp_path):
+    key = b"A" * 32
+    storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
+    assert storage.secret_key == [key]
+
+
+def test_post_init_str_key(tmp_path):
+    key = "A" * 32
+    storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
+    assert storage.secret_key == [key.encode("utf-8")]
+
+
+def test_post_init_str_key_with_delimiter(tmp_path):
+    key = "A" * 32 + ":" + "B" * 32
+    storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
+    assert storage.secret_key == [
+        ("A" * 32).encode("utf-8"),
+        ("B" * 32).encode("utf-8"),
+    ]
+
+
+def test_post_init_short_key_raises(tmp_path):
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        PickleFile.with_pickle(root=tmp_path, secret_key=b"tooshort")
+
+
+def test_post_init_wrong_key_type_raises(tmp_path):
+    with pytest.raises(TypeError):
+        PickleFile.with_pickle(root=tmp_path, secret_key=42)
+
+
+def test_post_init_str_key_roundtrip(tmp_path):
+    key = "A" * 32
+    storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
+    value = {"hello": "world"}
+    digest_key = storage.save(value)
+    assert storage.load(digest_key) == value


### PR DESCRIPTION
Add `_normalize_secret_key` helper to handle str/bytes/list inputs for `PickleFile.secret_key`:
- Wraps bare `bytes` or `str` in a list
- Splits `str` keys on `:` delimiter and encodes to UTF-8
- Validates each key meets minimum HMAC-SHA256 size (≥32 bytes)
- Raises `TypeError` for unsupported element types

Closes #219

Generated with [Claude Code](https://claude.ai/code)