### PR TITLE
Add lazy reconstruction for DestructuringStorage

### DIFF
--- a/src/fleche/storage/__init__.py
+++ b/src/fleche/storage/__init__.py
@@ -11,6 +11,8 @@ from .base import (
     CallStorage,
     CallStorageAdapter,
     DestructuringStorage,
+    LazyIterable,
+    LazyDict,
 )
 from .memory import Memory
 from .void import Void
@@ -26,6 +28,8 @@ __all__ = [
     "CallStorage",
     "CallStorageAdapter",
     "DestructuringStorage",
+    "LazyIterable",
+    "LazyDict",
     "Memory",
     "Void",
     "FileStorage",

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,8 +1,9 @@
 import logging
 from dataclasses import dataclass
+from numbers import Number
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Any, Callable
+from typing import Iterable, Any, Callable, Self
 
 from ..digest import digest, Digest, DIGEST_LENGTH
 from ..call import Call
@@ -126,13 +127,27 @@ class Digested(ABC):
     def __digest__(self):
         return digest(self.underlying())
 
+    @abstractmethod
+    def mend(self, storage): ...
+
+    @classmethod
+    @abstractmethod
+    def sunder(cls, save: Callable[[Any], Digest], value): ...
+
 
 @dataclass
 class DigestedIterable(Digested):
-    items: Iterable
+    items: list | tuple
 
     def underlying(self):
         return self.items
+
+    @classmethod
+    def sunder(cls, save: Callable[[Any], Digest], value: list | tuple) -> Self:
+        return cls(type(value)(save(v) for v in value))
+
+    def mend(self, storage: 'DestructuringStorage') -> list | tuple:
+        return type(self.items)(map(storage._load, self.items))
 
 
 @dataclass
@@ -142,34 +157,74 @@ class DigestedDict(Digested):
     def underlying(self):
         return self.items
 
+    @classmethod
+    def sunder(cls, save: Callable[[Any], Digest], value: dict) -> Self:
+        return cls({save(k): save(v) for k, v in value.items()})
+
+    def mend(self, storage: 'DestructuringStorage') -> dict:
+        return {storage._load(k): storage._load(v) for k, v in self.items.items()}
+
 
 @dataclass
 class DestructuringStorage(Storage):
+    """Special cases certain types to enable to store their constituents separately.
+
+    This allows us to leverage redundancy in common data to save on storage.
+
+    Instead of saving values passed to :meth:`DestructuringStorage.save` as a single blob, break supported types into
+    smaller values and save these into the underlying storage :attr:`DestructuringStorage.storage`.  Instead of the full
+    object a :class:`.Digested` placeholder is created that contains digests and fragments and saved into the same
+    storage.  On loading the placeholder is retrieved and the constituents are by digest to recreate the original value.
+
+    Supported types for destructuring are `tuple`, `list`, and `dict`.
+
+    Args:
+        storage (:class:`Storage`): underlying storage
+        remaining_depth (int): destructure supported type until this 'nesting level' remains"""
     storage: Storage
+    remaining_depth: int = 0
+
+    def _depth(self, value: Any):
+        match value:
+            case list() | tuple():
+                return 1 + max((self._depth(v) for v in value), default=0)
+            case dict():
+                return 1 + max(
+                        max((self._depth(k) for k in value.keys()), default=0),
+                        max((self._depth(v) for v in value.values()), default=0),
+                )
+            case Number() | str() | bytes() | bool():
+                return 1
+            case _:
+                return 2 ** 64
 
     def _save(self, value: Any, key: Digest) -> Digest:
+        def depth_aware_save(value):
+            """recursively save content values iff they have more nested levels than given cutoff to avoid putting
+            each and every int/float/etc into its own storage bin."""
+            if self._depth(value) <= self.remaining_depth:
+                return value
+            else:
+                return self.save(value)
+
         if isinstance(value, Digest):
             return value
         match value:
             case list() | tuple():
-                return self.storage.save(
-                    DigestedIterable(type(value)(self.save(v) for v in value))
-                )
+                return self.storage.save(DigestedIterable.sunder(depth_aware_save, value))
             case dict():
-                return self.storage.save(
-                    DigestedDict({self.save(k): self.save(v) for k, v in value.items()})
-                )
+                return self.storage.save(DigestedDict.sunder(depth_aware_save, value))
             case _:
                 return self.storage.save(value, key)
 
-    def _load(self, key: Digest) -> Any:
+    def _load(self, key: Digest | Any) -> Any:
+        if not isinstance(key, Digest):
+            return key  # passing through an actual value from Digested.mend
         value = self.storage.load(key)
 
         match value:
-            case DigestedIterable(items=items):
-                return type(items)(self.load(v) for v in items)
-            case DigestedDict(items=items):
-                return {self.load(k): self.load(v) for k, v in items.items()}
+            case Digested():
+                return value.mend(self)
             case _:
                 return value
 

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence, Mapping as MappingABC
 from dataclasses import dataclass
 from numbers import Number
 
@@ -165,6 +166,117 @@ class DigestedDict(Digested):
         return {storage._load(k): storage._load(v) for k, v in self.items.items()}
 
 
+class LazyIterable(Sequence):
+    """Lazy proxy for a :class:`DigestedIterable` that loads elements on access.
+
+    Elements are fetched from storage only when first accessed and cached thereafter.
+    Compares equal to the equivalent ``list`` or ``tuple`` depending on the underlying type.
+
+    Args:
+        digested: the :class:`DigestedIterable` placeholder holding element digests
+        storage: the :class:`DestructuringStorage` used to load elements
+    """
+
+    def __init__(self, digested: 'DigestedIterable', storage: 'DestructuringStorage'):
+        self._digested = digested
+        self._storage = storage
+        self._cache: dict[int, Any] = {}
+
+    def _load_item(self, index: int) -> Any:
+        if index not in self._cache:
+            self._cache[index] = self._storage._load(self._digested.items[index])
+        return self._cache[index]
+
+    def __len__(self) -> int:
+        return len(self._digested.items)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return type(self._digested.items)(
+                self._load_item(i) for i in range(*index.indices(len(self)))
+            )
+        if index < 0:
+            index += len(self)
+        if not 0 <= index < len(self):
+            raise IndexError(index)
+        return self._load_item(index)
+
+    def __eq__(self, other):
+        if isinstance(other, (list, tuple)):
+            return (
+                isinstance(other, type(self._digested.items))
+                and len(self) == len(other)
+                and all(a == b for a, b in zip(self, other))
+            )
+        if isinstance(other, LazyIterable):
+            return (
+                type(self._digested.items) == type(other._digested.items)
+                and self._digested.items == other._digested.items
+            )
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return repr(type(self._digested.items)(self))
+
+    def realize(self) -> 'list | tuple':
+        """Eagerly load and return the full underlying list or tuple."""
+        return type(self._digested.items)(self)
+
+
+class LazyDict(MappingABC):
+    """Lazy proxy for a :class:`DigestedDict` that loads values on access.
+
+    Keys are loaded eagerly (required for iteration and membership tests), while
+    values are fetched from storage only when first accessed and cached thereafter.
+    Compares equal to the equivalent ``dict``.
+
+    Args:
+        digested: the :class:`DigestedDict` placeholder holding key/value digests
+        storage: the :class:`DestructuringStorage` used to load keys and values
+    """
+
+    def __init__(self, digested: 'DigestedDict', storage: 'DestructuringStorage'):
+        self._digested = digested
+        self._storage = storage
+        # Load all keys eagerly; map real_key -> digest_key for deferred value lookup.
+        # Keys must be hashable, so realize any LazyIterable proxies (e.g. tuple keys).
+        self._key_map: dict[Any, Any] = {}
+        for dk in digested.items:
+            k = storage._load(dk)
+            if isinstance(k, LazyIterable):
+                k = k.realize()
+            self._key_map[k] = dk
+        self._value_cache: dict[Any, Any] = {}
+
+    def __len__(self) -> int:
+        return len(self._key_map)
+
+    def __iter__(self):
+        return iter(self._key_map)
+
+    def __getitem__(self, key):
+        dk = self._key_map[key]  # raises KeyError for missing keys
+        if key not in self._value_cache:
+            self._value_cache[key] = self._storage._load(self._digested.items[dk])
+        return self._value_cache[key]
+
+    def __eq__(self, other):
+        if isinstance(other, dict):
+            if len(self) != len(other):
+                return False
+            return all(k in other and other[k] == v for k, v in self.items())
+        if isinstance(other, LazyDict):
+            return self._digested.items == other._digested.items
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return repr(dict(self.items()))
+
+    def realize(self) -> dict:
+        """Eagerly load and return the full underlying dict."""
+        return dict(self.items())
+
+
 @dataclass
 class DestructuringStorage(Storage):
     """Special cases certain types to enable to store their constituents separately.
@@ -180,9 +292,13 @@ class DestructuringStorage(Storage):
 
     Args:
         storage (:class:`Storage`): underlying storage
-        remaining_depth (int): destructure supported type until this 'nesting level' remains"""
+        remaining_depth (int): destructure supported type until this 'nesting level' remains
+        lazy (bool): if ``True``, :meth:`load` returns :class:`LazyIterable` / :class:`LazyDict`
+            proxies instead of eagerly reconstructing the full structure; elements are fetched
+            from storage only when first accessed"""
     storage: Storage
     remaining_depth: int = 0
+    lazy: bool = False
 
     def _depth(self, value: Any):
         match value:
@@ -223,6 +339,10 @@ class DestructuringStorage(Storage):
         value = self.storage.load(key)
 
         match value:
+            case DigestedIterable() if self.lazy:
+                return LazyIterable(value, self)
+            case DigestedDict() if self.lazy:
+                return LazyDict(value, self)
             case Digested():
                 return value.mend(self)
             case _:

--- a/tests/unit/storage/test_destructuring_storage.py
+++ b/tests/unit/storage/test_destructuring_storage.py
@@ -1,60 +1,47 @@
 import pytest
+from hypothesis import given, settings, HealthCheck, strategies as st
 from fleche.storage import Memory, DestructuringStorage
-from fleche.digest import digest
+from fleche.storage.base import DigestedIterable, DigestedDict, Digested
+from fleche.digest import digest, Digest
+
+from tests.strategies import st_base_values, st_nested_values, st_key_values
 
 
-def test_destructuring_storage_recursive_list():
+@pytest.fixture
+def mem():
+    return Memory(storage={})
+
+
+@pytest.fixture
+def ds(mem):
+    return DestructuringStorage(mem)
+
+
+def make_ds(remaining_depth=0):
     mem = Memory(storage={})
-    ds = DestructuringStorage(mem)
-
-    data = [1, [2, 3], {"a": 4}]
-    key = ds.save(data)
-
-    # Check that it's saved in the underlying memory storage
-    assert key in mem.list()
-
-    # Check that components are also saved
-    # [2, 3] should be saved
-    # {"a": 4} should be saved
-    # etc.
-
-    loaded = ds.load(key)
-    assert loaded == data
-    assert isinstance(loaded, list)
-    assert isinstance(loaded[1], list)
-    assert isinstance(loaded[2], dict)
+    ds = DestructuringStorage(mem, remaining_depth=remaining_depth)
+    return mem, ds
 
 
-def test_destructuring_storage_recursive_dict():
-    mem = Memory(storage={})
-    ds = DestructuringStorage(mem)
-
-    data = {"k1": [1, 2], "k2": {"inner": "v"}}
-    key = ds.save(data)
-
-    loaded = ds.load(key)
-    assert loaded == data
-    assert isinstance(loaded["k1"], list)
-    assert isinstance(loaded["k2"], dict)
+# ---- Roundtrip tests ----
 
 
-def test_destructuring_storage_tuple():
-    mem = Memory(storage={})
-    ds = DestructuringStorage(mem)
-
-    data = (1, 2, (3, 4))
-    key = ds.save(data)
-
-    loaded = ds.load(key)
-    assert loaded == data
-    assert isinstance(loaded, tuple)
-    assert isinstance(loaded[2], tuple)
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st_nested_values)
+def test_roundtrip(ds, value):
+    """Any nested value survives a save/load roundtrip."""
+    key = ds.save(value)
+    assert ds.load(key) == value
 
 
-def test_destructuring_storage_evict():
-    mem = Memory(storage={})
-    ds = DestructuringStorage(mem)
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st_nested_values)
+def test_save_is_deterministic(ds, value):
+    """Saving the same value twice yields the same key."""
+    assert ds.save(value) == ds.save(value)
 
+
+def test_evict(ds, mem):
     data = [1, 2]
     key = ds.save(data)
     assert key in mem.list()
@@ -63,3 +50,225 @@ def test_destructuring_storage_evict():
     assert key not in mem.list()
     with pytest.raises(KeyError):
         ds.load(key)
+
+
+# ---- Tests for _depth ----
+
+st_scalars = st.one_of(
+    st.integers(), st.floats(allow_nan=False), st.text(), st.binary(), st.booleans(),
+)
+
+
+@given(st_scalars)
+def test_depth_scalar(value):
+    ds = DestructuringStorage(Memory(storage={}))
+    assert ds._depth(value) == 1
+
+
+@given(st.lists(st_scalars, min_size=1))
+def test_depth_flat_list(items):
+    ds = DestructuringStorage(Memory(storage={}))
+    assert ds._depth(items) == 2
+
+
+@given(st.lists(st_scalars, min_size=1).map(tuple))
+def test_depth_flat_tuple(items):
+    ds = DestructuringStorage(Memory(storage={}))
+    assert ds._depth(items) == 2
+
+
+@given(st.dictionaries(st.text(), st_scalars, min_size=1))
+def test_depth_flat_dict(items):
+    ds = DestructuringStorage(Memory(storage={}))
+    assert ds._depth(items) == 2
+
+
+@pytest.mark.parametrize("value, expected", [
+    ([], 1),
+    ({}, 1),
+    ((), 1),
+    ([1, [2, 3]], 3),
+    ({"a": {"b": 1}}, 3),
+    ([[[1]]], 4),
+    ({"k": [1, [2]]}, 4),
+    ({(1, 2): 0}, 3),
+])
+def test_depth_specific(ds, value, expected):
+    assert ds._depth(value) == expected
+
+
+def test_depth_unknown_type_returns_huge(ds):
+    """Non-scalar, non-collection types get depth 2**64 so they always get destructured."""
+    assert ds._depth(object()) == 2 ** 64
+
+
+# ---- Tests for sunder / mend ----
+
+
+@given(st.lists(st_base_values, min_size=1, max_size=6))
+def test_digested_iterable_sunder_list(items):
+    di = DigestedIterable.sunder(digest, items)
+    assert isinstance(di, DigestedIterable)
+    assert isinstance(di.items, list)
+    assert len(di.items) == len(items)
+    assert all(isinstance(i, Digest) for i in di.items)
+
+
+@given(st.lists(st_base_values, min_size=1, max_size=6).map(tuple))
+def test_digested_iterable_sunder_tuple(items):
+    di = DigestedIterable.sunder(digest, items)
+    assert isinstance(di.items, tuple)
+
+
+@given(st.dictionaries(st_key_values, st_base_values, min_size=1, max_size=6))
+def test_digested_dict_sunder(d):
+    dd = DigestedDict.sunder(digest, d)
+    assert isinstance(dd, DigestedDict)
+    assert len(dd.items) == len(d)
+    for k, v in dd.items.items():
+        assert isinstance(k, Digest)
+        assert isinstance(v, Digest)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.lists(st_base_values, min_size=1, max_size=6))
+def test_digested_iterable_mend_roundtrip(ds, mem, items):
+    key = ds.save(items)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedIterable)
+    assert raw.mend(ds) == items
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.dictionaries(st.text(), st_base_values, min_size=1, max_size=6))
+def test_digested_dict_mend_roundtrip(ds, mem, d):
+    key = ds.save(d)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedDict)
+    assert raw.mend(ds) == d
+
+
+@given(st.lists(st_base_values, min_size=1, max_size=6))
+def test_digest_transparency_iterable(items):
+    """Digested iterables must hash identically to the value they replace."""
+    di = DigestedIterable.sunder(digest, items)
+    assert digest(di) == digest(items)
+
+
+@given(st.dictionaries(st_key_values, st_base_values, min_size=1, max_size=6))
+def test_digest_transparency_dict(d):
+    """Digested dicts must hash identically to the value they replace."""
+    dd = DigestedDict.sunder(digest, d)
+    assert digest(dd) == digest(d)
+
+
+# ---- Tests for remaining_depth ----
+
+
+@given(st.lists(st_scalars, min_size=1, max_size=6))
+def test_remaining_depth_0_destructures_everything(items):
+    """With remaining_depth=0, every element gets its own storage slot."""
+    mem, ds = make_ds(remaining_depth=0)
+    key = ds.save(items)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedIterable)
+    assert all(isinstance(i, Digest) for i in raw.items)
+
+
+@given(st.lists(st_scalars, min_size=1, max_size=6))
+def test_remaining_depth_1_inlines_scalars(items):
+    """With remaining_depth=1, scalar elements (depth 1) are kept inline."""
+    mem, ds = make_ds(remaining_depth=1)
+    key = ds.save(items)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedIterable)
+    assert raw.items == items
+    assert ds.load(key) == items
+
+
+def test_remaining_depth_1_still_destructures_nested():
+    """With remaining_depth=1, nested containers (depth>1) are still destructured."""
+    mem, ds = make_ds(remaining_depth=1)
+    data = [1, [2, 3]]
+    key = ds.save(data)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedIterable)
+    assert raw.items[0] == 1
+    assert isinstance(raw.items[1], Digest)
+    assert ds.load(key) == data
+
+
+def test_remaining_depth_2_inlines_flat_list():
+    """With remaining_depth=2, a flat list (depth 2) inside another list stays inline."""
+    mem, ds = make_ds(remaining_depth=2)
+    data = [1, [2, 3]]
+    key = ds.save(data)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedIterable)
+    assert raw.items[0] == 1
+    assert raw.items[1] == [2, 3]
+    assert ds.load(key) == data
+
+
+def test_remaining_depth_2_destructures_deeper():
+    """With remaining_depth=2, a list nested 3 deep is still destructured."""
+    mem, ds = make_ds(remaining_depth=2)
+    data = [1, [[2]]]
+    key = ds.save(data)
+    raw = mem.load(key)
+    assert isinstance(raw, DigestedIterable)
+    assert raw.items[0] == 1
+    assert isinstance(raw.items[1], Digest)
+    assert ds.load(key) == data
+
+
+@given(remaining_depth=st.integers(min_value=0, max_value=5))
+def test_remaining_depth_roundtrip_nested(remaining_depth):
+    """Any remaining_depth correctly roundtrips nested data."""
+    mem, ds = make_ds(remaining_depth=remaining_depth)
+    data = {"a": 1, "b": [2, [3, 4]], "c": (5,)}
+    key = ds.save(data)
+    assert ds.load(key) == data
+
+
+def test_remaining_depth_reduces_storage_slots():
+    """Higher remaining_depth should use fewer storage slots."""
+    mem0, ds0 = make_ds(remaining_depth=0)
+    mem2, ds2 = make_ds(remaining_depth=2)
+
+    data = [1, 2, [3, 4]]
+    ds0.save(data)
+    ds2.save(data)
+
+    assert len(list(mem2.list())) < len(list(mem0.list()))
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st_base_values)
+def test_load_passthrough_non_digest(ds, value):
+    """_load returns non-Digest values as-is (inline values from mend)."""
+    assert ds._load(value) == value
+
+
+@given(
+    value=st_nested_values,
+    write_depth=st.integers(min_value=0, max_value=5),
+    read_depth=st.integers(min_value=0, max_value=5),
+)
+def test_cross_depth_roundtrip(value, write_depth, read_depth):
+    """Data written at one remaining_depth is readable at any other."""
+    mem = Memory(storage={})
+    writer = DestructuringStorage(mem, remaining_depth=write_depth)
+    reader = DestructuringStorage(mem, remaining_depth=read_depth)
+    key = writer.save(value)
+    assert reader.load(key) == value
+
+
+@pytest.mark.parametrize("data", [[], (), {}])
+def test_remaining_depth_empty_containers(data):
+    """Empty containers with remaining_depth > 0 round-trip correctly."""
+    _, ds = make_ds(remaining_depth=2)
+    key = ds.save(data)
+    loaded = ds.load(key)
+    assert loaded == data
+    assert type(loaded) == type(data)

--- a/tests/unit/storage/test_lazy_storage.py
+++ b/tests/unit/storage/test_lazy_storage.py
@@ -1,0 +1,352 @@
+"""Tests for lazy reconstruction in DestructuringStorage (lazy=True)."""
+import pytest
+from hypothesis import given, settings, HealthCheck, strategies as st
+from fleche.storage import Memory, DestructuringStorage, LazyIterable, LazyDict
+from fleche.storage.base import DigestedIterable, DigestedDict
+
+from tests.strategies import st_base_values, st_nested_values, st_key_values
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture
+def mem():
+    return Memory(storage={})
+
+
+@pytest.fixture
+def lazy_ds(mem):
+    return DestructuringStorage(mem, lazy=True)
+
+
+def make_lazy_ds(remaining_depth=0):
+    mem = Memory(storage={})
+    ds = DestructuringStorage(mem, remaining_depth=remaining_depth, lazy=True)
+    return mem, ds
+
+
+# ---- LazyIterable ----
+
+
+def test_lazy_load_list_returns_lazy_iterable(mem, lazy_ds):
+    key = lazy_ds.save([1, 2, 3])
+    result = lazy_ds.load(key)
+    assert isinstance(result, LazyIterable)
+
+
+def test_lazy_load_tuple_returns_lazy_iterable(mem, lazy_ds):
+    key = lazy_ds.save((1, 2, 3))
+    result = lazy_ds.load(key)
+    assert isinstance(result, LazyIterable)
+
+
+def test_lazy_iterable_len(lazy_ds):
+    key = lazy_ds.save([10, 20, 30])
+    result = lazy_ds.load(key)
+    assert len(result) == 3
+
+
+def test_lazy_iterable_getitem(lazy_ds):
+    data = [10, 20, 30]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result[0] == 10
+    assert result[1] == 20
+    assert result[2] == 30
+
+
+def test_lazy_iterable_negative_index(lazy_ds):
+    data = [10, 20, 30]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result[-1] == 30
+    assert result[-2] == 20
+
+
+def test_lazy_iterable_index_out_of_range(lazy_ds):
+    key = lazy_ds.save([1, 2])
+    result = lazy_ds.load(key)
+    with pytest.raises(IndexError):
+        result[5]
+
+
+def test_lazy_iterable_slice(lazy_ds):
+    data = [1, 2, 3, 4, 5]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result[1:3] == [2, 3]
+
+
+def test_lazy_iterable_iter(lazy_ds):
+    data = [10, 20, 30]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert list(result) == data
+
+
+def test_lazy_iterable_eq_list(lazy_ds):
+    data = [1, 2, 3]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result == data
+    assert data == result
+
+
+def test_lazy_iterable_eq_tuple(lazy_ds):
+    data = (1, 2, 3)
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result == data
+    assert data == result
+
+
+def test_lazy_iterable_neq_wrong_type(lazy_ds):
+    """A LazyIterable wrapping a list should not equal a tuple with same elements."""
+    key = lazy_ds.save([1, 2, 3])
+    result = lazy_ds.load(key)
+    assert result != (1, 2, 3)
+
+
+def test_lazy_iterable_realize(lazy_ds):
+    data = [1, 2, 3]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert isinstance(result, LazyIterable)
+    realized = result.realize()
+    assert realized == data
+    assert isinstance(realized, list)
+
+
+def test_lazy_iterable_realize_tuple(lazy_ds):
+    data = (1, 2, 3)
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    realized = result.realize()
+    assert realized == data
+    assert isinstance(realized, tuple)
+
+
+def test_lazy_iterable_caches_elements(mem, lazy_ds):
+    """Each element should be loaded from storage only once."""
+    data = [1, 2, 3]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+
+    load_count_before = len(list(mem.list()))
+    _ = result[0]
+    _ = result[0]  # second access; should use cache
+    # No new storage entries created by repeated access
+    assert len(list(mem.list())) == load_count_before
+
+
+def test_lazy_iterable_repr(lazy_ds):
+    data = [1, 2]
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert repr(result) == repr(data)
+
+
+# ---- LazyDict ----
+
+
+def test_lazy_load_dict_returns_lazy_dict(mem, lazy_ds):
+    key = lazy_ds.save({"a": 1})
+    result = lazy_ds.load(key)
+    assert isinstance(result, LazyDict)
+
+
+def test_lazy_dict_len(lazy_ds):
+    key = lazy_ds.save({"a": 1, "b": 2})
+    result = lazy_ds.load(key)
+    assert len(result) == 2
+
+
+def test_lazy_dict_getitem(lazy_ds):
+    data = {"x": 10, "y": 20}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result["x"] == 10
+    assert result["y"] == 20
+
+
+def test_lazy_dict_getitem_missing_key(lazy_ds):
+    key = lazy_ds.save({"a": 1})
+    result = lazy_ds.load(key)
+    with pytest.raises(KeyError):
+        result["missing"]
+
+
+def test_lazy_dict_iter(lazy_ds):
+    data = {"a": 1, "b": 2}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert set(result) == {"a", "b"}
+
+
+def test_lazy_dict_keys(lazy_ds):
+    data = {"a": 1, "b": 2}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert set(result.keys()) == {"a", "b"}
+
+
+def test_lazy_dict_values(lazy_ds):
+    data = {"a": 1, "b": 2}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert set(result.values()) == {1, 2}
+
+
+def test_lazy_dict_items(lazy_ds):
+    data = {"a": 1, "b": 2}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert dict(result.items()) == data
+
+
+def test_lazy_dict_contains(lazy_ds):
+    data = {"a": 1}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert "a" in result
+    assert "z" not in result
+
+
+def test_lazy_dict_eq(lazy_ds):
+    data = {"a": 1, "b": 2}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert result == data
+    assert data == result
+
+
+def test_lazy_dict_realize(lazy_ds):
+    data = {"a": 1, "b": 2}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    realized = result.realize()
+    assert realized == data
+    assert isinstance(realized, dict)
+
+
+def test_lazy_dict_repr(lazy_ds):
+    data = {"a": 1}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert repr(result) == repr(data)
+
+
+def test_lazy_dict_caches_values(mem, lazy_ds):
+    """Each value should be loaded from storage only once."""
+    data = {"a": 1}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+
+    storage_count = len(list(mem.list()))
+    _ = result["a"]
+    _ = result["a"]  # second access; should use cache
+    assert len(list(mem.list())) == storage_count
+
+
+# ---- Roundtrip & correctness ----
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st_nested_values)
+def test_lazy_roundtrip_equals_eager(mem, value):
+    """Lazy and eager storage produce equal results for all nested values."""
+    eager = DestructuringStorage(mem, lazy=False)
+    key = eager.save(value)
+
+    lazy = DestructuringStorage(mem, lazy=True)
+    loaded = lazy.load(key)
+
+    # Recursively compare: realize any lazy proxies before equality check
+    def realize(v):
+        if isinstance(v, LazyIterable):
+            return type(v._digested.items)(realize(e) for e in v)
+        if isinstance(v, LazyDict):
+            return {realize(k): realize(val) for k, val in v.items()}
+        return v
+
+    assert realize(loaded) == value
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.lists(st_base_values, min_size=1, max_size=6))
+def test_lazy_list_eq_eager_list(mem, items):
+    """A lazily loaded list compares equal to the eagerly loaded list."""
+    eager_ds = DestructuringStorage(mem)
+    lazy_ds = DestructuringStorage(mem, lazy=True)
+    key = eager_ds.save(items)
+    eager_result = eager_ds.load(key)
+    lazy_result = lazy_ds.load(key)
+    assert lazy_result == eager_result
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.dictionaries(st.text(), st_base_values, min_size=1, max_size=6))
+def test_lazy_dict_eq_eager_dict(mem, d):
+    """A lazily loaded dict compares equal to the eagerly loaded dict."""
+    eager_ds = DestructuringStorage(mem)
+    lazy_ds = DestructuringStorage(mem, lazy=True)
+    key = eager_ds.save(d)
+    eager_result = eager_ds.load(key)
+    lazy_result = lazy_ds.load(key)
+    assert lazy_result == eager_result
+
+
+def test_lazy_nested_list(lazy_ds):
+    """Nested list elements are also lazily loaded."""
+    data = [[1, 2], [3, 4]]
+    key = lazy_ds.save(data)
+    outer = lazy_ds.load(key)
+    assert isinstance(outer, LazyIterable)
+    inner = outer[0]
+    assert isinstance(inner, LazyIterable)
+    assert inner[0] == 1
+    assert inner[1] == 2
+
+
+def test_lazy_nested_dict(lazy_ds):
+    """Nested dict values are also lazily loaded."""
+    data = {"a": {"b": 1}}
+    key = lazy_ds.save(data)
+    outer = lazy_ds.load(key)
+    assert isinstance(outer, LazyDict)
+    inner = outer["a"]
+    assert isinstance(inner, LazyDict)
+    assert inner["b"] == 1
+
+
+def test_lazy_dict_tuple_keys(lazy_ds):
+    """Dict keys that are tuples (stored as DigestedIterable) remain hashable and usable."""
+    data = {(1, 2): "a", (3, 4): "b"}
+    key = lazy_ds.save(data)
+    result = lazy_ds.load(key)
+    assert isinstance(result, LazyDict)
+    assert result[(1, 2)] == "a"
+    assert result[(3, 4)] == "b"
+    assert result == data
+
+
+def test_lazy_false_returns_concrete_types():
+    """When lazy=False (default), load returns plain list/dict, not proxies."""
+    mem = Memory(storage={})
+    ds = DestructuringStorage(mem, lazy=False)
+    key = ds.save([1, 2, 3])
+    result = ds.load(key)
+    assert isinstance(result, list)
+    assert not isinstance(result, LazyIterable)
+
+
+@given(remaining_depth=st.integers(min_value=0, max_value=4))
+def test_lazy_remaining_depth_roundtrip(remaining_depth):
+    """lazy=True roundtrips all values correctly across different remaining_depth values."""
+    mem = Memory(storage={})
+    ds = DestructuringStorage(mem, remaining_depth=remaining_depth, lazy=True)
+    data = {"a": 1, "b": [2, [3, 4]], "c": (5,)}
+    key = ds.save(data)
+    loaded = ds.load(key)
+    assert loaded == data


### PR DESCRIPTION
Adds `LazyIterable` and `LazyDict` proxy classes that defer element loading from storage until first access. Controlled by a new `lazy` flag on `DestructuringStorage` (default `False` for backward compatibility).

- `LazyIterable` wraps `DigestedIterable` and implements `collections.abc.Sequence`; supports indexing, slicing, iteration, and equality with `list`/`tuple`.
- `LazyDict` wraps `DigestedDict` and implements `collections.abc.Mapping`; keys are loaded eagerly (needed for iteration/lookup), values deferred. Tuple keys are realized eagerly to preserve hashability.
- Both proxies cache loaded elements and expose a `realize()` method for explicit eager materialization.
- Nesting is handled transparently: accessing a lazy element that itself wraps a `Digested` returns another lazy proxy.