### PR TITLE
Add storage_from_config (public, non-mutating refactor of _get_storage)

### DIFF
--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -94,26 +94,42 @@ def load_default_metadata():
     return tuple(meta_objects)
 
 
-def _get_storage(config: dict[str, Any]) -> storage.Storage:
-    storage_type = config.pop("type")
+def storage_from_config(d: dict[str, Any]) -> storage.Storage:
+    """Construct a :class:`~fleche.storage.Storage` from a config dict.
+
+    The dict must contain a ``"type"`` key (case-sensitive) and any additional
+    parameters required by that storage backend.  The input dict is **not**
+    mutated.
+
+    Supported types: ``"Memory"``, ``"Void"``, ``"DestructuringStorage"``,
+    ``"PickleFile"``, ``"CloudpickleFile"``, ``"DillFile"``,
+    ``"BagOfHoldingH5File"``, ``"Sql"``.
+    """
+    d = dict(d)
+    storage_type = d.pop("type")
     match storage_type:
         case "Memory":
             return storage.Memory({})
         case "Void":
             return storage.Void()
         case "DestructuringStorage":
-            inner = _get_storage(config.pop("storage"))
+            inner = storage_from_config(d.pop("storage"))
             return storage.DestructuringStorage(inner)
         case "PickleFile":
-            return storage.PickleFile.with_pickle(**config)
+            return storage.PickleFile.with_pickle(**d)
         case "CloudpickleFile":
-            return storage.PickleFile.with_cloudpickle(**config)
+            return storage.PickleFile.with_cloudpickle(**d)
         case "DillFile":
-            return storage.PickleFile.with_dill(**config)
+            return storage.PickleFile.with_dill(**d)
         case "BagOfHoldingH5File" | "Sql":
-            return getattr(storage, storage_type)(**config)
+            return getattr(storage, storage_type)(**d)
         case _:
             raise ValueError(f"Unknown storage type: {storage_type}")
+
+
+def _get_storage(config: dict[str, Any]) -> storage.Storage:
+    """Deprecated: use :func:`storage_from_config` instead."""
+    return storage_from_config(config)
 
 
 def storage_to_config(s: storage.Storage) -> dict[str, Any]:

--- a/tests/unit/config/test_storage_to_config.py
+++ b/tests/unit/config/test_storage_to_config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from fleche import storage
-from fleche.config import storage_to_config, _get_storage
+from fleche.config import storage_to_config, storage_from_config, _get_storage
 
 
 def test_memory():
@@ -91,21 +91,21 @@ def test_unknown_storage_raises():
 
 def test_roundtrip_memory():
     cfg = {"type": "Memory"}
-    s = _get_storage(cfg.copy())
+    s = storage_from_config(cfg)
     assert isinstance(s, storage.Memory)
     assert storage_to_config(s) == {"type": "Memory"}
 
 
 def test_roundtrip_void():
     cfg = {"type": "Void"}
-    s = _get_storage(cfg.copy())
+    s = storage_from_config(cfg)
     assert isinstance(s, storage.Void)
     assert storage_to_config(s) == {"type": "Void"}
 
 
 def test_roundtrip_destructuring_memory():
     cfg = {"type": "DestructuringStorage", "storage": {"type": "Memory"}}
-    s = _get_storage(cfg.copy())
+    s = storage_from_config(cfg)
     assert isinstance(s, storage.DestructuringStorage)
     assert isinstance(s.storage, storage.Memory)
     result = storage_to_config(s)
@@ -116,6 +116,23 @@ def test_roundtrip_pickle_file(tmp_path):
     root = tmp_path / "values"
     original = storage.PickleFile.with_pickle(root=root)
     cfg = storage_to_config(original)
-    reconstructed = _get_storage(cfg)
+    reconstructed = storage_from_config(cfg)
     assert isinstance(reconstructed, storage.PickleFile)
     assert reconstructed.root == original.root
+
+
+def test_storage_from_config_does_not_mutate():
+    cfg = {"type": "Memory"}
+    storage_from_config(cfg)
+    assert cfg == {"type": "Memory"}
+
+
+def test_storage_from_config_destructuring_does_not_mutate():
+    cfg = {"type": "DestructuringStorage", "storage": {"type": "Memory"}}
+    storage_from_config(cfg)
+    assert cfg == {"type": "DestructuringStorage", "storage": {"type": "Memory"}}
+
+
+def test_storage_from_config_unknown_type():
+    with pytest.raises(ValueError, match="UnknownType"):
+        storage_from_config({"type": "UnknownType"})


### PR DESCRIPTION
Closes #235, part of #232.

Refactors `_get_storage` into a public `storage_from_config` that does not mutate its input dict. `_get_storage` is kept as a deprecated thin wrapper.

Generated with [Claude Code](https://claude.ai/code)