### PR TITLE
Fix typing for storage `load` methods to consistently accept `Digest | str`

### DIFF
--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -33,7 +33,7 @@ class BagOfHoldingH5File(FileStorage):
             raise SaveError(value) from None
         return key
 
-    def _load(self, key: str) -> Any:
+    def _load(self, key: Digest) -> Any:
         try:
             return H5Bag(self._path(key)).load()
         except FileNotFoundError:

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -200,7 +200,7 @@ class CallStorage(StorageBase):
     @abstractmethod
     def _save(self, call: Call) -> Digest: ...
 
-    def load(self, key: str) -> Call:
+    def load(self, key: str | Digest) -> Call:
         if len(key) < DIGEST_LENGTH:
             key = self.expand(key)
         else:

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -196,11 +196,11 @@ class Sql(CallStorage):
         finally:
             session.close()
 
-    def _load(self, key: str) -> Call:
+    def _load(self, key: Digest) -> Call:
         session = self.session()
         try:
             call_model = session.execute(
-                select(CallModel).where(CallModel.key == key)
+                select(CallModel).where(CallModel.key == str(key))
             ).scalar_one_or_none()
             if call_model is None:
                 raise KeyError(key)
@@ -208,7 +208,7 @@ class Sql(CallStorage):
             arguments = {arg.name: Digest(arg.value) for arg in call_model.arguments}
 
             meta_rows = (
-                session.execute(select(MetaModel).where(MetaModel.call_key == key))
+                session.execute(select(MetaModel).where(MetaModel.call_key == str(key)))
                 .scalars()
                 .all()
             )
@@ -281,10 +281,10 @@ class Sql(CallStorage):
             f"Short digest {key} is ambiguous; need at least {i+1} characters."
         )
 
-    def _evict(self, key: str) -> None:
+    def _evict(self, key: Digest) -> None:
         session = self.session()
         try:
-            instance = session.get(CallModel, key)
+            instance = session.get(CallModel, str(key))
             if instance is None:
                 return
             session.delete(instance)


### PR DESCRIPTION
Fix typing for storage `load` methods to consistently accept `Digest | str`

The implementations of the `load`, `_load`, `evict`, and `_evict` methods on the various `Storage` classes correctly expand shorthand `str` digests to full-length `Digest` objects before operating on them, or operate on `Digest` objects directly. The type hints for some of these methods previously indicated only `str` or did not include `Digest`. This change aligns the type hints of these methods in the `Storage` protocols (`base.py`) and implementations (`sql.py`, `bagofholding_file.py`) with their actual expected behavior.

---
*PR created automatically by Jules for task [18309661075640098991](https://jules.google.com/task/18309661075640098991) started by @pmrv*