### PR TITLE
Add ThreadSafeMixin and MemoryThreadSafe for thread-safe storage

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -188,7 +188,10 @@ class Cache(BaseCache):
 
     def __post_init__(self, _calls):
         if isinstance(_calls, storage.Storage):
-            self.calls = storage.CallStorageAdapter(_calls)
+            if isinstance(_calls, storage.base.ThreadSafeMixin):
+                self.calls = storage.base.ThreadSafeCallStorageAdapter(_calls)
+            else:
+                self.calls = storage.CallStorageAdapter(_calls)
         else:
             self.calls = _calls
 

--- a/src/fleche/storage/__init__.py
+++ b/src/fleche/storage/__init__.py
@@ -4,6 +4,7 @@ This module re-exports the primary storage interfaces and implementations
 for backward compatibility with `from fleche.storage import ...` imports.
 """
 
+from .thread_safe import ThreadSafeMixin
 from .base import (
     SaveError,
     AmbiguousDigestError,
@@ -11,9 +12,10 @@ from .base import (
     CallStorage,
     CallStorageAdapter,
     DestructuringMixin,
+    ThreadSafeCallStorageAdapter,
     DestructuringStorage,
 )
-from .memory import Memory
+from .memory import Memory, MemoryThreadSafe
 from .void import Void
 from .file import FileStorage
 from .pickle_file import PickleFile
@@ -27,8 +29,11 @@ __all__ = [
     "CallStorage",
     "CallStorageAdapter",
     "DestructuringMixin",
+    "ThreadSafeCallStorageAdapter",
     "DestructuringStorage",
+    "ThreadSafeMixin",
     "Memory",
+    "MemoryThreadSafe",
     "Void",
     "FileStorage",
     "PickleFile",

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -7,6 +7,7 @@ from typing import Iterable, Any, Callable, Self
 
 from ..digest import digest, Digest, DIGEST_LENGTH
 from ..call import Call, QueryCall
+from .thread_safe import ThreadSafeMixin
 
 logger = logging.getLogger("fleche.storage")
 
@@ -383,7 +384,7 @@ class CallStorage(StorageBase):
             return False
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class CallStorageAdapter(CallStorage):
     """Implement a CallStorage from a generic Storage."""
 
@@ -403,3 +404,12 @@ class CallStorageAdapter(CallStorage):
 
     def list(self) -> Iterable[Digest]:
         return self.storage.list()
+
+
+class ThreadSafeCallStorageAdapter(ThreadSafeMixin, CallStorageAdapter):
+    """Thread-safe :class:`CallStorageAdapter`.
+
+    The compound check-evict-save in :meth:`CallStorage.save` is executed
+    atomically under a per-instance :class:`threading.RLock` provided by
+    :class:`~fleche.storage.thread_safe.ThreadSafeMixin`.
+    """

--- a/src/fleche/storage/memory.py
+++ b/src/fleche/storage/memory.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Iterable
 
 from .base import Storage
+from .thread_safe import ThreadSafeMixin
 from ..digest import Digest
 from copy import deepcopy
 
@@ -29,3 +30,20 @@ class Memory(Storage):
 
     def _evict(self, key: Digest) -> None:
         self.storage.pop(key, None)
+
+
+class MemoryThreadSafe(ThreadSafeMixin, Memory):
+    """Thread-safe in-memory storage.
+
+    All public operations (*save*, *load*, *contains*, *evict*, *list*) are
+    serialised with a per-instance :class:`threading.RLock`.
+
+    When passed to :class:`~fleche.caches.Cache` as both the value *and* call
+    storage, ``Cache`` automatically wraps the call-storage side in a
+    :class:`~fleche.storage.base.ThreadSafeCallStorageAdapter` so that the
+    compound check-evict-save in
+    :meth:`~fleche.storage.base.CallStorage.save` is also atomic::
+
+        mem = MemoryThreadSafe({})
+        cache = Cache(mem, mem)   # fully thread-safe
+    """

--- a/src/fleche/storage/thread_safe.py
+++ b/src/fleche/storage/thread_safe.py
@@ -1,0 +1,82 @@
+"""Thread-safety mixin for Storage and CallStorage classes."""
+
+import threading
+from typing import Any, Iterable
+
+
+class ThreadSafeMixin:
+    """Mixin that serialises all public storage operations with a per-instance RLock.
+
+    Wrapping *save*, *load*, *contains*, *evict*, and *list* with a reentrant
+    lock has two useful properties:
+
+    1. Individual dict / file operations become atomic even when multiple
+       threads share the same storage object.
+    2. When the mixin is applied to a :class:`~fleche.storage.base.CallStorage`
+       subclass the *compound* check-evict-save sequence in
+       ``CallStorage.save()`` becomes fully atomic, because the outer
+       ``ThreadSafeMixin.save()`` call holds the lock for the whole duration
+       of ``super().save()``, and the inner calls to ``contains()`` and
+       ``evict()`` simply re-acquire the same RLock reentrantly.
+
+    The lock is created lazily (on first access) so that it is never part of
+    the object's pickle payload; it is recreated transparently after
+    unpickling.
+
+    Usage::
+
+        class MyThreadSafeStorage(ThreadSafeMixin, MyStorage):
+            pass
+
+        mem = MemoryThreadSafe({})          # value storage
+        calls = ThreadSafeCallStorageAdapter(mem)  # call storage
+    """
+
+    @property
+    def _lock(self) -> threading.RLock:
+        """Per-instance reentrant lock, created lazily."""
+        try:
+            return object.__getattribute__(self, "_ts_lock")
+        except AttributeError:
+            lock = threading.RLock()
+            # object.__setattr__ bypasses frozen-dataclass restrictions and
+            # writes directly into __dict__ (available because this mixin does
+            # not define __slots__).
+            object.__setattr__(self, "_ts_lock", lock)
+            return lock
+
+    # ------------------------------------------------------------------
+    # Public API overrides – each acquires the lock before delegating
+    # ------------------------------------------------------------------
+
+    def save(self, *args: Any, **kwargs: Any) -> Any:
+        with self._lock:
+            return super().save(*args, **kwargs)  # type: ignore[misc]
+
+    def load(self, *args: Any, **kwargs: Any) -> Any:
+        with self._lock:
+            return super().load(*args, **kwargs)  # type: ignore[misc]
+
+    def contains(self, *args: Any, **kwargs: Any) -> bool:
+        with self._lock:
+            return super().contains(*args, **kwargs)  # type: ignore[misc]
+
+    def evict(self, *args: Any, **kwargs: Any) -> None:
+        with self._lock:
+            super().evict(*args, **kwargs)  # type: ignore[misc]
+
+    def list(self) -> Iterable:
+        with self._lock:
+            return super().list()  # type: ignore[misc]
+
+    # ------------------------------------------------------------------
+    # Pickle support – exclude the (non-picklable) lock
+    # ------------------------------------------------------------------
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state.pop("_ts_lock", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)

--- a/tests/unit/storage/test_thread_safe.py
+++ b/tests/unit/storage/test_thread_safe.py
@@ -1,0 +1,201 @@
+"""Tests for ThreadSafeMixin, MemoryThreadSafe, and ThreadSafeCallStorageAdapter."""
+
+import pickle
+import threading
+import time
+
+import pytest
+
+from fleche.storage import (
+    CallStorageAdapter,
+    Memory,
+    MemoryThreadSafe,
+    ThreadSafeCallStorageAdapter,
+    ThreadSafeMixin,
+)
+from fleche.call import Call
+from fleche.digest import Digest
+
+
+# ---------------------------------------------------------------------------
+# ThreadSafeMixin structural tests
+# ---------------------------------------------------------------------------
+
+
+def test_memory_thread_safe_is_mixin_subclass():
+    assert issubclass(MemoryThreadSafe, ThreadSafeMixin)
+    assert issubclass(MemoryThreadSafe, Memory)
+
+
+def test_thread_safe_call_storage_adapter_is_mixin_subclass():
+    assert issubclass(ThreadSafeCallStorageAdapter, ThreadSafeMixin)
+    assert issubclass(ThreadSafeCallStorageAdapter, CallStorageAdapter)
+
+
+def test_plain_memory_is_not_thread_safe_mixin():
+    assert not issubclass(Memory, ThreadSafeMixin)
+
+
+def test_lock_is_per_instance():
+    a = MemoryThreadSafe({})
+    b = MemoryThreadSafe({})
+    assert a._lock is not b._lock
+
+
+def test_lock_is_rlock():
+    mem = MemoryThreadSafe({})
+    assert isinstance(mem._lock, type(threading.RLock()))
+
+
+def test_lock_identity_stable():
+    mem = MemoryThreadSafe({})
+    lock1 = mem._lock
+    lock2 = mem._lock
+    assert lock1 is lock2
+
+
+# ---------------------------------------------------------------------------
+# Pickling
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip(obj):
+    return pickle.loads(pickle.dumps(obj))
+
+
+def test_memory_thread_safe_picklable():
+    mem = MemoryThreadSafe({})
+    restored = _roundtrip(mem)
+    assert isinstance(restored, MemoryThreadSafe)
+
+
+def test_memory_thread_safe_functional_after_pickle():
+    mem = MemoryThreadSafe({})
+    key = mem.save(42)
+    restored = _roundtrip(mem)
+    assert restored.load(key) == 42
+
+
+def test_thread_safe_call_storage_adapter_picklable():
+    adapter = ThreadSafeCallStorageAdapter(MemoryThreadSafe({}))
+    restored = _roundtrip(adapter)
+    assert isinstance(restored, ThreadSafeCallStorageAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Storage correctness
+# ---------------------------------------------------------------------------
+
+
+def test_memory_thread_safe_save_load_roundtrip():
+    mem = MemoryThreadSafe({})
+    key = mem.save("hello")
+    assert mem.load(key) == "hello"
+
+
+def test_memory_thread_safe_evict():
+    mem = MemoryThreadSafe({})
+    key = mem.save("hello")
+    assert mem.contains(key)
+    mem.evict(key)
+    assert not mem.contains(key)
+
+
+def test_memory_thread_safe_list():
+    mem = MemoryThreadSafe({})
+    k1 = mem.save(1)
+    k2 = mem.save(2)
+    assert set(mem.list()) == {k1, k2}
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety: concurrent saves do not cause temporary key absence
+# ---------------------------------------------------------------------------
+
+
+def _make_call(name: str, arg: str) -> Call:
+    return Call(
+        name=name,
+        arguments={"x": arg * 64},
+        metadata={},
+        module=None,
+        version=None,
+        result=42,
+    )
+
+
+def test_concurrent_call_saves_no_key_gap():
+    """The key must never be absent between evict and re-save under concurrent load."""
+    call = _make_call("f", "a")
+    key = call.to_lookup_key()
+
+    adapter = ThreadSafeCallStorageAdapter(MemoryThreadSafe({}))
+    adapter.save(call)
+
+    errors = []
+    gap_detected = threading.Event()
+
+    def saver():
+        for _ in range(50):
+            adapter.save(call)
+
+    def checker():
+        for _ in range(200):
+            if not adapter.contains(str(key)):
+                gap_detected.set()
+                errors.append("key absent during concurrent saves")
+            time.sleep(0)
+
+    threads = [threading.Thread(target=saver) for _ in range(4)]
+    threads += [threading.Thread(target=checker)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Detected {len(errors)} gap(s): {errors[0]}"
+
+
+def test_concurrent_value_saves_no_data_loss():
+    """Concurrent saves to MemoryThreadSafe must not lose data."""
+    mem = MemoryThreadSafe({})
+    n = 100
+    keys = []
+    lock = threading.Lock()
+
+    def saver(value):
+        k = mem.save(value)
+        with lock:
+            keys.append(k)
+
+    threads = [threading.Thread(target=saver, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(keys) == n
+    for k in keys:
+        assert mem.contains(k)
+
+
+# ---------------------------------------------------------------------------
+# Cache auto-selects ThreadSafeCallStorageAdapter for MemoryThreadSafe
+# ---------------------------------------------------------------------------
+
+
+def test_cache_uses_thread_safe_adapter_for_memory_thread_safe():
+    from fleche.caches import Cache
+
+    mem = MemoryThreadSafe({})
+    cache = Cache(mem, mem)
+    assert isinstance(cache.calls, ThreadSafeCallStorageAdapter)
+
+
+def test_cache_uses_plain_adapter_for_plain_memory():
+    from fleche.caches import Cache
+
+    mem = Memory({})
+    cache = Cache(mem, mem)
+    assert isinstance(cache.calls, CallStorageAdapter)
+    assert not isinstance(cache.calls, ThreadSafeCallStorageAdapter)


### PR DESCRIPTION
Fixes the non-atomic check-evict-save race in `CallStorage.save()` (issue 213).

## Changes

- **`ThreadSafeMixin`** (`storage/thread_safe.py`): reusable mixin with a per-instance `RLock` that serialises `save`, `load`, `contains`, `evict`, and `list`. When applied to a `CallStorage` subclass, the entire compound check-evict-save runs atomically (RLock is reentrant so inner re-acquisitions succeed). Pickle-safe: lock is created lazily and excluded from pickle state.

- **`MemoryThreadSafe(ThreadSafeMixin, Memory)`**: drop-in thread-safe replacement for `Memory`.

- **`ThreadSafeCallStorageAdapter(ThreadSafeMixin, CallStorageAdapter)`**: thread-safe call storage adapter.

- **`Cache.__post_init__`** auto-selects `ThreadSafeCallStorageAdapter` when the backing storage is a `ThreadSafeMixin` instance — `Cache(mem, mem)` with a `MemoryThreadSafe` is fully thread-safe without extra configuration.

## Usage

```python
from fleche.storage.memory import MemoryThreadSafe
from fleche.caches import Cache

mem = MemoryThreadSafe({})
cache = Cache(mem, mem)  # automatically uses ThreadSafeCallStorageAdapter for calls
```

The mixin is reusable for future storages:

```python
class MyThreadSafeStorage(ThreadSafeMixin, MyStorage):
    pass
```

Closes pmrv/fleche#213

Generated with [Claude Code](https://claude.ai/code)
