### PR TITLE
fix: .query() no longer applies default argument values

### DIFF
--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -186,8 +186,7 @@ class QueryCall:
         # Normalize arguments using function signature
         sig = signature(func)
         bound = sig.bind_partial(*args, **kwargs)
-        bound.apply_defaults()
-        # missing arguments are set to None
+        # Do NOT apply defaults: unspecified arguments are treated as None (wildcard)
         arguments = {name: bound.arguments.get(name) for name in sig.parameters}
 
         call = cls(func.__name__, arguments)

--- a/tests/unit/call/test_partial_binding.py
+++ b/tests/unit/call/test_partial_binding.py
@@ -44,8 +44,8 @@ def test_simple_full():
 
 def test_args_partial():
     call = QueryCall.from_call(func_args, 1)
-    # *args defaults to empty tuple with apply_defaults()
-    assert call.arguments == {"a": 1, "args": ()}
+    # *args not supplied → None (wildcard)
+    assert call.arguments == {"a": 1, "args": None}
 
 
 def test_args_partial_with_values():
@@ -55,8 +55,8 @@ def test_args_partial_with_values():
 
 def test_kwargs_partial():
     call = QueryCall.from_call(func_kwargs, 1)
-    # **kwargs defaults to empty dict with apply_defaults()
-    assert call.arguments == {"a": 1, "kwargs": {}}
+    # **kwargs not supplied → None (wildcard)
+    assert call.arguments == {"a": 1, "kwargs": None}
 
 
 def test_kwargs_partial_with_values():
@@ -84,25 +84,19 @@ def test_posonly_partial_with_values():
     assert call.arguments == {"a": 1, "b": 2}
 
 
-def test_defaults_partial():
-    # Verify that defaults ARE applied even when partial=True.
+def test_defaults_not_specified():
+    # Unspecified args are None (wildcard), defaults are NOT applied.
     call = QueryCall.from_call(func_defaults)
-    assert call.arguments == {"a": 1, "b": 2}
-
-
-def test_defaults_full():
-    # Verify that defaults ARE applied when partial=False (default behavior).
-    call = QueryCall.from_call(func_defaults)
-    assert call.arguments == {"a": 1, "b": 2}
+    assert call.arguments == {"a": None, "b": None}
 
 
 def test_defaults_partial_explicit():
-    # If explicitly passed, overrides default
+    # If explicitly passed, the value is used; unspecified args remain None (wildcard)
     call = QueryCall.from_call(func_defaults, a=10)
-    assert call.arguments == {"a": 10, "b": 2}
+    assert call.arguments == {"a": 10, "b": None}
 
 
 def test_defaults_partial_explicit_none():
-    # If explicitly passed None, it overrides default (wildcard behavior)
+    # Explicitly passing None is still None (wildcard)
     call = QueryCall.from_call(func_defaults, b=None)
-    assert call.arguments == {"a": 1, "b": None}
+    assert call.arguments == {"a": None, "b": None}

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -263,28 +263,19 @@ def test_query_partial_arguments(test_cache):
             return x + y + z
 
         call_obj = QueryCall.from_call(bar, y=5)
-        assert call_obj.arguments == {"x": None, "y": 5, "z": 10}
+        # Unspecified z is None (wildcard), default is NOT applied
+        assert call_obj.arguments == {"x": None, "y": 5, "z": None}
 
         # Test that .query uses partial binding
         bar(1, 5, 10)
         bar(2, 5, 20)
         bar(1, 6, 10)
 
-        # Querying for y=5 with z=None explicitly restores wildcard behavior
-        # Should return 2 results (x=1, y=5, z=10 and x=2, y=5, z=20)
-        results = list(bar.query(y=5, z=None))
-        assert len(results) == 2
-
-        # Querying for x=1 with z=None explicitly restores wildcard behavior
-        # Should return 2 results (x=1, y=5, z=10 and x=1, y=6, z=10)
-        results = list(bar.query(x=1, z=None))
-        assert len(results) == 2
-
-        # Querying for y=5 should return 1 results (x=1, z=10), since default z=10 is applied
+        # Querying for y=5: z is not specified so it's a wildcard → 2 results
         results = list(bar.query(y=5))
-        assert len(results) == 1
+        assert len(results) == 2
 
-        # Querying for x=1 should return 2 results (y=5, z=10 and y=6, z=10)
+        # Querying for x=1: y and z are not specified so they're wildcards → 2 results
         results = list(bar.query(x=1))
         assert len(results) == 2
 


### PR DESCRIPTION
Calling `foo.query()` is now equivalent to passing `None` for all arguments (wildcard match), rather than filling in function defaults.

Closes #258

Generated with [Claude Code](https://claude.ai/code)