### PR TITLE
Fix stale __all__ entries and redundant Sql base class

### DIFF
--- a/src/fleche/storage/__init__.py
+++ b/src/fleche/storage/__init__.py
@@ -39,10 +39,7 @@ __all__ = [
     "FileStorage",
     "ValuePickleFile",
     "CallPickleFile",
-    "PickleFile",
     "ValueBagOfHoldingH5File",
     "CallBagOfHoldingH5File",
-    "BagOfHoldingH5File",
-    "CallSql",
     "Sql",
 ]

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -123,7 +123,7 @@ def _enable_sqlite_foreign_keys(engine) -> None:
 
 
 @dataclass(frozen=True)
-class Sql(CallStorage, KeyManagement):
+class Sql(CallStorage):
     """SQLAlchemy-backed CallStorage with JSON metadata and DB-backed expand()."""
 
     url: str | None = None


### PR DESCRIPTION
Remove PickleFile, BagOfHoldingH5File, and CallSql from __all__ in storage/__init__.py — these names are not imported or aliased and would cause AttributeError if accessed.

Remove redundant KeyManagement base from Sql since CallStorage already inherits from it.

Closes #245