### PR TITLE
Fix incorrect claim that Call is a frozen dataclass

### DIFF
--- a/docs/lazy_call.rst
+++ b/docs/lazy_call.rst
@@ -39,7 +39,7 @@ Parity with Call
 
 * **Digests**: ``digest(lazy_call)`` is identical to ``digest(original_call)``.
 * **Lookup Keys**: ``lazy_call.to_lookup_key()`` returns the same key.
-* **Immutability**: Like ``Call``, ``LazyCall`` is a frozen dataclass.
+* **Immutability**: ``LazyCall`` is a frozen dataclass — its fields cannot be reassigned after creation.
 
 LazyArguments
 -------------


### PR DESCRIPTION
The docs stated LazyCall is frozen "like Call", but Call uses @dataclass without frozen=True. Updated to describe only LazyCall's immutability.

https://claude.ai/code/session_012LzfJ451BXaLuii9SPfC6V