### PR TITLE
Fix config file search order docs to reflect elif logic

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,9 +4,11 @@ Configuration
 ``fleche`` looks for a configuration file in the following order:
 
 1. ``fleche.toml`` in the current working directory (local config)
-2. ``$XDG_CONFIG_HOME/fleche/cache.toml`` (if ``$XDG_CONFIG_HOME`` is set)
-3. ``$HOME/.fleche.toml`` (if ``$HOME`` is set)
-4. ``~/.fleche.toml`` (fallback)
+2. A global config file, determined by the first matching rule:
+
+   - If ``$XDG_CONFIG_HOME`` is set: ``$XDG_CONFIG_HOME/fleche/cache.toml``
+   - Otherwise, if ``$HOME`` is set: ``$HOME/.fleche.toml``
+   - Otherwise: ``~/.fleche.toml``
 
 The first file found is used. If no configuration file exists, ``fleche`` falls back to a default in-memory cache.
 


### PR DESCRIPTION
The documentation presented the global-config lookup as a four-step sequential fallback chain, but `_get_config_path()` in `src/fleche/config.py` actually uses `if/elif/else` — meaning only one of the XDG / HOME / `~` branches is tried, chosen by which environment variables are set. A user with `XDG_CONFIG_HOME` set whose file doesn't exist there would not (contrary to the old wording) fall through to `$HOME/.fleche.toml`.

Rewrote steps 2–4 as sub-bullets under a single step 2, making the exclusive nature explicit.

https://claude.ai/code/session_012LzfJ451BXaLuii9SPfC6V