### PR TITLE
Fix incorrect entry point group in custom_digests.rst

### DIFF
--- a/docs/custom_digests.rst
+++ b/docs/custom_digests.rst
@@ -44,12 +44,12 @@ Registering Entry Points
 
 For library authors who want to provide ``fleche`` support for their types without requiring users to manually call ``add_hook``, ``fleche`` supports Python entry points.
 
-You can register your digest hooks in the ``fleche.digest`` entry point group in your ``pyproject.toml`` (or equivalent).
+You can register your digest hooks in the ``fleche`` entry point group with the name ``digest`` in your ``pyproject.toml`` (or equivalent).
 
 .. code-block:: toml
 
-   [project.entry-points."fleche.digest"]
-   my_package_hooks = "my_package.hooks:get_hooks"
+   [project.entry-points."fleche"]
+   digest = "my_package.hooks:get_hooks"
 
 The entry point can point to:
 * A single ``fleche.digest.Hook`` object.


### PR DESCRIPTION
The "Registering Entry Points" section showed:

```toml
[project.entry-points."fleche.digest"]
my_package_hooks = "my_package.hooks:get_hooks"
```

But `load_entry_points()` in `src/fleche/digest.py` calls `importlib.metadata.entry_points(group="fleche", name="digest")`. That looks up the group `"fleche"` and requires the entry point to be named exactly `digest`. The TOML shown in the docs registers a group `"fleche.digest"` with an arbitrary name, so fleche would never discover it.

Updated the example and surrounding prose to the correct form:

```toml
[project.entry-points."fleche"]
digest = "my_package.hooks:get_hooks"
```

https://claude.ai/code/session_012LzfJ451BXaLuii9SPfC6V