### PR TITLE
Fix misleading hit-transfer example in cache_stack.rst

### DIFF
--- a/docs/cache_stack.rst
+++ b/docs/cache_stack.rst
@@ -25,15 +25,19 @@ Example
     local_cache = Cache(Memory({}), Memory({}))
     remote_cache = Cache(Memory({}), Memory({}))
 
-    # Create a stack
-    stack = CacheStack((local_cache, remote_cache))
-
     @fleche
     def my_function(x):
         return x * 2
 
+    # Populate remote_cache with a result
+    with cache(remote_cache):
+        my_function(10)
+
+    # Create a stack with an empty local_cache on top
+    stack = CacheStack((local_cache, remote_cache))
+
     with cache(stack):
-        # Result is found in remote_cache, and automatically saved to local_cache
+        # Result is found in remote_cache and automatically copied to local_cache
         my_function(10)
 
 Automatic hit transfer only applies to full function calls (``Call`` objects) and not to individual values loaded via ``load_value``.


### PR DESCRIPTION
The example was supposed to demonstrate automatic hit transfer from a fallback cache down to the base cache, but the code called `my_function(10)` exactly once on two empty caches. On that single call the result is a miss in both, gets computed, and is saved to `local_cache` — there is no transfer from `remote_cache` to show. The comment ("Result is found in remote_cache, and automatically saved to local_cache") did not match what the example actually does.

Restructured the example so it actually demonstrates the behavior:

1. First populate `remote_cache` directly (`with cache(remote_cache): my_function(10)`).
2. Then construct a `CacheStack((local_cache, remote_cache))` with `local_cache` still empty.
3. The subsequent call inside `with cache(stack):` misses in `local_cache`, hits in `remote_cache`, and is transferred down.

https://claude.ai/code/session_012LzfJ451BXaLuii9SPfC6V