### PR TITLE
Special case namedtuples in DestructuringMixin

### DIFF
--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -1,4 +1,5 @@
 import logging
+import collections
 from dataclasses import dataclass
 from numbers import Number
 
@@ -235,6 +236,10 @@ class DestructuringMixin(StorageBackend):
 
     remaining_depth: int = 0
 
+    @staticmethod
+    def _is_trojan_tuple(value):
+        return hasattr(value, "_fields") and hasattr(value, "_field_defaults")
+
     def _intern_rec(self, value: Any, key: Digest | None = None) -> tuple[Any, int | float]:
         """Post-order traversal: recurse to leaves, decide inline-vs-store on the way back up.
 
@@ -256,6 +261,12 @@ class DestructuringMixin(StorageBackend):
             # destructuring the empty container
             case dict() | list() | tuple() if not value:
                 depth = 0
+
+            # because nothing is ever simple, namedtuple break LSP by not accepting a single iterable
+            # this is considered highly annoying, because e.g. a lot of numpy functions we'd like to wrap return
+            # NamedTuple
+            case tuple() if self._is_trojan_tuple(value):
+                pass
 
             case list() | tuple():
                 value, depth = DigestedIterable.sunder(self._intern_rec, value)

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,5 +1,6 @@
 from hypothesis import strategies as st
 from dataclasses import make_dataclass
+import collections
 import string
 import keyword
 import numpy as np
@@ -34,6 +35,26 @@ def dataclasses(draw, field_types, frozen=None, clscache={}):
     return cls(*fields)
 
 
+@st.composite
+def namedtuples(draw, field_types, clscache={}):
+    fields = draw(
+        st.dictionaries(
+            st.text(string.ascii_letters, min_size=3, max_size=3).filter(
+                lambda s: not keyword.iskeyword(s) and s != "mro"
+            ),
+            field_types,
+            min_size=1,
+            max_size=5,
+        )
+    )
+    clsname = 'NT' + digest.digest(list(fields.keys()))
+    if clsname not in clscache:
+        cls = clscache[clsname] = collections.namedtuple(clsname, list(fields.keys()))
+    else:
+        cls = clscache[clsname]
+    return cls(**fields)
+
+
 def calls(value_types):
     """Generate random Call objects using st.builds."""
     return st.builds(
@@ -61,6 +82,7 @@ key_strategies = [
     st.booleans(),
 ]
 key_strategies.append(dataclasses(st.one_of(*key_strategies), frozen=True))
+key_strategies.append(namedtuples(st.one_of(*key_strategies)))
 
 
 # Base values include all key strategies plus unhashable types like Call
@@ -79,6 +101,7 @@ st_nested_values = st.recursive(
         st.composite(lambda draw: tuple(draw(st_l)))(),
         st.dictionaries(st_key_values, children, max_size=6),  # Use only hashable keys
         dataclasses(children, frozen=True),
+        namedtuples(children),
     ),
     max_leaves=10,
 )

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -199,6 +199,9 @@ def randomly_digest_subvalues(value, data):
     # Otherwise, recurse into the structure
     if isinstance(value, list):
         return [randomly_digest_subvalues(v, data) for v in value]
+    elif isinstance(value, tuple) and hasattr(value, "_fields") and hasattr(value, "_field_defaults"):
+        # namedtuple: reconstruct preserving the concrete type, since digest() includes type.__name__
+        return type(value)(*[randomly_digest_subvalues(v, data) for v in value])
     elif isinstance(value, tuple):
         return tuple(randomly_digest_subvalues(v, data) for v in value)
     elif isinstance(value, dict):

--- a/tests/unit/storage/test_destructuring_storage.py
+++ b/tests/unit/storage/test_destructuring_storage.py
@@ -1,4 +1,5 @@
 import pytest
+from collections import namedtuple
 from dataclasses import dataclass
 from hypothesis import given, settings, HealthCheck, strategies as st
 from fleche.storage import ValueMixin, DestructuringMixin
@@ -6,7 +7,7 @@ from fleche.storage.memory import MemoryBackend
 from fleche.storage.base import DigestedIterable, DigestedDict, Digested
 from fleche.digest import digest, Digest
 
-from tests.strategies import st_base_values, st_nested_values, st_key_values
+from tests.strategies import st_base_values, st_nested_values, st_key_values, namedtuples
 
 
 @dataclass(frozen=True)
@@ -261,3 +262,85 @@ def test_plain_dict_stored_when_all_inline():
     raw = ds.storage[key]
     assert not isinstance(raw, Digested)
     assert raw == data
+
+
+# ---- Namedtuple tests ----
+
+Point = namedtuple('Point', ['x', 'y'])
+Triple = namedtuple('Triple', ['a', 'b', 'c'])
+
+
+def test_namedtuple_roundtrip(ds):
+    """A namedtuple survives a save/load roundtrip as the same type."""
+    p = Point(x=1, y=2)
+    key = ds.save(p)
+    loaded = ds.load(key)
+    assert loaded == p
+    assert type(loaded) is Point
+
+
+def test_namedtuple_not_destructured(ds):
+    """Namedtuples are stored atomically, not wrapped in DigestedIterable."""
+    p = Point(x=3, y=4)
+    key = ds.save(p)
+    raw = ds.storage[key]
+    assert not isinstance(raw, DigestedIterable)
+    assert type(raw) is Point
+
+
+def test_namedtuple_in_list_roundtrip(ds):
+    """A namedtuple inside a list is preserved through the roundtrip."""
+    data = [Point(x=1, y=2), 42, "hello"]
+    key = ds.save(data)
+    loaded = ds.load(key)
+    assert loaded == data
+    assert type(loaded[0]) is Point
+
+
+def test_namedtuple_in_dict_roundtrip(ds):
+    """A namedtuple stored as a dict value round-trips correctly."""
+    data = {"point": Point(x=5, y=6), "other": 99}
+    key = ds.save(data)
+    loaded = ds.load(key)
+    assert loaded == data
+    assert type(loaded["point"]) is Point
+
+
+def test_namedtuple_nested_in_list_not_destructured(ds):
+    """Namedtuple nested inside a list is stored atomically (not broken apart)."""
+    p = Point(x=7, y=8)
+    data = [p, 1]
+    key = ds.save(data)
+    raw = ds.storage[key]
+    assert isinstance(raw, DigestedIterable)
+    # The namedtuple child should be stored separately as a Digest reference,
+    # but when retrieved it must still be a Point, not a plain tuple.
+    loaded = ds.load(key)
+    assert type(loaded[0]) is Point
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(namedtuples(st_base_values))
+def test_namedtuple_hypothesis_roundtrip(ds, nt):
+    """Hypothesis-generated namedtuples round-trip with their type preserved."""
+    key = ds.save(nt)
+    loaded = ds.load(key)
+    assert loaded == nt
+    assert type(loaded) is type(nt)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(namedtuples(st_base_values))
+def test_namedtuple_hypothesis_not_destructured(ds, nt):
+    """Hypothesis-generated namedtuples are never stored as DigestedIterable."""
+    key = ds.save(nt)
+    raw = ds.storage[key]
+    assert not isinstance(raw, DigestedIterable)
+    assert type(raw) is type(nt)
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(namedtuples(st_base_values))
+def test_namedtuple_save_is_deterministic(ds, nt):
+    """Saving the same namedtuple twice yields the same key."""
+    assert ds.save(nt) == ds.save(nt)


### PR DESCRIPTION
namedtuples are not real tuples, because they change __new__ such that it expects each value as a separate arg, rather than tuple's __init__ that accepts the full iterable.  Because they are by type subclasses of tuple, however, _rec_intern let's them into the DestructuringMixin garden.
DigestedIterable.mend is then hit by the colletaral when it cannot reinstantiate the namedtuple.
Because namedtuples are also have not common ancestor and are just a lose collection of sub types of tuple that happen to do subclass in the same way, there's not real way to check subtype relationship here. I follow an empiric approach here and check for some attributes. While I could apply this check in DigestedIterable.mend and special case the reconstruction, I am hurt now and I don't want to play with namedtuple anymore until it apologizes.

Fixes #298 