### PR TITLE
Add BoundWrapper to public API, executor tests, and notebook docs

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -3,118 +3,95 @@ Parallel Execution
 
 Fleche-decorated functions work with Python's ``concurrent.futures`` executors
 and other process-/thread-based parallelism libraries.  This page explains the
-interaction between fleche's context-variable state and the different executor
-models, and shows recommended patterns for each.
+recommended patterns for each executor type.
 
 .. contents:: On this page
    :local:
    :depth: 2
 
-Background: How Fleche Tracks State
-------------------------------------
-
-Fleche stores the active cache and metadata in Python
-:mod:`contextvars` — specifically two ``ContextVar`` instances for the cache
-and for metadata.  Context managers like ``fleche.cache(...)`` and
-``fleche.meta(...)`` set these variables for the current context.
-
-This design is inherently **thread-safe**: each logical execution context gets
-its own value.  However, whether a new thread or process *inherits* the
-parent's context depends on how it is spawned.
-
 ThreadPoolExecutor
 ------------------
 
-Threads spawned by :class:`concurrent.futures.ThreadPoolExecutor` do **not**
-automatically inherit ``ContextVar`` values from the submitting thread.  A
-fleche-decorated function submitted to a thread pool will therefore see the
-*default* cache rather than one set via ``with fleche.cache(...)``.
-
-Propagating context explicitly
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Use :func:`contextvars.copy_context` to snapshot the current context and
-``ctx.run()`` to execute the function inside that snapshot:
+Use :class:`~fleche.BoundWrapper` with a ``with cache(...)`` block.
+``BoundWrapper.bind(func)`` captures the active cache at bind time and
+restores it on every call — including inside worker threads — so all tasks
+write to the same store:
 
 .. code-block:: python
 
-   import contextvars
    import concurrent.futures
    import fleche
+   from fleche import BoundWrapper
    from fleche.caches import Cache
-   from fleche.storage import Memory
+   from fleche.storage.memory import ValueMemory, CallMemory
 
    @fleche.fleche
    def compute(x):
        return x ** 2
 
-   my_cache = Cache(Memory({}), Memory({}))
+   my_cache = Cache(ValueMemory({}), CallMemory({}))
 
    with fleche.cache(my_cache):
-       ctx = contextvars.copy_context()
        with concurrent.futures.ThreadPoolExecutor() as executor:
-           future = executor.submit(ctx.run, compute, 42)
-           result = future.result()  # 1764, cached in my_cache
+           futures = [executor.submit(BoundWrapper.bind(compute), i) for i in range(4)]
+           results = [f.result() for f in futures]  # all cached in my_cache
 
-Results are written to ``my_cache`` because the worker thread runs inside the
-copied context.
+Passing a bound function around
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. tip::
+Because :class:`~fleche.BoundWrapper` is a regular picklable callable, you can
+bind it once and pass it anywhere — to multiple executor pools, helper modules,
+or across function calls.  The captured state travels with the callable:
 
-   If you submit many tasks, create **one** context snapshot and reuse it for
-   every ``submit`` call — the snapshot is a lightweight, read-copy-on-write
-   object.
+.. code-block:: python
+
+   with fleche.cache(my_cache):
+       bound_compute = BoundWrapper.bind(compute)   # bind once
+
+   # bound_compute carries my_cache — no cache context manager needed at the call site
+   with concurrent.futures.ThreadPoolExecutor() as executor:
+       futures = [executor.submit(bound_compute, i) for i in range(4)]
+       results = [f.result() for f in futures]
 
 ProcessPoolExecutor
 -------------------
 
 Worker processes are independent OS processes with their own Python
-interpreter.  ``ContextVar`` values set in the parent are **never** visible in
-workers — they always start from the default.
-
-In-memory caches are therefore **not shared** across processes.  A result
+interpreter.  In-memory caches are **not shared** across processes — a result
 computed in a worker is stored in the worker's own ephemeral cache and is lost
 when the worker exits.
 
-Using file- or SQL-backed storage
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To share cached results between the parent and worker processes, point both
-sides at the same **file-** or **SQL-backed** storage:
+To share cached results, point both the parent and workers at the same
+**file-** or **SQL-backed** storage.  ``BoundWrapper.bind(func)`` embeds the
+cache configuration into the callable so no manual worker-wrapper function is
+needed:
 
 .. code-block:: python
 
    import concurrent.futures
+   import tempfile, os
    import fleche
+   from fleche import BoundWrapper
    from fleche.caches import Cache
-   from fleche.storage.pickle_file import PickleFile
+   from fleche.storage.pickle_file import ValuePickleFile, CallPickleFile
 
    @fleche.fleche
    def heavy_computation(x):
        return x ** 3
 
-   def worker(x, values_dir, calls_dir):
-       """Each worker sets up a cache pointing at the shared directory."""
-       values = PickleFile.with_pickle(root=values_dir)
-       calls  = PickleFile.with_pickle(root=calls_dir)
-       with fleche.cache(Cache(values, calls)):
-           return heavy_computation(x)
+   with tempfile.TemporaryDirectory() as tmpdir:
+       file_cache = Cache(
+           ValuePickleFile.with_pickle(root=os.path.join(tmpdir, "values")),
+           CallPickleFile.with_pickle(root=os.path.join(tmpdir, "calls")),
+       )
 
-   # Shared directories (could also be SQL connection strings)
-   values_dir = "/tmp/fleche_values"
-   calls_dir  = "/tmp/fleche_calls"
+       with fleche.cache(file_cache):
+           with concurrent.futures.ProcessPoolExecutor() as executor:
+               futures = [executor.submit(BoundWrapper.bind(heavy_computation), i)
+                          for i in range(8)]
+               results = [f.result() for f in futures]
 
-   with concurrent.futures.ProcessPoolExecutor() as executor:
-       futures = [executor.submit(worker, i, values_dir, calls_dir)
-                  for i in range(8)]
-       results = [f.result() for f in futures]
-
-   # Parent can now read the cached results
-   parent_cache = Cache(
-       PickleFile.with_pickle(root=values_dir),
-       PickleFile.with_pickle(root=calls_dir),
-   )
-   assert parent_cache.contains(heavy_computation.digest(3))
+       assert file_cache.contains(heavy_computation.digest(3))
 
 Fleche's file-based storage uses lock files to coordinate concurrent writes, so
 multiple workers can safely write to the same directory.
@@ -133,34 +110,9 @@ multiple workers can safely write to the same directory.
 BoundWrapper — Freezing State for Workers
 -----------------------------------------
 
-:class:`fleche.state.BoundWrapper` captures the current cache and metadata into
+:class:`fleche.BoundWrapper` captures the current cache and metadata into
 a picklable callable, so workers automatically use the correct state without
-manual setup:
-
-.. code-block:: python
-
-   import concurrent.futures
-   from fleche.state import BoundWrapper
-   from fleche.caches import Cache
-   from fleche.storage import Memory
-   import fleche
-
-   @fleche.fleche
-   def predict(x):
-       return x * 2
-
-   file_cache = Cache(Memory({}), Memory({}))
-
-   with fleche.cache(file_cache):
-       bound_predict = BoundWrapper.bind(predict)
-
-   with concurrent.futures.ProcessPoolExecutor() as executor:
-       futures = [executor.submit(bound_predict, i) for i in range(4)]
-       results = [f.result() for f in futures]
-
-``BoundWrapper.bind(func)`` snapshots the active cache and metadata at bind
-time.  When called — even in a different process after pickling — the bound
-wrapper restores that state before invoking the function.
+manual setup.
 
 This also works for **plain functions that call fleche-decorated functions
 internally**: the bound state propagates to all nested fleche calls.
@@ -192,19 +144,17 @@ follow the same ``concurrent.futures`` interface but manage HPC resources
 processes, the same rules as ``ProcessPoolExecutor`` apply:
 
 - In-memory caches are **not** shared with workers.
-- Use **file-** or **SQL-backed** storage and set it up explicitly in each
-  worker, or use :class:`~fleche.state.BoundWrapper` with a file-backed cache.
+- Use **file-** or **SQL-backed** storage with :class:`~fleche.BoundWrapper`.
 
 .. code-block:: python
 
    from executorlib import SingleNodeExecutor
 
    with fleche.cache(file_cache):
-       bound = BoundWrapper.bind(heavy_computation)
-
-   with SingleNodeExecutor() as executor:
-       future = executor.submit(bound, 42)
-       result = future.result()
+       with SingleNodeExecutor() as executor:
+           futures = [executor.submit(BoundWrapper.bind(heavy_computation), i)
+                      for i in range(4)]
+           results = [f.result() for f in futures]
 
 The ``isolate`` Flag
 --------------------
@@ -235,12 +185,12 @@ Quick Reference
    * - ``ThreadPoolExecutor``
      - Yes
      - No (manual)
-     - ``ctx.run()`` with ``copy_context()``
+     - ``BoundWrapper.bind(func)``
    * - ``ProcessPoolExecutor``
      - Yes
      - No (separate process)
-     - File/SQL storage or ``BoundWrapper``
+     - File/SQL storage + ``BoundWrapper``
    * - ``executorlib.SingleNodeExecutor``
      - Yes
      - No (separate process)
-     - File/SQL storage or ``BoundWrapper``
+     - File/SQL storage + ``BoundWrapper``

--- a/notebooks/ConcurrentExecution.ipynb
+++ b/notebooks/ConcurrentExecution.ipynb
@@ -10,300 +10,68 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import time\nimport contextvars\nfrom concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor\n\nfrom fleche import fleche, cache, BoundWrapper\nfrom fleche.caches import Cache\nfrom fleche.storage.memory import Memory"
+   "source": "import time\nimport tempfile\nimport os\nfrom concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor\n\nfrom fleche import fleche, cache, BoundWrapper\nfrom fleche.caches import Cache\nfrom fleche.storage.memory import ValueMemory, CallMemory\nfrom fleche.storage.pickle_file import ValuePickleFile, CallPickleFile"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## 1. ThreadPoolExecutor\n",
-    "\n",
-    "### The problem: threads don't inherit the cache context by default\n",
-    "\n",
-    "Python threads each start with a *copy* of the context that existed when `ThreadPoolExecutor` was created, not a live reference to the calling thread's context. This means that if you set a cache inside the main thread and submit work to a pool, the workers won't see it."
-   ]
+   "source": "## 1. ThreadPoolExecutor\n\n`BoundWrapper.bind(func)` captures the active cache at bind time and restores it on every call — including inside worker threads. Use it directly inside a `with cache(...):` block to ensure all submitted tasks write to the same store:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "@fleche\n",
-    "def add(x, y):\n",
-    "    return x + y"
-   ]
+   "source": "@fleche\ndef add(x, y):\n    return x + y"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "mem = Memory({})\n",
-    "my_cache = Cache(mem, mem)\n",
-    "\n",
-    "with cache(my_cache):\n",
-    "    with ThreadPoolExecutor(max_workers=2) as pool:\n",
-    "        pool.submit(add, 1, 2).result()\n",
-    "\n",
-    "# The result was NOT stored in my_cache — the thread used the default cache\n",
-    "print(\"In my_cache:\", my_cache.contains(add.digest(1, 2)))  # False"
-   ]
+   "source": "my_cache = Cache(ValueMemory({}), CallMemory({}))\n\nwith cache(my_cache):\n    with ThreadPoolExecutor(max_workers=2) as pool:\n        futures = [pool.submit(BoundWrapper.bind(add), x, x + 1) for x in range(4)]\n        results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                          # [1, 3, 5, 7]\nprint(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### The fix: propagate context explicitly with `ctx.run`\n",
-    "\n",
-    "Capture the current context with `contextvars.copy_context()` and wrap the call in `ctx.run(...)`. This hands the *exact same context object* to the thread, so the `cache(...)` context manager is visible inside the worker."
-   ]
+   "source": "### Passing a bound function around\n\nBecause the bound callable is a regular Python object, you can bind it once and pass it to other modules, helper functions, or executor pools without re-specifying the cache. The captured state travels with the callable:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "mem = Memory({})\n",
-    "my_cache = Cache(mem, mem)\n",
-    "\n",
-    "with cache(my_cache):\n",
-    "    ctx = contextvars.copy_context()          # snapshot the current context\n",
-    "    with ThreadPoolExecutor(max_workers=2) as pool:\n",
-    "        futures = [\n",
-    "            pool.submit(ctx.run, add, x, x + 1)  # ctx.run propagates the context\n",
-    "            for x in range(4)\n",
-    "        ]\n",
-    "        results = [f.result() for f in futures]\n",
-    "\n",
-    "print(\"Results:\", results)                       # [1, 3, 5, 7]\n",
-    "print(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a9943dcc",
-   "source": "### Alternative: `BoundWrapper.bind`\n\n`BoundWrapper.bind(func)` captures the active cache at bind time. The resulting callable\nrestores that cache on every call — no `ctx.run` is required at the call site. This is\nparticularly convenient when you want to pass a pre-configured callable around without\nthreading a context object alongside it.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "91907f3d",
-   "source": "mem = Memory({})\nmy_cache = Cache(mem, mem)\n\nwith cache(my_cache):\n    bound_add = BoundWrapper.bind(add)   # capture cache context at bind time\n\n# bound_add always uses my_cache — no ctx.run needed at the call site\nwith ThreadPoolExecutor(max_workers=2) as pool:\n    futures = [pool.submit(bound_add, x, x + 1) for x in range(4)]\n    results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                          # [1, 3, 5, 7]\nprint(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "source": "my_cache = Cache(ValueMemory({}), CallMemory({}))\n\nwith cache(my_cache):\n    bound_add = BoundWrapper.bind(add)   # bind once, reuse anywhere\n\n# bound_add carries my_cache — the cache context manager is no longer needed at the call site\nwith ThreadPoolExecutor(max_workers=2) as pool:\n    futures = [pool.submit(bound_add, x, x + 1) for x in range(4)]\n    results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                          # [1, 3, 5, 7]\nprint(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Shared cache across all threads\n",
-    "\n",
-    "Because all workers run inside the same context, they share the same in-memory store. Results computed by one thread are immediately visible to every other thread in the pool."
-   ]
+   "source": "---\n## 2. ProcessPoolExecutor\n\nWorker processes run in separate Python interpreters — an in-memory cache set in the parent is **not visible** inside workers. Use a **file-** or **SQL-backed** backend so that results written by workers are visible to the parent process."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "@fleche\n",
-    "def slow_square(x):\n",
-    "    time.sleep(0.1)   # simulate work\n",
-    "    return x * x\n",
-    "\n",
-    "mem = Memory({})\n",
-    "my_cache = Cache(mem, mem)\n",
-    "\n",
-    "# First batch — computes and caches\n",
-    "with cache(my_cache):\n",
-    "    ctx = contextvars.copy_context()\n",
-    "    with ThreadPoolExecutor(max_workers=4) as pool:\n",
-    "        list(pool.map(lambda x: ctx.run(slow_square, x), range(5)))\n",
-    "\n",
-    "# Second batch — everything hits the cache (no sleep)\n",
-    "start = time.time()\n",
-    "with cache(my_cache):\n",
-    "    ctx = contextvars.copy_context()\n",
-    "    with ThreadPoolExecutor(max_workers=4) as pool:\n",
-    "        results = list(pool.map(lambda x: ctx.run(slow_square, x), range(5)))\n",
-    "\n",
-    "elapsed = time.time() - start\n",
-    "print(f\"Results: {results}\")\n",
-    "print(f\"Second batch took {elapsed:.3f}s (cache hits — no sleep)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## 2. ProcessPoolExecutor\n",
-    "\n",
-    "### Why `ctx.run` doesn't work across processes\n",
-    "\n",
-    "With `ProcessPoolExecutor`, every argument passed to a worker must be serialised with `pickle` and sent to a new Python interpreter. `contextvars.Context` objects **cannot be pickled**, so the threadpool trick is not available:\n",
-    "\n",
-    "```python\n",
-    "# ❌ This raises: TypeError: cannot pickle 'Context' object\n",
-    "ctx = contextvars.copy_context()\n",
-    "executor.submit(ctx.run, add, 1, 2)\n",
-    "```\n",
-    "\n",
-    "The good news: `@fleche`-decorated functions *are* picklable (they are module-level names), so you can pass them as worker targets without any issues."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### The pattern: set up cache inside the worker\n",
-    "\n",
-    "Each worker process starts with a fresh Python interpreter that has no cache configured. The simplest fix is to wrap your cached call inside a thin helper that creates the cache context *after* the process has spawned."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Worker functions must be defined at module level to be picklable\n",
-    "\n",
-    "@fleche\n",
-    "def expensive(x):\n",
-    "    return x ** 3\n",
-    "\n",
-    "def _worker(x):\n",
-    "    \"\"\"Thin wrapper that sets up a cache before calling the real function.\"\"\"\n",
-    "    with cache(Cache(Memory({}), Memory({}))):\n",
-    "        return expensive(x)\n",
-    "\n",
-    "\n",
-    "with ProcessPoolExecutor(max_workers=2) as pool:\n",
-    "    results = list(pool.map(_worker, range(5)))\n",
-    "\n",
-    "print(\"Results:\", results)   # [0, 1, 8, 27, 64]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Sharing a persistent cache across processes\n",
-    "\n",
-    "With in-memory storage each worker gets its own isolated cache. To share results between processes you need a **picklable, on-disk backend** (e.g. file-based storage). Pass the cache object as an argument and re-register it inside the worker:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tempfile, os\n",
-    "from fleche.storage.file import PickleFileStorage\n",
-    "\n",
-    "tmpdir = tempfile.mkdtemp()\n",
-    "shared_cache = Cache(\n",
-    "    PickleFileStorage(os.path.join(tmpdir, \"meta\")),\n",
-    "    PickleFileStorage(os.path.join(tmpdir, \"results\")),\n",
-    ")\n",
-    "\n",
-    "def _worker_shared(x, worker_cache):\n",
-    "    with cache(worker_cache):     # re-register the pickled cache object\n",
-    "        return expensive(x)\n",
-    "\n",
-    "\n",
-    "# First run — computes and persists to disk\n",
-    "with ProcessPoolExecutor(max_workers=2) as pool:\n",
-    "    futures = [pool.submit(_worker_shared, x, shared_cache) for x in range(5)]\n",
-    "    results = [f.result() for f in futures]\n",
-    "\n",
-    "print(\"Results:\", results)\n",
-    "\n",
-    "# Verify results are in the shared cache\n",
-    "print(\"Cached:\", shared_cache.contains(expensive.digest(3)))   # True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "480c2239",
-   "source": "### Cleaner pattern: `BoundWrapper.bind`\n\nInstead of writing a separate worker wrapper function and passing directory paths as arguments,\nuse `BoundWrapper.bind(func)`. It embeds the cache configuration into the callable — the worker\nreceives the bound callable and automatically uses the correct cache.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "0048430d",
-   "source": "with tempfile.TemporaryDirectory() as tmpdir:\n    shared_cache = Cache(\n        PickleFileStorage(os.path.join(tmpdir, \"meta\")),\n        PickleFileStorage(os.path.join(tmpdir, \"results\")),\n    )\n\n    with cache(shared_cache):\n        bound_expensive = BoundWrapper.bind(expensive)   # carry the cache config\n\n    # No separate wrapper function needed — submit bound_expensive directly\n    with ProcessPoolExecutor(max_workers=2) as pool:\n        results = list(pool.map(bound_expensive, range(5)))\n\nprint(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\nprint(\"Cached:\", shared_cache.contains(expensive.digest(3)))   # True",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "source": "@fleche\ndef expensive(x):\n    return x ** 3\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    shared_cache = Cache(\n        ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n        CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n    )\n\n    with cache(shared_cache):\n        with ProcessPoolExecutor(max_workers=2) as pool:\n            results = list(pool.map(BoundWrapper.bind(expensive), range(5)))\n\n    print(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\n    print(\"Cached:\", shared_cache.contains(expensive.digest(3)))   # True"
   },
   {
    "cell_type": "markdown",
    "id": "ky1m64wquxm",
-   "source": "---\n## 3. executorlib.SingleNodeExecutor\n\n[executorlib](https://github.com/pyiron/executorlib) is a third-party library for submitting tasks to HPC schedulers and local process pools. Its `SingleNodeExecutor` uses *process-based* workers with the same isolation semantics as `ProcessPoolExecutor`.\n\n> **Note:** `executorlib` is an optional dependency. Install it with `pip install executorlib`.\n\n`@fleche`-decorated functions are picklable (they are module-level names), so they can be submitted to `SingleNodeExecutor` directly:",
-   "metadata": {}
+   "metadata": {},
+   "source": "---\n## 3. executorlib.SingleNodeExecutor\n\n[executorlib](https://github.com/pyiron/executorlib) is a third-party library for submitting tasks to HPC schedulers and local process pools. Its `SingleNodeExecutor` uses *process-based* workers with the same isolation semantics as `ProcessPoolExecutor`.\n\n> **Note:** `executorlib` is an optional dependency. Install it with `pip install executorlib`.\n\nUse a **file-backed** cache with `BoundWrapper.bind` so that results written by workers are visible to the parent process:"
   },
   {
    "cell_type": "code",
-   "id": "p643mxgcnj",
-   "source": "from executorlib import SingleNodeExecutor\n\n@fleche\ndef cube_sne(x):\n    return x ** 3\n\nwith SingleNodeExecutor() as executor:\n    future = executor.submit(cube_sne, 4)\n    result = future.result()\n\nprint(\"Result:\", result)  # 64",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ibdhi1bkf4j",
-   "source": "### In-memory cache is not propagated\n\nLike `ProcessPoolExecutor`, `SingleNodeExecutor` spawns worker processes with fresh Python interpreters. An in-memory cache set in the parent is **not visible** inside the worker — results computed there are stored in the worker's own ephemeral cache and are lost when the process exits.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "yuggrvxrhz",
-   "source": "mem = Memory({})\nmy_cache = Cache(mem, mem)\n\nwith cache(my_cache):\n    with SingleNodeExecutor() as executor:\n        future = executor.submit(cube_sne, 5)\n        result = future.result()\n\nprint(\"Result:\", result)                                # 125\nprint(\"In my_cache:\", my_cache.contains(cube_sne.digest(5)))  # False — worker results don't reach the parent",
    "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "l4oilpkkx3h",
-   "source": "### Sharing results with file-backed storage\n\nTo persist results across processes, use a **file-backed storage backend** and point the worker at the same on-disk directory. The worker sets up a fresh `Cache` around the file-backed store; results written to disk are immediately visible to any process that reads from the same path.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "vzfsqge5ltp",
-   "source": "def _sne_worker_shared(x, values_dir, calls_dir):\n    \"\"\"Worker that wires up a shared file-backed cache then calls the fleche function.\"\"\"\n    worker_cache = Cache(\n        PickleFileStorage(os.path.join(values_dir)),\n        PickleFileStorage(os.path.join(calls_dir)),\n    )\n    with cache(worker_cache):\n        return cube_sne(x)\n\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    values_dir = os.path.join(tmpdir, \"values\")\n    calls_dir  = os.path.join(tmpdir, \"calls\")\n\n    parent_cache = Cache(\n        PickleFileStorage(values_dir),\n        PickleFileStorage(calls_dir),\n    )\n\n    with SingleNodeExecutor() as executor:\n        futures = [executor.submit(_sne_worker_shared, x, values_dir, calls_dir) for x in range(5)]\n        results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\nprint(\"In parent_cache:\", parent_cache.contains(cube_sne.digest(3)))  # True",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3545a1a9",
-   "source": "### Cleaner pattern: `BoundWrapper.bind`\n\nInstead of writing a separate worker function that recreates the cache from directory arguments,\nuse `BoundWrapper.bind(func)`. It embeds the cache configuration into the callable itself —\nno extra arguments need to be threaded through to the worker.",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "f1aaa1ea",
-   "source": "with tempfile.TemporaryDirectory() as tmpdir:\n    values_dir = os.path.join(tmpdir, \"values\")\n    calls_dir  = os.path.join(tmpdir, \"calls\")\n\n    parent_cache = Cache(\n        PickleFileStorage(values_dir),\n        PickleFileStorage(calls_dir),\n    )\n\n    with cache(parent_cache):\n        bound_cube = BoundWrapper.bind(cube_sne)   # carry the cache config\n\n    # No separate wrapper function needed — submit bound_cube directly\n    with SingleNodeExecutor() as executor:\n        futures = [executor.submit(bound_cube, x) for x in range(5)]\n        results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                                          # [0, 1, 8, 27, 64]\nprint(\"In parent_cache:\", parent_cache.contains(cube_sne.digest(3)))  # True",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "source": "from executorlib import SingleNodeExecutor\n\n@fleche\ndef cube_sne(x):\n    return x ** 3\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    shared_cache = Cache(\n        ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n        CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n    )\n\n    with cache(shared_cache):\n        with SingleNodeExecutor() as executor:\n            futures = [executor.submit(BoundWrapper.bind(cube_sne), x) for x in range(5)]\n            results = [f.result() for f in futures]\n\n    print(\"Results:\", results)                                          # [0, 1, 8, 27, 64]\n    print(\"In shared_cache:\", shared_cache.contains(cube_sne.digest(3)))  # True"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Summary\n\n```\nThreadPoolExecutor\n  Default (no propagation)          →  workers use the default cache, NOT your custom one ❌\n  With ctx.run                       →  workers share the same cache as the main thread ✅\n  With BoundWrapper.bind(func)       →  same effect, no ctx.run needed at call site ✅\n\nProcessPoolExecutor\n  In-memory cache (parent-side)      →  isolated per-worker caching, parent cannot read results ❌\n  File-backed + BoundWrapper.bind()  →  shared persistent cache, no wrapper function needed ✅\n  ctx.run                            →  not possible (Context not picklable) ❌\n\nexecutorlib.SingleNodeExecutor\n  In-memory cache (parent-side)      →  not visible in worker processes ❌\n  File-backed + BoundWrapper.bind()  →  worker results visible to parent ✅\n  ctx.run                            →  not possible (process-based) ❌\n```\n\n**Storage reference**\n\n| Backend | Cross-process sharing |\n|---|---|\n| `Memory` | ❌ Ephemeral — process-local only |\n| `PickleFile` | ✅ Persistent — shared via filesystem |\n| `Sql` | ✅ Persistent — shared via database |\n| `BagOfHolding` | ✅ Persistent — shared via HDF5 file |"
+   "source": "### Summary\n\n```\nThreadPoolExecutor\n  with cache(...): with ThreadPoolExecutor() as pool:\n    pool.submit(BoundWrapper.bind(func), ...)     ✅ workers share the same cache\n\nProcessPoolExecutor / executorlib.SingleNodeExecutor\n  In-memory cache                               ❌ not visible in worker processes\n  File/SQL cache + BoundWrapper.bind(func)      ✅ worker results visible to parent\n```\n\n**Storage reference**\n\n| Backend | Cross-process sharing |\n|---|---|\n| `Memory` | ❌ Ephemeral — process-local only |\n| `PickleFile` | ✅ Persistent — shared via filesystem |\n| `Sql` | ✅ Persistent — shared via database |\n| `BagOfHolding` | ✅ Persistent — shared via HDF5 file |"
   }
  ],
  "metadata": {

--- a/notebooks/ConcurrentExecution.ipynb
+++ b/notebooks/ConcurrentExecution.ipynb
@@ -3,22 +3,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Concurrent Execution with Fleche\n\nThis notebook shows how to use `@fleche`-decorated functions with Python's three executor types:\n\n| Executor | Cache context propagation | How |\n|---|---|---|\n| `ThreadPoolExecutor` | ✅ Yes (with one trick) | `contextvars.copy_context().run` |\n| `ProcessPoolExecutor` | ⚠️ Manual setup required | File-backed storage + re-create cache inside each worker |\n| `SingleNodeExecutor` (executorlib) | ⚠️ Manual setup required | File-backed storage + re-create cache in worker |"
+   "source": "# Concurrent Execution with Fleche\n\nThis notebook shows how to use `@fleche`-decorated functions with Python's three executor types.\n\n`BoundWrapper.bind(func)` is the recommended pattern for sharing cache state across workers: it captures the active cache and metadata at bind time and restores them on every subsequent call — even in subprocesses — without requiring a hand-written wrapper function.\n\n| Executor | Required storage | Recommended pattern |\n|---|---|---|\n| `ThreadPoolExecutor` | Any (Memory or file) | `BoundWrapper.bind(func)` |\n| `ProcessPoolExecutor` | **Persistent** (file / SQL) | `BoundWrapper.bind(func)` |\n| `SingleNodeExecutor` (executorlib) | **Persistent** (file / SQL) | `BoundWrapper.bind(func)` |"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import time\n",
-    "import contextvars\n",
-    "from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor\n",
-    "\n",
-    "from fleche import fleche, cache\n",
-    "from fleche.caches import Cache\n",
-    "from fleche.storage.memory import Memory"
-   ]
+   "source": "import time\nimport contextvars\nfrom concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor\n\nfrom fleche import fleche, cache, BoundWrapper\nfrom fleche.caches import Cache\nfrom fleche.storage.memory import Memory"
   },
   {
    "cell_type": "markdown",
@@ -89,6 +81,20 @@
     "print(\"Results:\", results)                       # [1, 3, 5, 7]\n",
     "print(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9943dcc",
+   "source": "### Alternative: `BoundWrapper.bind`\n\n`BoundWrapper.bind(func)` captures the active cache at bind time. The resulting callable\nrestores that cache on every call — no `ctx.run` is required at the call site. This is\nparticularly convenient when you want to pass a pre-configured callable around without\nthreading a context object alongside it.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "91907f3d",
+   "source": "mem = Memory({})\nmy_cache = Cache(mem, mem)\n\nwith cache(my_cache):\n    bound_add = BoundWrapper.bind(add)   # capture cache context at bind time\n\n# bound_add always uses my_cache — no ctx.run needed at the call site\nwith ThreadPoolExecutor(max_workers=2) as pool:\n    futures = [pool.submit(bound_add, x, x + 1) for x in range(4)]\n    results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                          # [1, 3, 5, 7]\nprint(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -226,6 +232,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "480c2239",
+   "source": "### Cleaner pattern: `BoundWrapper.bind`\n\nInstead of writing a separate worker wrapper function and passing directory paths as arguments,\nuse `BoundWrapper.bind(func)`. It embeds the cache configuration into the callable — the worker\nreceives the bound callable and automatically uses the correct cache.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "0048430d",
+   "source": "with tempfile.TemporaryDirectory() as tmpdir:\n    shared_cache = Cache(\n        PickleFileStorage(os.path.join(tmpdir, \"meta\")),\n        PickleFileStorage(os.path.join(tmpdir, \"results\")),\n    )\n\n    with cache(shared_cache):\n        bound_expensive = BoundWrapper.bind(expensive)   # carry the cache config\n\n    # No separate wrapper function needed — submit bound_expensive directly\n    with ProcessPoolExecutor(max_workers=2) as pool:\n        results = list(pool.map(bound_expensive, range(5)))\n\nprint(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\nprint(\"Cached:\", shared_cache.contains(expensive.digest(3)))   # True",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "ky1m64wquxm",
    "source": "---\n## 3. executorlib.SingleNodeExecutor\n\n[executorlib](https://github.com/pyiron/executorlib) is a third-party library for submitting tasks to HPC schedulers and local process pools. Its `SingleNodeExecutor` uses *process-based* workers with the same isolation semantics as `ProcessPoolExecutor`.\n\n> **Note:** `executorlib` is an optional dependency. Install it with `pip install executorlib`.\n\n`@fleche`-decorated functions are picklable (they are module-level names), so they can be submitted to `SingleNodeExecutor` directly:",
    "metadata": {}
@@ -268,8 +288,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3545a1a9",
+   "source": "### Cleaner pattern: `BoundWrapper.bind`\n\nInstead of writing a separate worker function that recreates the cache from directory arguments,\nuse `BoundWrapper.bind(func)`. It embeds the cache configuration into the callable itself —\nno extra arguments need to be threaded through to the worker.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "f1aaa1ea",
+   "source": "with tempfile.TemporaryDirectory() as tmpdir:\n    values_dir = os.path.join(tmpdir, \"values\")\n    calls_dir  = os.path.join(tmpdir, \"calls\")\n\n    parent_cache = Cache(\n        PickleFileStorage(values_dir),\n        PickleFileStorage(calls_dir),\n    )\n\n    with cache(parent_cache):\n        bound_cube = BoundWrapper.bind(cube_sne)   # carry the cache config\n\n    # No separate wrapper function needed — submit bound_cube directly\n    with SingleNodeExecutor() as executor:\n        futures = [executor.submit(bound_cube, x) for x in range(5)]\n        results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                                          # [0, 1, 8, 27, 64]\nprint(\"In parent_cache:\", parent_cache.contains(cube_sne.digest(3)))  # True",
    "metadata": {},
-   "source": "### Summary\n\n```\nThreadPoolExecutor\n  Default (no ctx.run)  →  workers use the default cache, NOT your custom one\n  With ctx.run          →  workers share the same cache as the main thread ✅\n\nProcessPoolExecutor\n  Each worker creates its own fresh cache  →  isolated per-worker caching ✅\n  Pass a picklable cache as an argument   →  shared persistent cache ✅\n  ctx.run                                 →  not possible (Context not picklable) ❌\n\nexecutorlib.SingleNodeExecutor\n  In-memory cache (parent-side)           →  not visible in worker processes ❌\n  File-backed storage (shared directory)  →  worker results visible to parent ✅\n  ctx.run                                 →  not possible (process-based) ❌\n```"
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Summary\n\n```\nThreadPoolExecutor\n  Default (no propagation)          →  workers use the default cache, NOT your custom one ❌\n  With ctx.run                       →  workers share the same cache as the main thread ✅\n  With BoundWrapper.bind(func)       →  same effect, no ctx.run needed at call site ✅\n\nProcessPoolExecutor\n  In-memory cache (parent-side)      →  isolated per-worker caching, parent cannot read results ❌\n  File-backed + BoundWrapper.bind()  →  shared persistent cache, no wrapper function needed ✅\n  ctx.run                            →  not possible (Context not picklable) ❌\n\nexecutorlib.SingleNodeExecutor\n  In-memory cache (parent-side)      →  not visible in worker processes ❌\n  File-backed + BoundWrapper.bind()  →  worker results visible to parent ✅\n  ctx.run                            →  not possible (process-based) ❌\n```\n\n**Storage reference**\n\n| Backend | Cross-process sharing |\n|---|---|\n| `Memory` | ❌ Ephemeral — process-local only |\n| `PickleFile` | ✅ Persistent — shared via filesystem |\n| `Sql` | ✅ Persistent — shared via database |\n| `BagOfHolding` | ✅ Persistent — shared via HDF5 file |"
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ tests = [
     "ipykernel",
     "tabulate",
 ]
+executorlib = [
+    "executorlib",
+]

--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -11,6 +11,7 @@ from .state import (
         meta,
         tags,
         project,
+        BoundWrapper,
 )
 from .wrapper import fleche, Ignored, Required
 
@@ -49,6 +50,7 @@ __all__ = [
         "meta",
         "tags",
         "project",
+        "BoundWrapper",
         "Ignored",
         "Required",
         "D",

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -8,6 +8,10 @@ In Python, ContextVar values are NOT automatically inherited by threads spawned 
 ThreadPoolExecutor. The tests below document both the failure case and the workaround
 (explicit context propagation via ``contextvars.copy_context()``).
 
+``BoundWrapper.bind(func)`` is the recommended alternative: it captures the current cache
+and metadata state at bind time and restores it on each call, without requiring
+``ctx.run`` at the call site.
+
 Process-based execution (ProcessPoolExecutor / executorlib SingleNodeExecutor)
 -------------------------------------------------------------------------------
 Worker processes are spawned as independent subprocesses with a fresh Python interpreter.
@@ -18,9 +22,11 @@ completely invisible to workers.
   return correct results.
 * However, an in-memory cache set via ``fleche.cache(...)`` in the parent process
   is **not visible** in the worker; results are NOT stored in the parent's cache.
-* To share cached results across processes, use **file- or SQL-backed storage** and
-  pass the shared path to the worker explicitly (see
-  ``test_executorlib_file_backed_cache_shared``).
+* To share cached results across processes use **file- or SQL-backed storage**.
+  ``BoundWrapper.bind(func)`` (called while the file cache is active) embeds the cache
+  configuration into the callable itself, eliminating the need for a separate worker
+  wrapper function (see ``test_process_executor_bound_wrapper`` and
+  ``test_executorlib_bound_wrapper``).
 """
 
 import concurrent.futures
@@ -29,6 +35,7 @@ import tempfile
 import pytest
 
 import fleche
+from fleche import BoundWrapper
 from fleche.caches import Cache
 from fleche.storage.memory import ValueMemory, CallMemory
 from fleche.storage.pickle_file import ValuePickleFile, CallPickleFile
@@ -209,4 +216,90 @@ def test_executorlib_file_backed_cache_shared():
         assert parent_cache.contains(double.digest(21)), (
             "With file-backed storage, results written by the worker process are "
             "visible to the parent via the shared filesystem path."
+        )
+
+
+# ---------------------------------------------------------------------------
+# BoundWrapper tests
+# ---------------------------------------------------------------------------
+# BoundWrapper.bind(func) captures the active cache and metadata at bind time
+# and restores them on every call, even across process boundaries (provided the
+# cache backend is picklable, i.e. file- or SQL-backed).
+
+
+def test_threadpool_bound_wrapper():
+    """
+    BoundWrapper propagates the cache to ThreadPoolExecutor workers without
+    requiring ctx.run at the call site.
+    """
+    cache1 = Cache(ValueMemory({}), CallMemory({}))
+
+    with fleche.cache(cache1):
+        bound = BoundWrapper.bind(my_func)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(bound, 300)
+        future.result()
+
+    assert cache1.contains(my_func.digest(300)), (
+        "BoundWrapper restores the bound cache in the thread so the result is "
+        "stored in the parent's cache object."
+    )
+
+
+def test_process_executor_bound_wrapper():
+    """
+    BoundWrapper with a file-backed cache eliminates the need for a separate
+    worker wrapper function: the bound callable carries the cache configuration
+    and sets it up automatically in the worker process.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        values_dir = f"{tmpdir}/values"
+        calls_dir = f"{tmpdir}/calls"
+
+        file_cache = Cache(
+            ValuePickleFile.with_pickle(root=values_dir),
+            CallPickleFile.with_pickle(root=calls_dir),
+        )
+
+        with fleche.cache(file_cache):
+            bound = BoundWrapper.bind(double)
+
+        with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(bound, 21).result()
+
+        assert result == 42, f"Expected 42, got {result}"
+        assert file_cache.contains(double.digest(21)), (
+            "BoundWrapper carries the file-backed cache into the worker; results "
+            "written there are visible to the parent via the shared filesystem path."
+        )
+
+
+@_skip_no_executorlib
+def test_executorlib_bound_wrapper():
+    """
+    BoundWrapper with a file-backed cache works the same way with
+    executorlib.SingleNodeExecutor.
+    """
+    from executorlib import SingleNodeExecutor
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        values_dir = f"{tmpdir}/values"
+        calls_dir = f"{tmpdir}/calls"
+
+        file_cache = Cache(
+            ValuePickleFile.with_pickle(root=values_dir),
+            CallPickleFile.with_pickle(root=calls_dir),
+        )
+
+        with fleche.cache(file_cache):
+            bound = BoundWrapper.bind(double)
+
+        with SingleNodeExecutor() as executor:
+            result = executor.submit(bound, 21).result()
+
+        assert result == 42, f"Expected 42, got {result}"
+        assert file_cache.contains(double.digest(21)), (
+            "BoundWrapper carries the file-backed cache into the executorlib worker; "
+            "results are visible to the parent via the shared filesystem path."
         )


### PR DESCRIPTION
Update tests and docs matrix based on BoundWrapper.

- Export `BoundWrapper` from `fleche.__init__`
- Add BoundWrapper-based tests for all three executor types in `test_parallel_execution.py`
- Update `ConcurrentExecution.ipynb`: reworked intro matrix, added BoundWrapper cells in each executor section, updated summary with storage reference table
- Add `executorlib` optional dep group to `pyproject.toml`

Closes #206

Generated with [Claude Code](https://claude.ai/code)