### PR TITLE
Update StorageBackends notebook heading level

### DIFF
--- a/notebooks/StorageBackends.ipynb
+++ b/notebooks/StorageBackends.ipynb
@@ -201,11 +201,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Clean Up\n",
-    "\n",
-    "Remove temporary cache directories."
-   ]
+   "source": "## Clean Up\n\nRemove temporary cache directories."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
Updated the markdown heading in the StorageBackends notebook to use a consistent heading level.

## Changes
- Changed the "Clean Up" section heading from level 1 (`#`) to level 2 (`##`)
- Reformatted the markdown cell to use inline source string instead of array format

## Details
This change improves the notebook's heading hierarchy by making the "Clean Up" section a subsection rather than a top-level heading, which is more appropriate for a cleanup section at the end of the notebook. The reformatting of the source string is a stylistic adjustment that maintains the same content and rendering.

https://claude.ai/code/session_0146ccopdztzDFe24ad42cbK