### PR TITLE
docs(cache_stack): fix broken Memory import in example

### DIFF
--- a/docs/cache_stack.rst
+++ b/docs/cache_stack.rst
@@ -19,11 +19,11 @@ Example
 
     from fleche import fleche, cache
     from fleche.caches import Cache, CacheStack
-    from fleche.storage import Memory
+    from fleche.storage import ValueMemory, CallMemory
 
     # Define two caches
-    local_cache = Cache(Memory({}), Memory({}))
-    remote_cache = Cache(Memory({}), Memory({}))
+    local_cache = Cache(ValueMemory({}), CallMemory({}))
+    remote_cache = Cache(ValueMemory({}), CallMemory({}))
 
     @fleche
     def my_function(x):


### PR DESCRIPTION
## Problem

The code example in `docs/cache_stack.rst` does not run. It imports `Memory` from `fleche.storage`, but that class does not exist:

```python
from fleche.storage import Memory  # ImportError!
local_cache = Cache(Memory({}), Memory({}))  # never reached
```

Running the example as written raises:

```
ImportError: cannot import name 'Memory' from 'fleche.storage'
```

`fleche.storage` exports two separate classes for values and calls: `ValueMemory` and `CallMemory`.

## Fix

Replace the non-existent `Memory` import and its usages with the correct `ValueMemory` and `CallMemory` classes:

```python
from fleche.storage import ValueMemory, CallMemory
local_cache = Cache(ValueMemory({}), CallMemory({}))
remote_cache = Cache(ValueMemory({}), CallMemory({}))
```

The corrected example runs and produces the expected hit-transfer behavior.

https://claude.ai/code/session_018aGNXorwbjZfQ8nRChke8u