### PR TITLE
docs(custom_digests): fix entry point example — target must be an object, not a function

### DIFF
--- a/docs/custom_digests.rst
+++ b/docs/custom_digests.rst
@@ -49,23 +49,27 @@ You can register your digest hooks in the ``fleche`` entry point group with the 
 .. code-block:: toml
 
    [project.entry-points."fleche"]
-   digest = "my_package.hooks:get_hooks"
+   digest = "my_package.hooks:hooks"
 
-The entry point can point to:
+The entry point must resolve to one of:
+
 * A single ``fleche.digest.Hook`` object.
 * A tuple of ``(Type, Callable)``.
 * A list containing any combination of the above.
+
+These must be **module-level objects**, not callables that return hooks.
+``fleche`` loads the entry point with ``importlib.metadata.EntryPoint.load()``,
+which returns the object at the given path directly — it does **not** call it.
 
 .. code-block:: python
 
    # my_package/hooks.py
    from fleche.digest import Hook
 
-   def get_hooks():
-       return [
-           Hook(TypeA, digest_a),
-           (TypeB, digest_b),
-       ]
+   hooks = [
+       Hook(TypeA, digest_a),
+       (TypeB, digest_b),
+   ]
 
 Lazy Loading and Retries
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Problem

The "Registering Entry Points" section of `docs/custom_digests.rst` shows the entry point pointing to a **function** that *returns* hooks:

```toml
[project.entry-points."fleche"]
digest = "my_package.hooks:get_hooks"
```

```python
def get_hooks():
    return [Hook(TypeA, digest_a), (TypeB, digest_b)]
```

This is incorrect. `importlib.metadata.EntryPoint.load()` returns the **object at the given path directly** — it does not call it. So `ep.load()` returns the function `get_hooks` itself, not its return value.

Inside `load_entry_points()` the function object ends up being treated as a hook, and the code immediately fails with:

```
AttributeError: 'function' object has no attribute 'type'
```

## Fix

Change the example so the entry point resolves to a **module-level list** of hooks (or a single `Hook`/tuple), rather than a function that returns hooks. Add an explicit note explaining that the target must be a module-level object, not a callable.

```toml
[project.entry-points."fleche"]
digest = "my_package.hooks:hooks"   # points to the list directly
```

```python
hooks = [
    Hook(TypeA, digest_a),
    (TypeB, digest_b),
]
```

This matches the behaviour confirmed by the unit tests in `tests/unit/digest/test_entry_points.py`, where `mock_ep.load.return_value` is always set to a `Hook` instance or a list, never to a callable.

https://claude.ai/code/session_018aGNXorwbjZfQ8nRChke8u