### PR TITLE
docs(README): fix default storage description and remove invalid query(lazy=True)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,14 @@ def my_function(x):
 
 ## Storage Backends
 
-### File Storage (Default)
-- Stores cache in filesystem using pickle by default
-- XDG Base Directory Specification compliant
+### In-Memory Storage (Default)
+- Default when no `fleche.toml` configuration file is present
+- Transient: data is lost when the process exits
+
+### File Storage
+- Stores cache in filesystem using pickle (or cloudpickle/dill)
+- Persistent across runs
+- XDG Base Directory Specification compliant when configured
 
 ### SQL Storage
 - Requires `sqlalchemy`
@@ -164,13 +169,14 @@ def fetch_data(user_id, date):
 fetch_data(user_id=123, date='2024-01-01')
 
 # Get all cached results
-all_results = fetch_data.query()
+all_results = list(fetch_data.query())
 
-# Get results matching specific arguments
-results = fetch_data.query(user_id=123)
+# Get results matching specific arguments (None acts as wildcard)
+results = list(fetch_data.query(user_id=123))
 
-# Load results lazily
-results = fetch_data.query(lazy=True)
+# Inspect a result
+for call in fetch_data.query(user_id=123):
+    print(call.arguments, call.result)
 ```
 
 ## Performance


### PR DESCRIPTION
## Problems

Two independent bugs in `README.md`:

### 1. Wrong default storage description

The README stated:

> **File Storage (Default)** — Stores cache in filesystem using pickle by default

This is wrong. When no `fleche.toml` configuration file exists, `config.load_cache_config()` returns `Cache(ValueMemory({}), CallMemory({}))` — an **in-memory** cache, not a filesystem one. The process logs "No config file found. Using default memory cache." to confirm this.

### 2. Non-existent `lazy` parameter on `.query()`

The Querying Results example called:

```python
results = fetch_data.query(lazy=True)
```

The `.query()` helper (`_query_func` in `wrapper.py`) accepts `*args`, `metadata={}`, and `**kwargs`, where `kwargs` are matched against function parameters. There is no `lazy` parameter. Passing `lazy=True` is treated as a query filter for a function argument named `lazy`, not a loading hint — and raises `TypeError: got an unexpected keyword argument 'lazy'` if the wrapped function has no such argument.

## Fixes

1. Renamed "File Storage (Default)" → "In-Memory Storage (Default)" and added a note that it is transient. Kept "File Storage" as a separate entry describing persistent, configured use.
2. Replaced `query(lazy=True)` with a working iteration pattern and a note that `None` acts as a wildcard for unspecified arguments.

All corrected examples were verified to run without error.

https://claude.ai/code/session_018aGNXorwbjZfQ8nRChke8u