### PR TITLE
Fix required check to recognise positionally-supplied arguments (#297)

### DIFF
--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -6,6 +6,32 @@ from collections.abc import Mapping
 from . import digest
 
 
+def bind(func, args, kwargs, apply_defaults=False, partial=False):
+    """Thin wrapper around :meth:`inspect.Signature.bind` / :meth:`~inspect.Signature.bind_partial`.
+
+    Args:
+        func: The callable whose signature to bind against.
+        args: Positional arguments.
+        kwargs: Keyword arguments.
+        apply_defaults: If ``True``, fill in default values for parameters
+            that were not explicitly supplied.
+        partial: If ``True``, use :meth:`~inspect.Signature.bind_partial`,
+            which allows required arguments to be omitted (treated as wildcards).
+
+    Returns:
+        :attr:`inspect.BoundArguments.arguments` — an ``OrderedDict``
+        containing the supplied (and, when requested, defaulted) values.
+    """
+    sig = signature(func)
+    if partial:
+        bound = sig.bind_partial(*args, **kwargs)
+    else:
+        bound = sig.bind(*args, **kwargs)
+    if apply_defaults:
+        bound.apply_defaults()
+    return bound.arguments
+
+
 @dataclass
 class Call:
     """
@@ -25,13 +51,7 @@ class Call:
 
     @classmethod
     def from_call(cls, func, *args, **kwargs):
-        # Normalize arguments using function signature
-        sig = signature(func)
-        bound = sig.bind(*args, **kwargs)
-        bound.apply_defaults()
-        arguments = dict(bound.arguments)
-
-        # Preserve declared parameter order via bound.arguments (OrderedDict)
+        arguments = dict(bind(func, args, kwargs, apply_defaults=True))
         call = cls(func.__name__, arguments)
         if hasattr(func, "__version__"):
             call.version = func.__version__
@@ -183,12 +203,9 @@ class QueryCall:
 
     @classmethod
     def from_call(cls, func, *args, **kwargs):
-        # Normalize arguments using function signature
-        sig = signature(func)
-        bound = sig.bind_partial(*args, **kwargs)
-        # Do NOT apply defaults: unspecified arguments are treated as None (wildcard)
-        arguments = {name: bound.arguments.get(name) for name in sig.parameters}
-
+        bound_args = bind(func, args, kwargs, partial=True)
+        # Unspecified arguments default to None (wildcard)
+        arguments = {name: bound_args.get(name) for name in signature(func).parameters}
         call = cls(func.__name__, arguments)
         if hasattr(func, "__version__"):
             call.version = func.__version__
@@ -241,6 +258,7 @@ AnyCall = Call | LazyCall
 
 
 __all__ = [
+        "bind",
         "Call",
         "LazyCall",
         "QueryCall",

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -168,11 +168,6 @@ def fleche(
 
         ignored_args, required_args = process_ignore_required_args(func, ignore, require)
 
-        try:
-            sig = signature(func)
-        except (TypeError, ValueError):
-            sig = None
-
         @wraps(func)
         def get_call(*args, **kwargs):
             call = Call.from_call(func, *args, **kwargs)
@@ -289,7 +284,7 @@ def fleche(
                 logger.warning("No hash for argument: %s", e.args[0])
                 return func(*args, **kwargs)
 
-            if required_args and sig is not None:
+            if required_args:
                 explicit = set(bind(func, args, kwargs).keys())
                 missing = [r for r in required_args if r not in explicit]
                 if missing:

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -97,6 +97,17 @@ def process_ignore_required_args(
         require = tuple(require)
     required_args = require + tuple(type_required)
 
+    try:
+        sig = signature(func)
+        for r in required_args:
+            if r in sig.parameters and sig.parameters[r].kind == sig.parameters[r].POSITIONAL_ONLY:
+                logger.warning(
+                    "Argument '%s' is marked as Required but is positional-only. Required only works for keyword arguments.",
+                    r
+                )
+    except (TypeError, ValueError):
+        pass
+
     return ignored_args, required_args
 
 
@@ -279,11 +290,14 @@ def fleche(
                 return func(*args, **kwargs)
 
             if required_args and sig is not None:
-                # Use sig.bind without apply_defaults: only explicitly-provided arguments
-                # appear in bound.arguments, regardless of whether they were positional
-                # or keyword.  This fixes the bug where positional required args were
-                # incorrectly treated as missing.
-                explicit = set(sig.bind(*args, **kwargs).arguments.keys())
+                # Determine which required args were explicitly provided, without
+                # re-binding.  Positional args map to their parameter names by index;
+                # keyword args are in kwargs directly.
+                positional_params = [
+                    name for name, p in sig.parameters.items()
+                    if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+                ]
+                explicit = set(positional_params[:len(args)]) | set(kwargs.keys())
                 missing = [r for r in required_args if r not in explicit]
                 if missing:
                     logger.warning(

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from . import digest
 from . import state
 from . import metadata
-from .call import Call, AnyCall, QueryCall
+from .call import Call, AnyCall, QueryCall, bind
 from .caches import Rejected, BaseCache, RefreshingCache
 
 
@@ -290,14 +290,7 @@ def fleche(
                 return func(*args, **kwargs)
 
             if required_args and sig is not None:
-                # Determine which required args were explicitly provided, without
-                # re-binding.  Positional args map to their parameter names by index;
-                # keyword args are in kwargs directly.
-                positional_params = [
-                    name for name, p in sig.parameters.items()
-                    if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
-                ]
-                explicit = set(positional_params[:len(args)]) | set(kwargs.keys())
+                explicit = set(bind(func, args, kwargs).keys())
                 missing = [r for r in required_args if r not in explicit]
                 if missing:
                     logger.warning(

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -97,14 +97,6 @@ def process_ignore_required_args(
         require = tuple(require)
     required_args = require + tuple(type_required)
 
-    try:
-        sig = signature(func)
-        for r in required_args:
-            if r in sig.parameters and sig.parameters[r].kind == sig.parameters[r].POSITIONAL_ONLY:
-                logger.warning("Argument '%s' is marked as Required but is positional-only. Required only works for keyword arguments.", r)
-    except (TypeError, ValueError):
-        pass
-
     return ignored_args, required_args
 
 
@@ -164,6 +156,11 @@ def fleche(
             func.__version__ = version  # ty: ignore
 
         ignored_args, required_args = process_ignore_required_args(func, ignore, require)
+
+        try:
+            sig = signature(func)
+        except (TypeError, ValueError):
+            sig = None
 
         @wraps(func)
         def get_call(*args, **kwargs):
@@ -274,22 +271,30 @@ def fleche(
                 for k, v in kwargs.items()
             }
 
-            missing = [r for r in required_args if r not in kwargs]
-            if missing:
-                logger.warning(
-                    "Missing required keyword arguments for caching: %s", missing
-                )
-                return func(*args, **kwargs)
-
             try:
                 call = get_call(*args, **kwargs)
                 key = call.to_lookup_key()
-                result = cache.load(key).result
-                logger.debug("Cache hit for %s with key %s", call.name, key)
-                return result
             except digest.Unhashable as e:
                 logger.warning("No hash for argument: %s", e.args[0])
                 return func(*args, **kwargs)
+
+            if required_args and sig is not None:
+                # Use sig.bind without apply_defaults: only explicitly-provided arguments
+                # appear in bound.arguments, regardless of whether they were positional
+                # or keyword.  This fixes the bug where positional required args were
+                # incorrectly treated as missing.
+                explicit = set(sig.bind(*args, **kwargs).arguments.keys())
+                missing = [r for r in required_args if r not in explicit]
+                if missing:
+                    logger.warning(
+                        "Missing required keyword arguments for caching: %s", missing
+                    )
+                    return func(*args, **kwargs)
+
+            try:
+                result = cache.load(key).result
+                logger.debug("Cache hit for %s with key %s", call.name, key)
+                return result
             except KeyError:
                 logger.debug("Cache miss for %s with key %s", call.name, key)
 

--- a/tests/regression/test_issue_297.py
+++ b/tests/regression/test_issue_297.py
@@ -1,0 +1,47 @@
+"""Regression tests for issue #297: Required args supplied positionally were not recognised."""
+import logging
+import pytest
+from fleche.storage import memory
+from fleche.caches import Cache
+from fleche import fleche, Required
+import fleche.state as state
+
+
+@pytest.fixture
+def memory_cache():
+    values_storage = memory.ValueMemory(storage={})
+    calls_storage = memory.CallMemory(storage={})
+    cache = Cache(values=values_storage, calls=calls_storage)
+    token = state._CACHE.set(cache)
+    yield calls_storage
+    state._CACHE.reset(token)
+
+
+def test_required_default_positional_caches(memory_cache, caplog):
+    """Required arg with a default, when passed positionally, should cache (#297)."""
+    calls_storage = memory_cache
+
+    @fleche(require='seed')
+    def foo(base, seed=None):
+        return base + (seed or 0)
+
+    # seed not provided (uses default None) — should NOT cache
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        foo(1)
+        assert len(calls_storage.storage) == 0
+        assert "Missing required keyword arguments" in caplog.text
+
+    # seed provided positionally — should cache
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        foo(1, 42)
+        assert len(calls_storage.storage) == 1
+        assert "Missing required keyword arguments" not in caplog.text
+
+    # seed provided as keyword — should also cache
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        foo(1, seed=99)
+        assert len(calls_storage.storage) == 2
+        assert "Missing required keyword arguments" not in caplog.text

--- a/tests/unit/fleche/test_process_args.py
+++ b/tests/unit/fleche/test_process_args.py
@@ -40,16 +40,6 @@ def test_process_type_hints():
     assert "b" in required
 
 
-def test_process_positional_only_required_warning(caplog):
-    def func(a: Required, /):
-        pass
-
-    import logging
-
-    with caplog.at_level(logging.WARNING):
-        process_ignore_required_args(func)
-        assert "is marked as Required but is positional-only" in caplog.text
-
 
 def test_process_merge_hints_and_args():
     def func(a: Ignored, b: Required):

--- a/tests/unit/fleche/test_process_args.py
+++ b/tests/unit/fleche/test_process_args.py
@@ -40,6 +40,16 @@ def test_process_type_hints():
     assert "b" in required
 
 
+def test_process_positional_only_required_warning(caplog):
+    def func(a: Required, /):
+        pass
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        process_ignore_required_args(func)
+        assert "is marked as Required but is positional-only" in caplog.text
+
 
 def test_process_merge_hints_and_args():
     def func(a: Ignored, b: Required):

--- a/tests/unit/fleche/test_type_hints.py
+++ b/tests/unit/fleche/test_type_hints.py
@@ -94,35 +94,6 @@ def test_required_positional_caches(memory_cache, caplog):
         assert "Missing required keyword arguments" not in caplog.text
 
 
-def test_required_default_positional_caches(memory_cache, caplog):
-    """Required arg with a default, when passed positionally, should cache (#297)."""
-    calls_storage = memory_cache
-
-    @fleche(require='seed')
-    def foo(base, seed=None):
-        return base + (seed or 0)
-
-    # seed not provided (uses default None) — should NOT cache
-    caplog.clear()
-    with caplog.at_level(logging.WARNING):
-        foo(1)
-        assert len(calls_storage.storage) == 0
-        assert "Missing required keyword arguments" in caplog.text
-
-    # seed provided positionally — should cache
-    caplog.clear()
-    with caplog.at_level(logging.WARNING):
-        foo(1, 42)
-        assert len(calls_storage.storage) == 1
-        assert "Missing required keyword arguments" not in caplog.text
-
-    # seed provided as keyword — should also cache
-    caplog.clear()
-    with caplog.at_level(logging.WARNING):
-        foo(1, seed=99)
-        assert len(calls_storage.storage) == 2
-        assert "Missing required keyword arguments" not in caplog.text
-
 def test_combined_hints_and_args(memory_cache):
     calls_storage = memory_cache
 

--- a/tests/unit/fleche/test_type_hints.py
+++ b/tests/unit/fleche/test_type_hints.py
@@ -79,15 +79,8 @@ def test_ignored_hint_generic(memory_cache):
     # FIXME: how to get load count?
     # assert memory_cache.load_count >= 1
 
-def test_required_hint_positional_warning(memory_cache, caplog):
-    caplog.clear()
-    with caplog.at_level(logging.WARNING):
-        @fleche
-        def foo(a: Required, /):
-            return a
-        assert "is marked as Required but is positional-only" in caplog.text
-
-def test_required_hint_positional_skip(memory_cache, caplog):
+def test_required_positional_caches(memory_cache, caplog):
+    """Required args provided positionally are treated as explicitly provided (#297)."""
     calls_storage = memory_cache
 
     @fleche
@@ -96,9 +89,39 @@ def test_required_hint_positional_skip(memory_cache, caplog):
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        foo(2) # Positional a, should NOT cache
+        foo(2)  # a provided positionally — should cache
+        assert len(calls_storage.storage) == 1
+        assert "Missing required keyword arguments" not in caplog.text
+
+
+def test_required_default_positional_caches(memory_cache, caplog):
+    """Required arg with a default, when passed positionally, should cache (#297)."""
+    calls_storage = memory_cache
+
+    @fleche(require='seed')
+    def foo(base, seed=None):
+        return base + (seed or 0)
+
+    # seed not provided (uses default None) — should NOT cache
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        foo(1)
         assert len(calls_storage.storage) == 0
         assert "Missing required keyword arguments" in caplog.text
+
+    # seed provided positionally — should cache
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        foo(1, 42)
+        assert len(calls_storage.storage) == 1
+        assert "Missing required keyword arguments" not in caplog.text
+
+    # seed provided as keyword — should also cache
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        foo(1, seed=99)
+        assert len(calls_storage.storage) == 2
+        assert "Missing required keyword arguments" not in caplog.text
 
 def test_combined_hints_and_args(memory_cache):
     calls_storage = memory_cache


### PR DESCRIPTION
Previously the required-args guard only scanned `kwargs`, so an argument passed positionally (e.g. `draw(..., np.random.randint(...))`) was treated as missing and the warning was logged a second time, bypassing the cache.

Restructure `wrapper` so the `Call` object is built first; the required check is then done via `sig.bind(*args, **kwargs)` *without* `apply_defaults`.  Only arguments the caller explicitly passed appear in `bound.arguments`, whether they were positional or keyword — this is the same sig-binding machinery used inside `Call.from_call`, avoiding any duplication of argument-traversal logic.

Also remove the now-inaccurate POSITIONAL_ONLY warning from `process_ignore_required_args`; positional args are handled correctly.

Tests updated to assert the fixed behaviour and add a regression test for the exact scenario reported in the issue.