### PR TITLE
feat(query): auto-convert timestart/timestop to datetime in table()

### DIFF
--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -34,8 +34,8 @@ class QueryIterator(Iterable[call.LazyCall]):
         Only requested arguments are loaded from cache.
 
         ``timestart`` and ``timestop`` columns (produced by the :class:`~fleche.metadata.Runtime`
-        metadata) are automatically converted from Unix timestamps (float seconds) to
-        :class:`pandas.Timestamp` for human-readable display.
+        metadata) are automatically converted from UTC Unix timestamps (float seconds) to
+        timezone-aware :class:`pandas.Timestamp` objects in the local timezone.
 
         Args:
             arguments (iterable of str): add the given arguments (of the queried calls) as columns to the table
@@ -71,7 +71,7 @@ class QueryIterator(Iterable[call.LazyCall]):
         df = pd.DataFrame.from_dict(rows, orient="index")
         for col in ("timestart", "timestop"):
             if col in df.columns:
-                df[col] = pd.to_datetime(df[col], unit="s")
+                df[col] = pd.to_datetime(df[col], unit="s", utc=True).dt.tz_convert("localtime")
         return df
 
     def results(self) -> Iterable[Any]:

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -33,6 +33,10 @@ class QueryIterator(Iterable[call.LazyCall]):
         If given argument names collide with any of the above columns, the are prefixed by 'a_'.
         Only requested arguments are loaded from cache.
 
+        ``timestart`` and ``timestop`` columns (produced by the :class:`~fleche.metadata.Runtime`
+        metadata) are automatically converted from Unix timestamps (float seconds) to
+        :class:`pandas.Timestamp` for human-readable display.
+
         Args:
             arguments (iterable of str): add the given arguments (of the queried calls) as columns to the table
             results (bool): if True, add results of queried calls to table
@@ -64,7 +68,11 @@ class QueryIterator(Iterable[call.LazyCall]):
                     row.update(data)
             rows[str(c.to_lookup_key())] = row
 
-        return pd.DataFrame.from_dict(rows, orient="index")
+        df = pd.DataFrame.from_dict(rows, orient="index")
+        for col in ("timestart", "timestop"):
+            if col in df.columns:
+                df[col] = pd.to_datetime(df[col], unit="s")
+        return df
 
     def results(self) -> Iterable[Any]:
         """Returns an iterable over the results of queried calls."""

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -255,6 +255,25 @@ def test_query_iterator_table_end_to_end_via_wrapper(test_cache):
 # Partial query binding through the wrapper
 # ---------------------------------------------------------------------------
 
+def test_query_iterator_table_timestart_timestop_converted_to_datetime(test_cache):
+    """timestart and timestop metadata columns are automatically converted to datetime."""
+    import time
+    t0 = time.time()
+    call = Call(
+        name="f",
+        arguments={"x": 1},
+        result=42,
+        metadata={"runtime": {"timestart": t0, "timestop": t0 + 1.5, "walltime": 1.5}},
+    )
+    test_cache.save(call)
+    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    df = test_cache.query(tpl).table()
+    assert pd.api.types.is_datetime64_any_dtype(df["timestart"])
+    assert pd.api.types.is_datetime64_any_dtype(df["timestop"])
+    # walltime should remain a float
+    assert pd.api.types.is_float_dtype(df["walltime"])
+
+
 def test_query_partial_arguments(test_cache):
     with cache(test_cache):
 

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -270,6 +270,9 @@ def test_query_iterator_table_timestart_timestop_converted_to_datetime(test_cach
     df = test_cache.query(tpl).table()
     assert pd.api.types.is_datetime64_any_dtype(df["timestart"])
     assert pd.api.types.is_datetime64_any_dtype(df["timestop"])
+    # Timestamps should be timezone-aware (local timezone)
+    assert df["timestart"].dt.tz is not None
+    assert df["timestop"].dt.tz is not None
     # walltime should remain a float
     assert pd.api.types.is_float_dtype(df["walltime"])
 


### PR DESCRIPTION
Automatically converts `timestart` and `timestop` columns (produced by the `Runtime` metadata) from Unix timestamps to `pandas.Timestamp` in `QueryIterator.table()`, so callers no longer need to do the conversion manually.

Closes #311

Generated with [Claude Code](https://claude.ai/code)