### PR TITLE
Fix UnknownTimeZoneError in query.table (#314)

### DIFF
--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import dataclass
 from typing import Iterable, Iterator, Any
 
@@ -69,9 +70,10 @@ class QueryIterator(Iterable[call.LazyCall]):
             rows[str(c.to_lookup_key())] = row
 
         df = pd.DataFrame.from_dict(rows, orient="index")
+        local_tz = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
         for col in ("timestart", "timestop"):
             if col in df.columns:
-                df[col] = pd.to_datetime(df[col], unit="s", utc=True).dt.tz_convert("localtime")
+                df[col] = pd.to_datetime(df[col], unit="s", utc=True).dt.tz_convert(local_tz)
         return df
 
     def results(self) -> Iterable[Any]:


### PR DESCRIPTION
Fix the `UnknownTimeZoneError: 'localtime'` crash in `QueryIterator.table()` introduced by #311.

The string `"localtime"` is not recognized by pytz on all systems. Replace it with `datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo` to get the local timezone using only stdlib.

Closes #314

Generated with [Claude Code](https://claude.ai/code)