### PR TITLE
Fix numpy 2.0 compatibility for boolean type checking

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -153,8 +153,8 @@ def _digest(value: Any) -> Digest:
         if isinstance(value, h.type):
             return h.digest(value)
 
-    # workaround for numpy removing bool from namespace
-    if hasattr(np, "bool") and isinstance(value, np.bool):
+    # np.bool_ is the numpy boolean scalar type (np.bool was removed in numpy 2.0)
+    if isinstance(value, np.bool_):
         return digest(bool(value))
 
     m.update(type(value).__name__.encode())


### PR DESCRIPTION
## Summary
Updated the numpy boolean type checking in the digest function to use `np.bool_` instead of the deprecated `np.bool`, which was removed in numpy 2.0.

## Key Changes
- Replaced `np.bool` with `np.bool_` for numpy boolean scalar type checking
- Removed the `hasattr(np, "bool")` guard since `np.bool_` is the standard numpy boolean type
- Updated the comment to clarify that `np.bool_` is the correct numpy boolean scalar type and that `np.bool` was removed in numpy 2.0

## Implementation Details
The change simplifies the boolean type checking logic by directly using `np.bool_`, which is the proper numpy boolean scalar type. This eliminates the need for the defensive `hasattr` check and makes the code more straightforward while ensuring compatibility with numpy 2.0+.

https://claude.ai/code/session_01NKC66GT3RzjpKE714vBahy