### PR TITLE
Unify secret_key normalization: hex-decode strings in both env-var and direct paths

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,6 +119,9 @@ Available storage types
     a concurrent write lock before attempting a read anyway.
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial wait interval
     (seconds) for exponential backoff while polling the write lock.
+    Optional: ``secret_key`` (list of hex strings) — HMAC-SHA256 signing keys for
+    tamper detection; see :doc:`security` for details.  If omitted, falls back to the
+    ``FLECHE_SECRET_KEY`` environment variable.
     Optional (value backend): ``remaining_depth`` — see `Destructuring`_ below.
 
 ``"cloudpickle"``
@@ -130,6 +133,7 @@ Available storage types
     a concurrent write lock before attempting a read anyway.
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial wait interval
     (seconds) for exponential backoff while polling the write lock.
+    Optional: ``secret_key`` (list of hex strings) — same as ``"pickle"``.
     Optional (value backend): ``remaining_depth`` — see `Destructuring`_ below.
 
 ``"dill"``
@@ -140,6 +144,7 @@ Available storage types
     a concurrent write lock before attempting a read anyway.
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial wait interval
     (seconds) for exponential backoff while polling the write lock.
+    Optional: ``secret_key`` (list of hex strings) — same as ``"pickle"``.
     Optional (value backend): ``remaining_depth`` — see `Destructuring`_ below.
 
 ``"bagofholding_hdf"``

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,20 +1,40 @@
 Security
 ========
 
-``fleche`` provides a built-in cryptographic security layer for filesystem-based storage backends (``PickleFile``, ``CloudpickleFile``, and ``DillFile``) to protect against insecure deserialization vulnerabilities. This prevents arbitrary code execution if an attacker manages to tamper with or replace the cache files.
+``fleche`` provides a built-in cryptographic security layer for filesystem-based storage backends (``pickle``, ``cloudpickle``, and ``dill``) to protect against insecure deserialization vulnerabilities. This prevents arbitrary code execution if an attacker manages to tamper with or replace the cache files.
 
 Enabling Security
 -----------------
 
-Security is controlled solely via the ``FLECHE_SECRET_KEY`` environment variable. By default, if this variable is not set, the security features are **turned off**, and caches are read and written as plain serialized files.
+By default, if no secret key is configured, security is **turned off** and caches are read and written as plain serialized files.
 
-To enable security, export a hex-encoded secret key before running your application:
+Security can be enabled in two ways:
+
+**Via environment variable** (recommended — keeps secrets out of config files):
 
 .. code-block:: bash
 
     export FLECHE_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(32))')"
 
-The value must be a hex-encoded string (``[0-9a-f]+``) of any length. ``fleche`` decodes it to raw bytes before use.
+The value must be a colon-separated list of hex-encoded byte strings (``[0-9a-f]+``).
+``fleche`` decodes each segment to raw bytes before use.
+
+**Via config file** (``fleche.toml``):
+
+.. code-block:: toml
+
+    [mycache]
+    values.type = "cloudpickle"
+    values.root = "~/.fleche/values"
+    values.secret_key = ["<hex-encoded-key>"]
+
+The ``secret_key`` value is a list of hex-encoded strings using the same format as ``FLECHE_SECRET_KEY``.
+
+.. warning::
+    Storing secrets in config files risks accidentally committing them to version control.
+    Prefer the environment variable approach for sensitive deployments.
+
+Both sources use the same key format and normalization logic: any ``bytes`` value is used as-is, and any ``str`` value is interpreted as a hex-encoded byte string. HMAC-SHA256 imposes no minimum key length, though using at least 32 random bytes (256 bits) is strongly recommended.
 
 When enabled, ``fleche`` will compute an HMAC-SHA256 signature for all newly cached data and append it to the file as a 64-byte hex string. Upon loading, ``fleche`` separates the signature and verifies the integrity of the data. If the signature is invalid or missing entirely from a modified file, a ``KeyError`` is raised, effectively treating the entry as a cache miss.
 
@@ -29,11 +49,17 @@ The signing implementation is designed to be partially backward compatible. Sign
 Key Rotation and Distributed Trust
 ----------------------------------
 
-You can specify multiple hex-encoded keys separated by colons in the environment variable.
+You can specify multiple hex-encoded keys separated by colons, in both the environment variable and the config file:
 
 .. code-block:: bash
 
     export FLECHE_SECRET_KEY="aabbccdd01:eeff009988:1122334455"
+
+Or in ``fleche.toml``:
+
+.. code-block:: toml
+
+    values.secret_key = ["aabbccdd01", "eeff009988", "1122334455"]
 
 When multiple keys are provided:
 * **Writing:** The *first* key in the list (``aabbccdd01``) is always used to sign new cache entries.

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -26,6 +26,9 @@ following **lowercase** identifiers:
     Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
     interval for exponential backoff (s).
+    Optional: ``secret_key`` (list of hex strings) — HMAC-SHA256 signing keys;
+    each element is a hex-encoded byte string (same format as ``FLECHE_SECRET_KEY``).
+    If omitted, falls back to the ``FLECHE_SECRET_KEY`` environment variable.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 
 ``"cloudpickle"``
@@ -36,6 +39,7 @@ following **lowercase** identifiers:
     Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
     interval for exponential backoff (s).
+    Optional: ``secret_key`` (list of hex strings) — same as ``"pickle"``.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 
 ``"dill"``
@@ -45,6 +49,7 @@ following **lowercase** identifiers:
     Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
     interval for exponential backoff (s).
+    Optional: ``secret_key`` (list of hex strings) — same as ``"pickle"``.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 
 ``"bagofholding_hdf"``
@@ -204,7 +209,7 @@ def storage_from_config(d: dict[str, Any], type: Literal["call", "value"]) -> st
     * ``{"type": "void"}``
     * ``{"type": "pickle", "root": "<path>"}``
       — optional: ``compress``, ``lock_timeout``, ``lock_wait_start``,
-      ``remaining_depth`` (value only)
+      ``secret_key`` (list of hex strings), ``remaining_depth`` (value only)
     * ``{"type": "cloudpickle", "root": "<path>"}``
       — same optional keys as ``"pickle"``
     * ``{"type": "dill", "root": "<path>"}``
@@ -258,7 +263,10 @@ def storage_to_config(s: storage.ValueStorage | storage.CallStorage) -> dict[str
             config["type"] = serializer_name
             del config["dumps"]
             del config["loads"]
-            del config["secret_key"]
+            if config["secret_key"]:
+                config["secret_key"] = [k.hex() for k in config["secret_key"]]
+            else:
+                del config["secret_key"]
             config["root"] = str(config["root"])
         case storage.bagofholding_file.BagOfHoldingH5FileBackend():
             config = asdict(s)  # type: ignore

--- a/src/fleche/security.py
+++ b/src/fleche/security.py
@@ -11,21 +11,68 @@ class SignatureError(Exception):
     """Exception raised when signature verification fails."""
     pass
 
+
+def normalize_secret_key(key) -> list[bytes]:
+    """
+    Normalize a secret key value to ``list[bytes]``.
+
+    Accepts:
+    - ``bytes``: wrapped in a list
+    - ``str``: interpreted as a hex-encoded key; colon (``:``) separates multiple keys
+    - ``list[bytes]``: each element used as-is
+    - ``list[str]``: each element interpreted as hex-encoded; colon-delimited parts
+      within an element are treated as separate keys
+
+    This is the single normalization path used by both the ``FLECHE_SECRET_KEY``
+    environment variable and programmatic ``secret_key`` arguments — so any key
+    that can be expressed in the environment variable can also be passed directly,
+    and vice-versa.
+
+    Raises:
+        TypeError: if ``key`` or any list element is not ``bytes`` or ``str``
+        ValueError: if any string part is not valid hex
+    """
+    if isinstance(key, (bytes, str)):
+        key = [key]
+
+    if not isinstance(key, list):
+        raise TypeError(
+            f"secret_key must be bytes, str, or list, got {type(key).__name__}"
+        )
+
+    result = []
+    for k in key:
+        if isinstance(k, str):
+            for part in k.split(":"):
+                result.append(bytes.fromhex(part))
+        elif isinstance(k, bytes):
+            result.append(k)
+        else:
+            raise TypeError(
+                f"Each element of secret_key must be bytes or str, "
+                f"got {type(k).__name__}"
+            )
+
+    return result
+
+
 def get_secret_key() -> list[bytes]:
     """
-    Retrieve the secret key(s) for signing cache entries.
+    Retrieve the secret key(s) from the ``FLECHE_SECRET_KEY`` environment variable.
 
-    Only supports FLECHE_SECRET_KEY environment variable.
-    If multiple keys are present, they should be colon-separated.
-    Each key must be a hex-encoded string which is decoded to bytes.
-    If no key is found, returns an empty list (security is disabled).
+    The value must be a colon-separated list of hex-encoded byte strings.
+    Returns an empty list if the environment variable is not set (security disabled).
+
+    Uses the same :func:`normalize_secret_key` logic as the programmatic API,
+    so any value valid here is also valid as a ``secret_key`` argument and
+    vice-versa.
 
     Returns:
         list[bytes]: A list of secret keys as bytes.
     """
     env_key = os.environ.get("FLECHE_SECRET_KEY")
     if env_key:
-        return [bytes.fromhex(k) for k in env_key.split(":")]
+        return normalize_secret_key(env_key)
     return []
 
 @dataclass(slots=True, frozen=True)

--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -8,64 +8,11 @@ from typing import Any, Callable
 from .file import FileStorage
 from .base import ValueMixin, CallMixin
 from .destructuring import DestructuringMixin
-from ..security import get_secret_key, SignedBytes, SignatureError
+from ..security import get_secret_key, normalize_secret_key, SignedBytes, SignatureError
 
 from pyiron_snippets.import_alarm import ImportAlarm
 
 logger = logging.getLogger("fleche.storage.pickle_file")
-
-_HMAC_MIN_KEY_BYTES = 32
-
-
-def _normalize_secret_key(key) -> list[bytes]:
-    """
-    Normalize a secret key value to ``list[bytes]``.
-
-    Accepts:
-    - ``bytes``: wrapped in a list
-    - ``str``: split on ``":"`` delimiter, each part encoded to UTF-8
-    - ``list[bytes]``: each element validated for minimum length
-    - ``list[str]``: each element (or colon-delimited parts) encoded to UTF-8
-
-    Each resulting key must be at least ``_HMAC_MIN_KEY_BYTES`` bytes long.
-
-    Raises:
-        TypeError: if ``key`` or any element is not ``bytes`` or ``str``.
-        ValueError: if any resulting key is shorter than ``_HMAC_MIN_KEY_BYTES``.
-    """
-    if isinstance(key, (bytes, str)):
-        key = [key]
-
-    if not isinstance(key, list):
-        raise TypeError(
-            f"secret_key must be bytes, str, or list, got {type(key).__name__}"
-        )
-
-    result = []
-    for k in key:
-        if isinstance(k, str):
-            for part in k.split(":"):
-                encoded = part.encode("utf-8")
-                if len(encoded) < _HMAC_MIN_KEY_BYTES:
-                    raise ValueError(
-                        f"Each secret key must be at least {_HMAC_MIN_KEY_BYTES} bytes, "
-                        f"got {len(encoded)}"
-                    )
-                result.append(encoded)
-        elif isinstance(k, bytes):
-            if len(k) < _HMAC_MIN_KEY_BYTES:
-                raise ValueError(
-                    f"Each secret key must be at least {_HMAC_MIN_KEY_BYTES} bytes, "
-                    f"got {len(k)}"
-                )
-            result.append(k)
-        else:
-            raise TypeError(
-                f"Each element of secret_key must be bytes or str, "
-                f"got {type(k).__name__}"
-            )
-
-    return result
 
 with ImportAlarm(
     "PickleFile.with_cloudpickle requires 'cloudpickle' to be installed. "
@@ -95,7 +42,7 @@ class PickleFileBackend(FileStorage):
 
     def __post_init__(self):
         super().__post_init__()
-        normalized_key = get_secret_key() if not self.secret_key else _normalize_secret_key(self.secret_key)
+        normalized_key = get_secret_key() if not self.secret_key else normalize_secret_key(self.secret_key)
         object.__setattr__(self, "secret_key", normalized_key)
 
     @classmethod

--- a/tests/unit/config/test_storage_to_config.py
+++ b/tests/unit/config/test_storage_to_config.py
@@ -95,6 +95,24 @@ def test_roundtrip_pickle_file(tmp_path):
     assert reconstructed.root == original.root
 
 
+def test_roundtrip_pickle_file_with_secret_key(tmp_path):
+    root = tmp_path / "values"
+    key = bytes.fromhex("ab" * 32)
+    original = storage.ValuePickleFile.with_pickle(root=root, secret_key=[key])
+    cfg = storage_to_config(original)
+    assert cfg["secret_key"] == [("ab" * 32)]
+    reconstructed = storage_from_config(cfg, "value")
+    assert isinstance(reconstructed, storage.ValuePickleFile)
+    assert reconstructed.secret_key == [key]
+
+
+def test_pickle_file_no_secret_key_omitted_from_config(tmp_path):
+    root = tmp_path / "values"
+    original = storage.ValuePickleFile.with_pickle(root=root, secret_key=[])
+    cfg = storage_to_config(original)
+    assert "secret_key" not in cfg
+
+
 def test_storage_from_config_does_not_mutate():
     cfg = {"type": "memory"}
     storage_from_config(cfg, "value")

--- a/tests/unit/storage/test_pickle_file.py
+++ b/tests/unit/storage/test_pickle_file.py
@@ -51,23 +51,16 @@ def test_post_init_bytes_key(tmp_path):
 
 
 def test_post_init_str_key(tmp_path):
-    key = "A" * 32
+    key = "ab" * 32  # valid 64-char hex string
     storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
-    assert storage.secret_key == [key.encode("utf-8")]
+    assert storage.secret_key == [bytes.fromhex(key)]
 
 
 def test_post_init_str_key_with_delimiter(tmp_path):
-    key = "A" * 32 + ":" + "B" * 32
+    k1, k2 = "ab" * 16, "cd" * 16
+    key = k1 + ":" + k2
     storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
-    assert storage.secret_key == [
-        ("A" * 32).encode("utf-8"),
-        ("B" * 32).encode("utf-8"),
-    ]
-
-
-def test_post_init_short_key_raises(tmp_path):
-    with pytest.raises(ValueError, match="at least 32 bytes"):
-        PickleFile.with_pickle(root=tmp_path, secret_key=b"tooshort")
+    assert storage.secret_key == [bytes.fromhex(k1), bytes.fromhex(k2)]
 
 
 def test_post_init_wrong_key_type_raises(tmp_path):
@@ -76,7 +69,7 @@ def test_post_init_wrong_key_type_raises(tmp_path):
 
 
 def test_post_init_str_key_roundtrip(tmp_path):
-    key = "A" * 32
+    key = "ab" * 32  # valid 64-char hex string
     storage = PickleFile.with_pickle(root=tmp_path, secret_key=key)
     value = {"hello": "world"}
     digest_key = storage.save(value)

--- a/tests/unit/storage/test_secure_storage.py
+++ b/tests/unit/storage/test_secure_storage.py
@@ -1,6 +1,7 @@
 import pickle
 import pytest
-from fleche.storage.pickle_file import ValuePickleFile as PickleFile, _normalize_secret_key
+from fleche.storage.pickle_file import ValuePickleFile as PickleFile
+from fleche.security import normalize_secret_key
 
 
 def test_secure_storage_tampering(tmp_path):
@@ -126,64 +127,60 @@ def test_secure_storage_multiple_keys(tmp_path):
         storage_auth1.load(digest_key_multi)
 
 
-# --- _normalize_secret_key tests ---
+# --- normalize_secret_key tests ---
 
 def test_normalize_bytes_wrapped_in_list():
     key = b"A" * 32
-    assert _normalize_secret_key(key) == [key]
+    assert normalize_secret_key(key) == [key]
 
 
-def test_normalize_str_encoded_to_bytes():
-    key = "A" * 32
-    assert _normalize_secret_key(key) == [key.encode("utf-8")]
+def test_normalize_str_hex_decoded():
+    key = "ab" * 32  # valid 64-char hex string
+    assert normalize_secret_key(key) == [bytes.fromhex(key)]
 
 
 def test_normalize_str_with_colon_delimiter():
-    key = "A" * 32 + ":" + "B" * 32
-    assert _normalize_secret_key(key) == [
-        ("A" * 32).encode("utf-8"),
-        ("B" * 32).encode("utf-8"),
-    ]
+    k1, k2 = "ab" * 16, "cd" * 16
+    key = k1 + ":" + k2
+    assert normalize_secret_key(key) == [bytes.fromhex(k1), bytes.fromhex(k2)]
 
 
 def test_normalize_list_of_str():
-    keys = ["A" * 32, "B" * 32]
-    assert _normalize_secret_key(keys) == [k.encode("utf-8") for k in keys]
+    keys = ["ab" * 32, "cd" * 32]
+    assert normalize_secret_key(keys) == [bytes.fromhex(k) for k in keys]
 
 
 def test_normalize_list_of_bytes():
     keys = [b"A" * 32, b"B" * 32]
-    assert _normalize_secret_key(keys) == keys
+    assert normalize_secret_key(keys) == keys
 
 
 def test_normalize_list_str_with_delimiter():
-    keys = ["A" * 32 + ":" + "B" * 32]
-    assert _normalize_secret_key(keys) == [
-        ("A" * 32).encode("utf-8"),
-        ("B" * 32).encode("utf-8"),
-    ]
+    k1, k2 = "ab" * 16, "cd" * 16
+    keys = [k1 + ":" + k2]
+    assert normalize_secret_key(keys) == [bytes.fromhex(k1), bytes.fromhex(k2)]
 
 
-def test_normalize_bytes_too_short_raises():
-    with pytest.raises(ValueError, match="at least 32 bytes"):
-        _normalize_secret_key(b"short")
-
-
-def test_normalize_str_too_short_raises():
-    with pytest.raises(ValueError, match="at least 32 bytes"):
-        _normalize_secret_key("short")
+def test_normalize_str_invalid_hex_raises():
+    with pytest.raises(ValueError):
+        normalize_secret_key("not-valid-hex!")
 
 
 def test_normalize_wrong_type_raises():
     with pytest.raises(TypeError, match="secret_key must be bytes, str, or list"):
-        _normalize_secret_key(12345)
+        normalize_secret_key(12345)
 
 
 def test_normalize_list_wrong_element_type_raises():
     with pytest.raises(TypeError, match="Each element of secret_key must be bytes or str"):
-        _normalize_secret_key([12345])
+        normalize_secret_key([12345])
 
 
 def test_normalize_empty_list_returns_empty():
     # Empty list means security disabled — no normalization needed
-    assert _normalize_secret_key([]) == []
+    assert normalize_secret_key([]) == []
+
+
+def test_normalize_short_bytes_allowed():
+    # HMAC has no minimum key length requirement
+    assert normalize_secret_key(b"short") == [b"short"]


### PR DESCRIPTION
Part of #232.

Two inconsistencies fixed:
1. String encoding: `get_secret_key()` (env var) used `bytes.fromhex()` while `_normalize_secret_key()` (direct API) used UTF-8 encode
2. Min key length: `_normalize_secret_key()` enforced 32-byte minimum; `get_secret_key()` did not — HMAC has no requirement
3. Config round-trip: `storage_to_config` silently deleted `secret_key`

Changes:
- Move `_normalize_secret_key` to `security.py` as public `normalize_secret_key`; strings are hex-decoded (matching `FLECHE_SECRET_KEY` format)
- Remove the 32-byte minimum key length check
- `get_secret_key()` delegates to `normalize_secret_key()`
- `storage_to_config` preserves `secret_key` as a list of hex strings; `storage_from_config` round-trips it
- Updated docs and tests

Generated with [Claude Code](https://claude.ai/code)