### PR TITLE
Remove Call.matches; use QueryCall.matches as single reference implementation

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -11,7 +11,7 @@ import pandas as pd
 from . import digest as _digest
 from .digest import Digest  # type hint convenience
 from . import storage
-from .call import Call, LazyCall
+from .call import Call, LazyCall, QueryCall
 from . import call
 from . import query
 
@@ -179,18 +179,18 @@ class BaseCache(ABC):
         )
         return self.query(tpl).table(arguments=arguments, results=results)
 
-    def filter(self, predicate: Callable[[Call | LazyCall], bool] | Call) -> 'FilteredCache':
+    def filter(self, predicate: Callable[[Call | LazyCall], bool] | QueryCall) -> 'FilteredCache':
         """Create a read-only view of this cache that only exposes calls matching the predicate.
 
         Args:
             predicate: A function that takes a Call or LazyCall and returns True
-                if it should be included in the new cache, or a Call object to
+                if it should be included in the new cache, or a QueryCall object to
                 use as a template.
 
         Returns:
             FilteredCache: A read-only view of the cache.
         """
-        if isinstance(predicate, Call):
+        if isinstance(predicate, QueryCall):
             predicate = predicate.matches
 
         return FilteredCache(self, predicate)

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -67,45 +67,6 @@ class Call:
         call = replace(self, arguments=arg_pairs, metadata=None, result=None)
         return digest.digest(call)
 
-    def matches(self, other: 'Call | LazyCall') -> bool:
-        """Check if this call matches another call, treating None as a wildcard in this object."""
-        def none_or_equal(a, b):
-            if a is None:
-                return True
-            # Use digest to handle both raw values and Digest objects consistently
-            return digest.digest(a) == digest.digest(b)
-
-        if not none_or_equal(self.name, other.name):
-            return False
-        if not none_or_equal(self.module, other.module):
-            return False
-        if not none_or_equal(self.version, other.version):
-            return False
-        if not none_or_equal(self.result, other.result):
-            return False
-
-        if self.arguments is not None:
-            for k, v in self.arguments.items():
-                if k not in other.arguments:
-                    return False
-                if not none_or_equal(v, other.arguments[k]):
-                    return False
-
-        if self.metadata:
-            for mname, filters in self.metadata.items():
-                data = other.metadata.get(mname)
-                if data is None:
-                    return False
-                for kk, vv in (filters or {}).items():
-                    if vv is None:
-                        if kk not in data:
-                            return False
-                    else:
-                        if data.get(kk) != vv:
-                            return False
-        return True
-
-
 class LazyArguments(Mapping):
     def __init__(self, cache, arg_digests):
         self._cache = cache

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -1,7 +1,7 @@
 import logging
 from unittest.mock import Mock, MagicMock
 from fleche import fleche, cache
-from fleche.call import Call
+from fleche.call import Call, QueryCall
 from fleche.digest import Digest
 from fleche.caches import Cache, CacheStack
 
@@ -281,7 +281,7 @@ def test_cache_query_decodes_values_and_args(monkeypatch):
     cache.save(original)
 
     # Build a template that matches by name only to retrieve the saved call
-    tpl = Call(
+    tpl = QueryCall(
         name="f", arguments=None, metadata=None, module=None, version=None, result=None
     )
     got = list(cache.query(tpl))

--- a/tests/unit/caches/test_filter.py
+++ b/tests/unit/caches/test_filter.py
@@ -1,7 +1,7 @@
 import pytest
 from fleche.storage import ValueMemory, CallMemory
 from fleche.caches import Cache, FilteredCache, Rejected
-from fleche.call import Call
+from fleche.call import Call, QueryCall
 from fleche import fleche, cache
 
 
@@ -25,8 +25,8 @@ def test_filter_by_name():
     c_foo = c.filter(lambda call: call.name == "foo")
     assert isinstance(c_foo, FilteredCache)
 
-    assert len(list(c_foo.query(Call(name="foo", arguments=None)))) == 2
-    assert len(list(c_foo.query(Call(name="bar", arguments=None)))) == 0
+    assert len(list(c_foo.query(QueryCall(name="foo", arguments=None)))) == 2
+    assert len(list(c_foo.query(QueryCall(name="bar", arguments=None)))) == 0
 
     # Check values
     assert c_foo.load(foo.digest(1)).result == 2
@@ -67,10 +67,10 @@ def test_filter_with_template():
         foo(2)
         bar(3)
 
-    # Filter using a Call object as a template
-    c_filtered = c.filter(Call(name="foo", arguments=None))
+    # Filter using a QueryCall object as a template
+    c_filtered = c.filter(QueryCall(name="foo", arguments=None))
 
-    assert len(list(c_filtered.query(Call(name=None, arguments=None)))) == 2
+    assert len(list(c_filtered.query(QueryCall(name=None, arguments=None)))) == 2
     assert c_filtered.load(foo.digest(1)).result == 2
     with pytest.raises(KeyError):
         c_filtered.load(bar.digest(3))

--- a/tests/unit/caches/test_lazy_call.py
+++ b/tests/unit/caches/test_lazy_call.py
@@ -1,7 +1,7 @@
 import pytest
 from hypothesis import given
 from unittest.mock import Mock, patch
-from fleche.call import Call, LazyCall, LazyArguments
+from fleche.call import Call, LazyCall, LazyArguments, QueryCall
 from fleche.caches import Cache
 from fleche import cache as cache_context
 from fleche.storage import ValueMemory, CallMemory
@@ -101,7 +101,7 @@ def test_cache_query_lazy():
     cache.save(Call(name="f", arguments={"x": 1}, result=10))
     cache.save(Call(name="f", arguments={"x": 2}, result=20))
 
-    tpl = Call(
+    tpl = QueryCall(
         name="f", arguments=None, metadata=None, module=None, version=None, result=None
     )
 

--- a/tests/unit/caches/test_size_limited.py
+++ b/tests/unit/caches/test_size_limited.py
@@ -1,7 +1,7 @@
 """Tests for SizeLimitedCache."""
 import threading
 
-from fleche.call import Call
+from fleche.call import Call, QueryCall
 from fleche.caches import Cache, SizeLimitedCache
 from fleche.storage.memory import ValueMemory, CallMemory
 
@@ -115,7 +115,7 @@ def test_query_delegates():
     cache.save(make_call("myf", 2, 20))
     cache.save(make_call("other", 3, 30))
 
-    tpl = Call(name="myf", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="myf", arguments=None, metadata=None, module=None, version=None, result=None)
     results = list(cache.query(tpl))
     assert len(results) == 2
     assert all(r.name == "myf" for r in results)

--- a/tests/unit/call/test_matches.py
+++ b/tests/unit/call/test_matches.py
@@ -1,28 +1,28 @@
-from fleche.call import Call
+from fleche.call import Call, QueryCall
 from fleche.caches import Cache
 from fleche.storage import ValueMemory, CallMemory
 
 
-def test_call_matches():
-    """Verify that Call.matches() correctly handles wildcards and values."""
+def test_query_call_matches():
+    """Verify that QueryCall.matches() correctly handles wildcards and values."""
     c1 = Call(name="f", arguments={"x": 1}, result=10)
 
     # Template matching
-    assert Call(name="f", arguments=None).matches(c1)
-    assert Call(name="f", arguments={"x": 1}).matches(c1)
-    assert Call(name=None, arguments={"x": 1}).matches(c1)
-    assert Call(name="f", arguments={"x": 1}, result=10).matches(c1)
-    assert Call(name=None, result=10, arguments=None).matches(c1)
+    assert QueryCall(name="f", arguments=None).matches(c1)
+    assert QueryCall(name="f", arguments={"x": 1}).matches(c1)
+    assert QueryCall(name=None, arguments={"x": 1}).matches(c1)
+    assert QueryCall(name="f", arguments={"x": 1}, result=10).matches(c1)
+    assert QueryCall(name=None, result=10, arguments=None).matches(c1)
 
     # Non-matching
-    assert not Call(name="g", arguments=None).matches(c1)
-    assert not Call(name="f", arguments={"x": 2}).matches(c1)
-    assert not Call(name="f", arguments={"y": 1}).matches(c1)
-    assert not Call(name="f", arguments={"x": 1}, result=20).matches(c1)
+    assert not QueryCall(name="g", arguments=None).matches(c1)
+    assert not QueryCall(name="f", arguments={"x": 2}).matches(c1)
+    assert not QueryCall(name="f", arguments={"y": 1}).matches(c1)
+    assert not QueryCall(name="f", arguments={"x": 1}, result=20).matches(c1)
 
 
-def test_call_matches_lazy():
-    """Verify that Call.matches() correctly handles LazyCall objects."""
+def test_query_call_matches_lazy():
+    """Verify that QueryCall.matches() correctly handles LazyCall objects."""
     values_storage = ValueMemory({})
     calls_storage = CallMemory({})
     cache = Cache(values_storage, calls_storage)
@@ -32,14 +32,14 @@ def test_call_matches_lazy():
     lazy = cache.load(key, lazy=True)
 
     # Template matching
-    assert Call(name="f", arguments=None).matches(lazy)
-    assert Call(name="f", arguments={"x": 1}).matches(lazy)
-    assert Call(name=None, arguments={"x": 1}).matches(lazy)
-    assert Call(name="f", arguments={"x": 1}, result=10).matches(lazy)
-    assert Call(name=None, result=10, arguments=None).matches(lazy)
+    assert QueryCall(name="f", arguments=None).matches(lazy)
+    assert QueryCall(name="f", arguments={"x": 1}).matches(lazy)
+    assert QueryCall(name=None, arguments={"x": 1}).matches(lazy)
+    assert QueryCall(name="f", arguments={"x": 1}, result=10).matches(lazy)
+    assert QueryCall(name=None, result=10, arguments=None).matches(lazy)
 
     # Non-matching
-    assert not Call(name="g", arguments=None).matches(lazy)
-    assert not Call(name="f", arguments={"x": 2}).matches(lazy)
-    assert not Call(name="f", arguments={"y": 1}).matches(lazy)
-    assert not Call(name="f", arguments={"x": 1}, result=20).matches(lazy)
+    assert not QueryCall(name="g", arguments=None).matches(lazy)
+    assert not QueryCall(name="f", arguments={"x": 2}).matches(lazy)
+    assert not QueryCall(name="f", arguments={"y": 1}).matches(lazy)
+    assert not QueryCall(name="f", arguments={"x": 1}, result=20).matches(lazy)

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -30,7 +30,7 @@ def test_query_iterator_is_iterable(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
 
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     it = test_cache.query(tpl)
 
     assert isinstance(it, QueryIterator)
@@ -71,7 +71,7 @@ def test_query_iterator_results(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
 
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     results = list(test_cache.query(tpl).results())
     assert sorted(results) == [10, 20]
 
@@ -102,7 +102,7 @@ def test_query_iterator_results_from_wrapper(test_cache):
 def test_query_iterator_table_returns_dataframe(test_cache):
     """table() returns a pandas DataFrame."""
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
     assert isinstance(df, pd.DataFrame)
 
@@ -110,7 +110,7 @@ def test_query_iterator_table_returns_dataframe(test_cache):
 def test_query_iterator_table_basic_columns(test_cache):
     """table() always has 'name' and 'module' columns."""
     test_cache.save(Call(name="my_func", arguments={"a": 1}, result=42, module="mymod"))
-    tpl = Call(name="my_func", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="my_func", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
     assert "name" in df.columns
     assert "module" in df.columns
@@ -123,7 +123,7 @@ def test_query_iterator_table_index_is_lookup_key(test_cache):
     test_cache.save(call1)
     test_cache.save(call2)
 
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
 
     expected_keys = {str(call1.to_lookup_key()), str(call2.to_lookup_key())}
@@ -133,7 +133,7 @@ def test_query_iterator_table_index_is_lookup_key(test_cache):
 def test_query_iterator_table_no_result_by_default(test_cache):
     """result column is not present unless results=True is passed."""
     test_cache.save(Call(name="f", arguments={"x": 1}, result=99))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
     assert "result" not in df.columns
 
@@ -152,7 +152,7 @@ def test_query_iterator_table_empty():
 def test_query_iterator_table_with_arguments(test_cache):
     """Requested argument names appear as columns in the DataFrame."""
     test_cache.save(Call(name="f", arguments={"x": 3, "y": 7}, result=10))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(arguments=["x", "y"])
     assert "x" in df.columns
     assert "y" in df.columns
@@ -163,7 +163,7 @@ def test_query_iterator_table_with_arguments(test_cache):
 def test_query_iterator_table_missing_argument_is_none(test_cache):
     """If a requested argument name does not exist on a call, the value is None."""
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(arguments=["nonexistent"])
     assert "nonexistent" in df.columns
     assert df["nonexistent"].iloc[0] is None
@@ -173,7 +173,7 @@ def test_query_iterator_table_argument_column_clash_prefixed(test_cache):
     """Arguments whose names clash with reserved columns are prefixed with 'a_'."""
     # 'name' and 'module' are reserved columns in the table
     test_cache.save(Call(name="f", arguments={"name": "clash_value"}, result=1))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(arguments=["name"])
     # Original 'name' column should still hold the function name
     assert df["name"].iloc[0] == "f"
@@ -189,7 +189,7 @@ def test_query_iterator_table_argument_column_clash_prefixed(test_cache):
 def test_query_iterator_table_with_results(test_cache):
     """results=True adds a 'result' column to the DataFrame."""
     test_cache.save(Call(name="f", arguments={"x": 5}, result=25))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(results=True)
     assert "result" in df.columns
     assert df["result"].iloc[0] == 25
@@ -199,7 +199,7 @@ def test_query_iterator_table_results_multiple_calls(test_cache):
     """results=True works correctly when there are multiple calls."""
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(results=True)
     assert set(df["result"]) == {10, 20}
 
@@ -217,7 +217,7 @@ def test_query_iterator_table_metadata_flattened(test_cache):
         metadata={"timing": {"elapsed": 1.5, "unit": "s"}},
     )
     test_cache.save(call)
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
     assert "elapsed" in df.columns
     assert df["elapsed"].iloc[0] == 1.5
@@ -228,7 +228,7 @@ def test_query_iterator_table_metadata_flattened(test_cache):
 def test_query_iterator_table_no_metadata(test_cache):
     """Calls without metadata produce no extra columns."""
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={}))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
     # Only standard columns expected
     assert set(df.columns) == {"name", "module"}
@@ -266,7 +266,7 @@ def test_query_iterator_table_timestart_timestop_converted_to_datetime(test_cach
         metadata={"runtime": {"timestart": t0, "timestop": t0 + 1.5, "walltime": 1.5}},
     )
     test_cache.save(call)
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table()
     assert pd.api.types.is_datetime64_any_dtype(df["timestart"])
     assert pd.api.types.is_datetime64_any_dtype(df["timestop"])

--- a/tests/unit/storage/test_sql_query.py
+++ b/tests/unit/storage/test_sql_query.py
@@ -5,7 +5,7 @@ from hypothesis import given, strategies as st
 from fleche.storage.sql import Sql
 from fleche.storage import ValueMemory
 from fleche.caches import Cache
-from fleche.call import Call
+from fleche.call import Call, QueryCall
 from fleche.digest import Digest, digest
 
 
@@ -278,7 +278,7 @@ def test_sql_call_digest_persistence(store):
 
 
 # ---------------------------------------------------------------------------
-# Consistency: SQL query vs Call.matches()
+# Consistency: SQL query vs QueryCall.matches()
 # ---------------------------------------------------------------------------
 
 
@@ -310,7 +310,7 @@ def test_sql_call_digest_persistence(store):
     ),
 )
 def test_sql_query_matches_call_matches(call_data, template_data):
-    """Verify that Sql storage query results are consistent with Call.matches()."""
+    """Verify that Sql storage query results are consistent with QueryCall.matches()."""
     values = ValueMemory({})
     sql_calls = Sql()  # in-memory sqlite
     cache = Cache(values, sql_calls)
@@ -335,7 +335,7 @@ def test_sql_query_matches_call_matches(call_data, template_data):
     if template_data["y"] is not None:
         template_args["y"] = template_data["y"]
 
-    template = Call(
+    template = QueryCall(
         name=template_data["name"],
         arguments=template_args if template_args else None,
         module=template_data["module"],


### PR DESCRIPTION
Remove `Call.matches` from the `Call` dataclass — it was dead weight on the production path since `QueryCall.matches` handles all real callers.

Also updates `BaseCache.filter()` to accept a `QueryCall` template predicate, and migrates all test sites that passed a bare `Call` as a query template to use `QueryCall` instead.

Closes #328 (partial)

Generated with [Claude Code](https://claude.ai/code)