### PR TITLE
Add shortcuts for table(arguments): True=all args, str=one-element tuple

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -4,7 +4,7 @@ import random
 import threading
 from dataclasses import dataclass, replace, field
 from copy import copy
-from typing import Iterable, Any, Callable, overload
+from typing import Iterable, Any, Callable, Literal, overload
 
 import pandas as pd
 
@@ -143,7 +143,7 @@ class BaseCache(ABC):
                 logger.warning("No hash for query argument: %s", e.args[0])
         return query.QueryIterator(_safe_iter())
 
-    def table(self, arguments: Iterable[str] = (), results=False) -> pd.DataFrame:
+    def table(self, arguments: Iterable[str] | str | Literal[True] = (), results=False) -> pd.DataFrame:
         """Return a pandas DataFrame summarizing cached calls via query().
 
         This implementation uses a fully-wildcard Call template to retrieve
@@ -163,7 +163,9 @@ class BaseCache(ABC):
         Only requested arguments are loaded from cache.
 
         Args:
-            arguments (iterable of str): add the given arguments (of the queried calls) as columns to the table
+            arguments: add the given arguments (of the queried calls) as columns to the table.
+                Pass ``True`` to add all arguments, or a single string as a shortcut for a
+                one-element tuple.
             results (bool): if True, add results of queried calls to table
 
         Returns:

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -1,6 +1,6 @@
 import datetime
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Any
+from typing import Iterable, Iterator, Any, Literal
 
 import pandas as pd
 
@@ -19,7 +19,7 @@ class QueryIterator(Iterable[call.LazyCall]):
     def __iter__(self) -> Iterator[call.LazyCall]:
         yield from self.calls
 
-    def table(self, arguments: Iterable[str] | str | bool = (), results=False) -> pd.DataFrame:
+    def table(self, arguments: Iterable[str] | str | Literal[True] = (), results=False) -> pd.DataFrame:
         """Return a pandas DataFrame summarizing queried calls.
 
         Arguments and results are elided.
@@ -48,9 +48,11 @@ class QueryIterator(Iterable[call.LazyCall]):
             :class:`pandas.DataFrame`: table of all calls on cache
         """
 
-        if isinstance(arguments, str):
+        if arguments is True:
+            pass
+        elif isinstance(arguments, str):
             arguments = (arguments,)
-        elif arguments is not True:
+        else:
             arguments = tuple(arguments)
 
         rows: dict[str, dict[str, Any]] = {}

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -19,7 +19,7 @@ class QueryIterator(Iterable[call.LazyCall]):
     def __iter__(self) -> Iterator[call.LazyCall]:
         yield from self.calls
 
-    def table(self, arguments: Iterable[str] = (), results=False) -> pd.DataFrame:
+    def table(self, arguments: Iterable[str] | str | bool = (), results=False) -> pd.DataFrame:
         """Return a pandas DataFrame summarizing queried calls.
 
         Arguments and results are elided.
@@ -39,14 +39,19 @@ class QueryIterator(Iterable[call.LazyCall]):
         timezone-aware :class:`pandas.Timestamp` objects in the local timezone.
 
         Args:
-            arguments (iterable of str): add the given arguments (of the queried calls) as columns to the table
+            arguments: add the given arguments (of the queried calls) as columns to the table.
+                Pass ``True`` to add all arguments, or a single string as a shortcut for a
+                one-element tuple.
             results (bool): if True, add results of queried calls to table
 
         Returns:
             :class:`pandas.DataFrame`: table of all calls on cache
         """
 
-        arguments = tuple(arguments)
+        if isinstance(arguments, str):
+            arguments = (arguments,)
+        elif arguments is not True:
+            arguments = tuple(arguments)
 
         rows: dict[str, dict[str, Any]] = {}
         for c in self.calls:
@@ -55,7 +60,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             }
             if results:
                 row["result"] = c.result
-            for a in arguments:
+            for a in (c.arguments.keys() if arguments is True else arguments):
                 # TODO: quick and easy strategy to avoid name clashes, alternative would be to use multicolumns, but
                 # those are a bit annoying
                 if a not in row:

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -163,7 +163,7 @@ def test_query_iterator_table_with_arguments(test_cache):
 def test_query_iterator_table_arguments_single_string(test_cache):
     """A single string passed to arguments is treated as a one-element tuple."""
     test_cache.save(Call(name="f", arguments={"x": 3, "y": 7}, result=10))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(arguments="x")
     assert "x" in df.columns
     assert df["x"].iloc[0] == 3
@@ -173,7 +173,7 @@ def test_query_iterator_table_arguments_single_string(test_cache):
 def test_query_iterator_table_arguments_true(test_cache):
     """arguments=True adds all arguments as columns."""
     test_cache.save(Call(name="f", arguments={"x": 3, "y": 7}, result=10))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(arguments=True)
     assert "x" in df.columns
     assert "y" in df.columns
@@ -185,7 +185,7 @@ def test_query_iterator_table_arguments_true_multiple_calls(test_cache):
     """arguments=True collects the union of argument names across all calls."""
     test_cache.save(Call(name="f", arguments={"x": 1, "y": 2}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 3, "z": 4}, result=20))
-    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     df = test_cache.query(tpl).table(arguments=True)
     assert "x" in df.columns
     assert "y" in df.columns

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -160,6 +160,38 @@ def test_query_iterator_table_with_arguments(test_cache):
     assert df["y"].iloc[0] == 7
 
 
+def test_query_iterator_table_arguments_single_string(test_cache):
+    """A single string passed to arguments is treated as a one-element tuple."""
+    test_cache.save(Call(name="f", arguments={"x": 3, "y": 7}, result=10))
+    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    df = test_cache.query(tpl).table(arguments="x")
+    assert "x" in df.columns
+    assert df["x"].iloc[0] == 3
+    assert "y" not in df.columns
+
+
+def test_query_iterator_table_arguments_true(test_cache):
+    """arguments=True adds all arguments as columns."""
+    test_cache.save(Call(name="f", arguments={"x": 3, "y": 7}, result=10))
+    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    df = test_cache.query(tpl).table(arguments=True)
+    assert "x" in df.columns
+    assert "y" in df.columns
+    assert df["x"].iloc[0] == 3
+    assert df["y"].iloc[0] == 7
+
+
+def test_query_iterator_table_arguments_true_multiple_calls(test_cache):
+    """arguments=True collects the union of argument names across all calls."""
+    test_cache.save(Call(name="f", arguments={"x": 1, "y": 2}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 3, "z": 4}, result=20))
+    tpl = Call(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    df = test_cache.query(tpl).table(arguments=True)
+    assert "x" in df.columns
+    assert "y" in df.columns
+    assert "z" in df.columns
+
+
 def test_query_iterator_table_missing_argument_is_none(test_cache):
     """If a requested argument name does not exist on a call, the value is None."""
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))


### PR DESCRIPTION
Implements #338:
- `arguments=True` adds all arguments as columns
- `arguments=str` expands to `arguments=(str,)`

Generated with [Claude Code](https://claude.ai/code)