### PR TITLE
Centralize Ignored/Required logic in ArgumentPolicy dataclass

### DIFF
--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from functools import wraps
 from inspect import signature
 from typing import Any, Callable, Dict, Iterable, TypeVar, Annotated, get_type_hints, get_origin, get_args
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import tempfile
 import contextlib
 from collections import defaultdict
@@ -52,11 +52,31 @@ class Required:
         return Annotated[item, cls]
 
 
+@dataclass(frozen=True)
+class ArgumentPolicy:
+    """Encapsulates the ignored/required argument policy for a cached function."""
+
+    ignored: frozenset[str]
+    required: frozenset[str]
+
+    def strip_for_key(self, bound: dict) -> None:
+        """Remove ignored arguments from a bound arguments dict in-place."""
+        for ign in self.ignored:
+            del bound[ign]
+
+    def check_required(self, func, args: tuple, kwargs: dict) -> list[str]:
+        """Return names of required args not explicitly provided as keyword arguments."""
+        if not self.required:
+            return []
+        explicit = set(bind(func, args, kwargs).keys())
+        return [r for r in self.required if r not in explicit]
+
+
 def process_ignore_required_args(
         func,
         ignore: None | str | Iterable[str] = None,
         require: None | str | Iterable[str] = None,
-) -> tuple[tuple[str, ...], tuple[str, ...]]:
+) -> "ArgumentPolicy":
     """Collates arguments that should be ignored/required for caching from explicit arguments and annotations."""
 
     try:
@@ -108,7 +128,7 @@ def process_ignore_required_args(
     except (TypeError, ValueError):
         pass
 
-    return ignored_args, required_args
+    return ArgumentPolicy(ignored=frozenset(ignored_args), required=frozenset(required_args))
 
 
 def _get_working_directory_root() -> Path:
@@ -166,7 +186,7 @@ def fleche(
         if version is not None:
             func.__version__ = version  # ty: ignore
 
-        ignored_args, required_args = process_ignore_required_args(func, ignore, require)
+        policy = process_ignore_required_args(func, ignore, require)
 
         @wraps(func)
         def get_call(*args, **kwargs):
@@ -176,8 +196,7 @@ def fleche(
             # generation, but then we'd also have to save it somehow and that just seems bothersome in particular for
             # Sql Callstorage.  We could add a new table there connecting unique functions and their ignored args, but
             # meh.
-            for ign in ignored_args:
-                del call.arguments[ign]
+            policy.strip_for_key(call.arguments)
             if not hash_version:
                 call.version = None
             if not hash_module:
@@ -207,8 +226,7 @@ def fleche(
                 iterable of matching :class:`.Call`
             """
             call = QueryCall.from_call(func, *args, **kwargs)
-            for ign in ignored_args:
-                del call.arguments[ign]
+            policy.strip_for_key(call.arguments)
             if "metadata" in call.arguments:
                 logger.warning(
                     "Function argument 'metadata' shadowed by query argument"
@@ -284,14 +302,12 @@ def fleche(
                 logger.warning("No hash for argument: %s", e.args[0])
                 return func(*args, **kwargs)
 
-            if required_args:
-                explicit = set(bind(func, args, kwargs).keys())
-                missing = [r for r in required_args if r not in explicit]
-                if missing:
-                    logger.warning(
-                        "Missing required keyword arguments for caching: %s", missing
-                    )
-                    return func(*args, **kwargs)
+            missing = policy.check_required(func, args, kwargs)
+            if missing:
+                logger.warning(
+                    "Missing required keyword arguments for caching: %s", missing
+                )
+                return func(*args, **kwargs)
 
             try:
                 result = cache.load(key).result
@@ -347,6 +363,7 @@ def fleche(
 
 
 __all__ = [
+        "ArgumentPolicy",
         "Ignored",
         "Required",
         "fleche",

--- a/tests/unit/fleche/test_process_args.py
+++ b/tests/unit/fleche/test_process_args.py
@@ -1,43 +1,44 @@
 from typing import Annotated
-from fleche.wrapper import process_ignore_required_args, Ignored, Required
+from fleche.wrapper import process_ignore_required_args, ArgumentPolicy, Ignored, Required
 
 
 def test_process_explicit_none():
     def func(a, b):
         pass
 
-    ignored, required = process_ignore_required_args(func, ignore=None, require=None)
-    assert ignored == ()
-    assert required == ()
+    policy = process_ignore_required_args(func, ignore=None, require=None)
+    assert isinstance(policy, ArgumentPolicy)
+    assert policy.ignored == frozenset()
+    assert policy.required == frozenset()
 
 
 def test_process_explicit_str():
     def func(a, b):
         pass
 
-    ignored, required = process_ignore_required_args(func, ignore="a", require="b")
-    assert ignored == ("a",)
-    assert required == ("b",)
+    policy = process_ignore_required_args(func, ignore="a", require="b")
+    assert policy.ignored == frozenset({"a"})
+    assert policy.required == frozenset({"b"})
 
 
 def test_process_explicit_iterable():
     def func(a, b, c, d):
         pass
 
-    ignored, required = process_ignore_required_args(
+    policy = process_ignore_required_args(
         func, ignore=["a", "b"], require=("c", "d")
     )
-    assert ignored == ("a", "b")
-    assert required == ("c", "d")
+    assert policy.ignored == frozenset({"a", "b"})
+    assert policy.required == frozenset({"c", "d"})
 
 
 def test_process_type_hints():
     def func(a: Ignored, b: Required):
         pass
 
-    ignored, required = process_ignore_required_args(func)
-    assert "a" in ignored
-    assert "b" in required
+    policy = process_ignore_required_args(func)
+    assert "a" in policy.ignored
+    assert "b" in policy.required
 
 
 def test_process_positional_only_required_warning(caplog):
@@ -55,9 +56,9 @@ def test_process_merge_hints_and_args():
     def func(a: Ignored, b: Required):
         pass
 
-    ignored, required = process_ignore_required_args(func, ignore="c", require="d")
-    assert set(ignored) == {"a", "c"}
-    assert set(required) == {"b", "d"}
+    policy = process_ignore_required_args(func, ignore="c", require="d")
+    assert policy.ignored == frozenset({"a", "c"})
+    assert policy.required == frozenset({"b", "d"})
 
 
 def test_process_missing_hints():
@@ -66,31 +67,63 @@ def test_process_missing_hints():
 
     # Deliberately remove __annotations__ to test the try-except block
     del func.__annotations__
-    ignored, required = process_ignore_required_args(func)
-    assert ignored == ()
-    assert required == ()
+    policy = process_ignore_required_args(func)
+    assert policy.ignored == frozenset()
+    assert policy.required == frozenset()
 
 
 def test_process_invalid_signature():
     # Some objects might not have a signature
-    ignored, required = process_ignore_required_args(object(), require="a")
-    assert ignored == ()
-    assert required == ("a",)
+    policy = process_ignore_required_args(object(), require="a")
+    assert policy.ignored == frozenset()
+    assert policy.required == frozenset({"a"})
 
 
 def test_process_annotated_type_hints():
     def func(a: Annotated[int, Ignored], b: Annotated[str, Required]):
         pass
 
-    ignored, required = process_ignore_required_args(func)
-    assert "a" in ignored
-    assert "b" in required
+    policy = process_ignore_required_args(func)
+    assert "a" in policy.ignored
+    assert "b" in policy.required
 
 
 def test_process_generic_type_hints():
     def func(a: Ignored[int], b: Required[str]):
         pass
 
-    ignored, required = process_ignore_required_args(func)
-    assert "a" in ignored
-    assert "b" in required
+    policy = process_ignore_required_args(func)
+    assert "a" in policy.ignored
+    assert "b" in policy.required
+
+
+def test_strip_for_key():
+    policy = ArgumentPolicy(ignored=frozenset({"a", "b"}), required=frozenset())
+    bound = {"a": 1, "b": 2, "c": 3}
+    policy.strip_for_key(bound)
+    assert bound == {"c": 3}
+
+
+def test_check_required_all_present():
+    def func(x, y=0):
+        pass
+
+    policy = ArgumentPolicy(ignored=frozenset(), required=frozenset({"x"}))
+    assert policy.check_required(func, (), {"x": 1}) == []
+
+
+def test_check_required_missing():
+    def func(x=0, y=0):
+        pass
+
+    policy = ArgumentPolicy(ignored=frozenset(), required=frozenset({"x"}))
+    missing = policy.check_required(func, (), {})
+    assert "x" in missing
+
+
+def test_check_required_empty():
+    def func(x=0):
+        pass
+
+    policy = ArgumentPolicy(ignored=frozenset(), required=frozenset())
+    assert policy.check_required(func, (1,), {}) == []


### PR DESCRIPTION
Introduces `ArgumentPolicy` (frozen dataclass) with `strip_for_key()` and `check_required()` methods, replacing the three-site pattern where ignored/required args were processed in `process_ignore_required_args`, dropped in `get_call`, and enforced in the main `wrapper` body separately.

Closes #334

Generated with [Claude Code](https://claude.ai/code)