### PR TITLE
Fix SQL code_digest round-trip causing KeyError in cache.load(table().index)

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -236,7 +236,7 @@ class Sql(PerKeyLockMixin, CallStorage):
             metadata={row.name: (row.data or {}) for row in meta_rows},
             module=call_model.module,
             version=call_model.version,
-            code_digest=call_model.code_digest,
+            code_digest=Digest(call_model.code_digest) if call_model.code_digest is not None else None,
             result=(
                 Digest(call_model.result) if call_model.result is not None else None
             ),

--- a/tests/regression/test_issue_319.py
+++ b/tests/regression/test_issue_319.py
@@ -1,0 +1,73 @@
+"""
+Regression test for issue #319: query().table() index doesn't match storage keys in SQL.
+
+Root cause: sql.py get() returned code_digest as a plain str, but at save time it was
+a Digest. digest(Digest(x)) == x (identity) but digest(str(x)) == SHA256("str" + x.encode()),
+so to_lookup_key() produced different hashes before and after SQL round-trip.
+"""
+
+import pytest
+from fleche.storage.sql import Sql
+from fleche.storage.memory import ValueMemory
+from fleche.caches import Cache
+from fleche import fleche, cache
+
+
+def test_sql_load_by_table_index_with_code_digest(tmp_path):
+    """cache.load(table().index.iloc[0]) must not raise KeyError in SQL config with hash_code=True."""
+    db_path = tmp_path / "calls.db"
+    c = Cache(values=ValueMemory(storage={}), calls=Sql(str(db_path)))
+
+    with cache(c):
+        @fleche(hash_code=True)
+        def my_func(x):
+            return x * 2
+
+        my_func(1)
+        my_func(2)
+
+        table = c.table()
+        assert len(table) == 2
+
+        for key in table.index:
+            result = c.load(key)
+            assert result is not None
+
+
+def test_sql_load_by_table_index_without_code_digest(tmp_path):
+    """cache.load(table().index.iloc[0]) must not raise KeyError in SQL config with hash_code=False."""
+    db_path = tmp_path / "calls.db"
+    c = Cache(values=ValueMemory(storage={}), calls=Sql(str(db_path)))
+
+    with cache(c):
+        @fleche(hash_code=False)
+        def my_func(x):
+            return x * 2
+
+        my_func(1)
+        my_func(2)
+
+        table = c.table()
+        assert len(table) == 2
+
+        for key in table.index:
+            result = c.load(key)
+            assert result is not None
+
+
+def test_sql_table_index_matches_storage_keys(tmp_path):
+    """table().index values must equal the keys returned by calls.list()."""
+    db_path = tmp_path / "calls.db"
+    c = Cache(values=ValueMemory(storage={}), calls=Sql(str(db_path)))
+
+    with cache(c):
+        @fleche(hash_code=True)
+        def my_func(x):
+            return x * 2
+
+        my_func(1)
+        my_func(2)
+
+    table = c.table()
+    storage_keys = set(str(k) for k in c.calls.list())
+    assert set(table.index) == storage_keys

--- a/tests/unit/storage/test_sql_query.py
+++ b/tests/unit/storage/test_sql_query.py
@@ -265,7 +265,7 @@ def test_sql_call_digest_persistence(store):
         metadata={"m": {"k": "v"}},
         module="mod",
         version=42,
-        code_digest="some_code_digest",
+        code_digest=Digest("some_code_digest"),
         result=digest(3)
     )
 


### PR DESCRIPTION
When loading a Call from SQL, code_digest was returned as a plain str, but at save time it was a Digest. digest(Digest(x)) == x (identity) while digest(str(x)) == SHA256("str"+x), so to_lookup_key() produced a different hash after SQL round-trip, breaking cache.load(table().index.iloc[0]).

Fix: wrap code_digest in Digest() in Sql.get(), matching the existing treatment of result and argument values.

Closes #319.

Generated with [Claude Code](https://claude.ai/code)