### PR TITLE
Expose version_validator in BagOfHoldingH5FileBackend

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,15 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',
     'autoapi.extension',
     'sphinx_rtd_theme',
     'nbsphinx',
 ]
+
+intersphinx_mapping = {
+    'bagofholding': ('https://bagofholding.readthedocs.io/en/latest/', None),
+}
 
 nbsphinx_execute = 'never'
 

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -275,8 +275,6 @@ def storage_to_config(s: storage.ValueStorage | storage.CallStorage) -> dict[str
             config = asdict(s)  # type: ignore
             config["type"] = "bagofholding_hdf"
             config["root"] = str(config["root"])
-            if config.get("version_validator") is None:
-                config.pop("version_validator", None)
         case storage.sql.Sql():
             config = {"type": "sql", "url": s.url, "echo": s.echo}
         case _:

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -61,7 +61,7 @@ following **lowercase** identifiers:
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
     interval for exponential backoff (s).
     Optional: ``version_validator`` (str, default omitted) — version validation
-    strategy passed to ``H5Bag.load()``.  One of ``"exact"``, ``"semantic-minor"``,
+    strategy passed to :class:`bagofholding:bagofholding.h5.bag.H5Bag`.load().  One of ``"exact"``, ``"semantic-minor"``,
     ``"semantic-major"``, ``"none"``.  When omitted, bagofholding's default applies.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -61,7 +61,7 @@ following **lowercase** identifiers:
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
     interval for exponential backoff (s).
     Optional: ``version_validator`` (str, default omitted) — version validation
-    strategy passed to :class:`bagofholding:bagofholding.h5.bag.H5Bag`.load().  One of ``"exact"``, ``"semantic-minor"``,
+    strategy passed to :meth:`bagofholding:bagofholding.h5.bag.H5Bag.load`.  One of ``"exact"``, ``"semantic-minor"``,
     ``"semantic-major"``, ``"none"``.  When omitted, bagofholding's default applies.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -60,6 +60,9 @@ following **lowercase** identifiers:
     Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
     interval for exponential backoff (s).
+    Optional: ``version_validator`` (str, default omitted) — version validation
+    strategy passed to ``H5Bag.load()``.  One of ``"exact"``, ``"semantic-minor"``,
+    ``"semantic-major"``, ``"none"``.  When omitted, bagofholding's default applies.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 
 ``"sql"``
@@ -216,7 +219,7 @@ def storage_from_config(d: dict[str, Any], type: Literal["call", "value"]) -> st
       — same optional keys as ``"pickle"``
     * ``{"type": "bagofholding_hdf", "root": "<path>"}``
       — optional: ``lock_timeout``, ``lock_wait_start``,
-      ``remaining_depth`` (value only)
+      ``version_validator``, ``remaining_depth`` (value only)
     * ``{"type": "sql", "url": "<sqlalchemy-url>"}``  *(call storage only)*
       — optional: ``echo``
 
@@ -272,6 +275,8 @@ def storage_to_config(s: storage.ValueStorage | storage.CallStorage) -> dict[str
             config = asdict(s)  # type: ignore
             config["type"] = "bagofholding_hdf"
             config["root"] = str(config["root"])
+            if config.get("version_validator") is None:
+                config.pop("version_validator", None)
         case storage.sql.Sql():
             config = {"type": "sql", "url": s.url, "echo": s.echo}
         case _:

--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 import logging
 
 from .file import FileStorage
@@ -18,9 +18,12 @@ with ImportAlarm(
 ) as bagofholding_alarm:
     from bagofholding import H5Bag
 
+VersionValidator = Literal["exact", "semantic-minor", "semantic-major", "none"]
+
 
 @dataclass(frozen=True)
 class BagOfHoldingH5FileBackend(FileStorage):
+    version_validator: VersionValidator | None = None
 
     @bagofholding_alarm
     def __post_init__(self):
@@ -35,7 +38,10 @@ class BagOfHoldingH5FileBackend(FileStorage):
 
     def _from_file(self, path: Path) -> Any:
         try:
-            return H5Bag(path).load()
+            kwargs = {}
+            if self.version_validator is not None:
+                kwargs["version_validator"] = self.version_validator
+            return H5Bag(path).load(**kwargs)
         except FileNotFoundError:
             raise KeyError(path) from None
         except OSError as e:

--- a/tests/unit/config/test_storage_to_config.py
+++ b/tests/unit/config/test_storage_to_config.py
@@ -39,7 +39,7 @@ def test_bagofholding_h5file(tmp_path):
     cfg = storage_to_config(s)
     assert cfg["type"] == "bagofholding_hdf"
     assert cfg["root"] == str(s.root)
-    assert "version_validator" not in cfg
+    assert cfg["version_validator"] is None
 
 
 def test_bagofholding_h5file_with_version_validator(tmp_path):

--- a/tests/unit/config/test_storage_to_config.py
+++ b/tests/unit/config/test_storage_to_config.py
@@ -39,6 +39,26 @@ def test_bagofholding_h5file(tmp_path):
     cfg = storage_to_config(s)
     assert cfg["type"] == "bagofholding_hdf"
     assert cfg["root"] == str(s.root)
+    assert "version_validator" not in cfg
+
+
+def test_bagofholding_h5file_with_version_validator(tmp_path):
+    pytest.importorskip("bagofholding")
+    root = tmp_path / "values"
+    s = storage.ValueBagOfHoldingH5File(root=root, version_validator="none")
+    cfg = storage_to_config(s)
+    assert cfg["type"] == "bagofholding_hdf"
+    assert cfg["version_validator"] == "none"
+
+
+def test_bagofholding_h5file_version_validator_roundtrip(tmp_path):
+    pytest.importorskip("bagofholding")
+    root = tmp_path / "values"
+    original = storage.ValueBagOfHoldingH5File(root=root, version_validator="semantic-minor")
+    cfg = storage_to_config(original)
+    reconstructed = storage_from_config(cfg, "value")
+    assert isinstance(reconstructed, storage.ValueBagOfHoldingH5File)
+    assert reconstructed.version_validator == "semantic-minor"
 
 
 def test_sql():

--- a/tests/unit/storage/test_bagofholding_file.py
+++ b/tests/unit/storage/test_bagofholding_file.py
@@ -20,3 +20,74 @@ def test_load_corrupt_h5_file(tmp_path, caplog):
             storage.get(key)
 
     assert f"Corrupt file present in cache at path {path}" in caplog.text
+
+
+def test_version_validator_default_is_none(tmp_path):
+    pytest.importorskip("bagofholding")
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    assert s.version_validator is None
+
+
+def test_version_validator_field_accepted(tmp_path):
+    pytest.importorskip("bagofholding")
+    s = BagOfHoldingH5FileBackend(tmp_path, version_validator="none")
+    assert s.version_validator == "none"
+
+
+def test_version_validator_passed_to_load(tmp_path, monkeypatch):
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    captured = {}
+
+    class FakeH5Bag:
+        def __init__(self, path):
+            self.path = path
+
+        def load(self, **kwargs):
+            captured.update(kwargs)
+            return 42
+
+        @staticmethod
+        def save(value, path):
+            pass
+
+    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path, version_validator="semantic-minor")
+    key = Digest("test_key")
+    s.put(42, key)
+    result = s.get(key)
+
+    assert result == 42
+    assert captured.get("version_validator") == "semantic-minor"
+
+
+def test_version_validator_none_not_passed_to_load(tmp_path, monkeypatch):
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    captured = {"called": False}
+
+    class FakeH5Bag:
+        def __init__(self, path):
+            self.path = path
+
+        def load(self, **kwargs):
+            captured["kwargs"] = kwargs
+            captured["called"] = True
+            return 42
+
+        @staticmethod
+        def save(value, path):
+            pass
+
+    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    key = Digest("test_key2")
+    s.put(42, key)
+    s.get(key)
+
+    assert captured["called"]
+    assert "version_validator" not in captured["kwargs"]


### PR DESCRIPTION
Add `version_validator` field to `BagOfHoldingH5FileBackend` that is passed through to `H5Bag.load()`.

Supported values: "exact", "semantic-minor", "semantic-major", "none". Defaults to `None` (bagofholding's default applies). Configurable via fleche.toml.

Closes #353

Generated with [Claude Code](https://claude.ai/code)