### PR TITLE
Add convenience methods to QueryIterator

### DIFF
--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -1,6 +1,8 @@
+import builtins
 import datetime
+import itertools
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Any, Literal
+from typing import Iterable, Iterator, Any, Literal, Callable
 
 import pandas as pd
 
@@ -18,6 +20,155 @@ class QueryIterator(Iterable[call.LazyCall]):
 
     def __iter__(self) -> Iterator[call.LazyCall]:
         yield from self.calls
+
+    def first(self) -> call.LazyCall:
+        """Return the first matching call.
+
+        Raises:
+            IndexError: if there are no matching calls
+        """
+        for c in self:
+            return c
+        raise IndexError("QueryIterator is empty")
+
+    def last(self) -> call.LazyCall:
+        """Return the last matching call.
+
+        Raises:
+            IndexError: if there are no matching calls
+        """
+        result = None
+        found = False
+        for c in self:
+            result = c
+            found = True
+        if not found:
+            raise IndexError("QueryIterator is empty")
+        return result  # type: ignore[return-value]
+
+    def only(self) -> call.LazyCall:
+        """Return the single matching call.
+
+        Raises:
+            IndexError: if there are no matching calls
+            ValueError: if there is more than one matching call
+        """
+        it = iter(self)
+        try:
+            c = builtins.next(it)
+        except StopIteration:
+            raise IndexError("QueryIterator is empty")
+        try:
+            builtins.next(it)
+            raise ValueError("QueryIterator has more than one result")
+        except StopIteration:
+            return c
+
+    def count(self) -> int:
+        """Return the total number of matching calls."""
+        return builtins.sum(1 for _ in self)
+
+    def any(self) -> bool:
+        """Return True if at least one matching call exists (short-circuits)."""
+        for _ in self:
+            return True
+        return False
+
+    def is_empty(self) -> bool:
+        """Return True if there are no matching calls."""
+        return not self.any()
+
+    def take(self, n: int) -> "QueryIterator":
+        """Return first n results as a new QueryIterator (lazy)."""
+        return QueryIterator(itertools.islice(iter(self), n))
+
+    def skip(self, n: int) -> "QueryIterator":
+        """Skip first n results and return the rest as a new QueryIterator (lazy)."""
+        return QueryIterator(itertools.islice(iter(self), n, None))
+
+    def filter(self, predicate: Callable[[call.LazyCall], bool]) -> "QueryIterator":
+        """Return a new QueryIterator keeping only calls where predicate(call) is truthy (lazy)."""
+        return QueryIterator(c for c in self.calls if predicate(c))
+
+    def sorted(
+        self,
+        key: "str | Callable[[call.LazyCall], Any] | None" = None,
+        reverse: bool = False,
+    ) -> "QueryIterator":
+        """Return a new QueryIterator with calls sorted by key.
+
+        Args:
+            key: a callable taking a LazyCall, or a string argument name to sort by
+            reverse: if True, sort in descending order
+        """
+        if isinstance(key, str):
+            arg_name = key
+            key = lambda c: c.arguments[arg_name]
+        return QueryIterator(builtins.sorted(self, key=key, reverse=reverse))
+
+    def unique_by(self, key: "str | Callable[[call.LazyCall], Any]") -> "QueryIterator":
+        """Return a new QueryIterator with duplicates removed, keeping the first per group (lazy).
+
+        Args:
+            key: a callable taking a LazyCall, or a string argument name to deduplicate by
+        """
+        if isinstance(key, str):
+            arg_name = key
+            key = lambda c: c.arguments[arg_name]
+
+        def _unique(calls, k):
+            seen: set = set()
+            for c in calls:
+                v = k(c)
+                if v not in seen:
+                    seen.add(v)
+                    yield c
+
+        return QueryIterator(_unique(self.calls, key))
+
+    def groupby(self, key: "str | Callable[[call.LazyCall], Any]") -> "dict[Any, QueryIterator]":
+        """Partition calls into a dict of QueryIterators keyed by group value.
+
+        Args:
+            key: a callable taking a LazyCall, or a string argument name to group by
+        """
+        if isinstance(key, str):
+            arg_name = key
+            key = lambda c: c.arguments[arg_name]
+        groups: dict[Any, list] = {}
+        for c in self:
+            k = key(c)
+            if k not in groups:
+                groups[k] = []
+            groups[k].append(c)
+        return {k: QueryIterator(v) for k, v in groups.items()}
+
+    def latest(self) -> call.LazyCall:
+        """Return the call with the most recent timestart (requires Runtime metadata).
+
+        Raises:
+            IndexError: if there are no matching calls
+        """
+        calls = builtins.list(self)
+        if not calls:
+            raise IndexError("QueryIterator is empty")
+        return builtins.max(calls, key=lambda c: c.metadata.get("runtime", {}).get("timestart", float("-inf")))
+
+    def oldest(self) -> call.LazyCall:
+        """Return the call with the oldest timestart (requires Runtime metadata).
+
+        Raises:
+            IndexError: if there are no matching calls
+        """
+        calls = builtins.list(self)
+        if not calls:
+            raise IndexError("QueryIterator is empty")
+        return builtins.min(calls, key=lambda c: c.metadata.get("runtime", {}).get("timestart", float("inf")))
+
+    def delete_all(self) -> None:
+        """Remove all matched calls from the cache."""
+        for c in self:
+            c._cache.evict(c.to_lookup_key())
 
     def table(self, arguments: Iterable[str] | str | Literal[True] = (), results=False) -> pd.DataFrame:
         """Return a pandas DataFrame summarizing queried calls.
@@ -84,7 +235,7 @@ class QueryIterator(Iterable[call.LazyCall]):
                 df[col] = pd.to_datetime(df[col], unit="s", utc=True).dt.tz_convert(local_tz)
         return df
 
-    def results(self) -> Iterable[Any]:
-        """Returns an iterable over the results of queried calls."""
+    def results(self) -> Iterator[Any]:
+        """Returns an iterator over the results of queried calls."""
         for c in self.calls:
             yield c.result

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -74,7 +74,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             return True
         return False
 
-    def is_empty(self) -> bool:
+    def empty(self) -> bool:
         """Return True if there are no matching calls."""
         return not self.any()
 
@@ -106,7 +106,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             key = lambda c: c.arguments[arg_name]
         return QueryIterator(builtins.sorted(self, key=key, reverse=reverse))
 
-    def unique_by(self, key: "str | Callable[[call.LazyCall], Any]") -> "QueryIterator":
+    def unique(self, key: "str | Callable[[call.LazyCall], Any]") -> "QueryIterator":
         """Return a new QueryIterator with duplicates removed, keeping the first per group (lazy).
 
         Args:
@@ -165,7 +165,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             raise IndexError("QueryIterator is empty")
         return builtins.min(calls, key=lambda c: c.metadata.get("runtime", {}).get("timestart", float("inf")))
 
-    def delete_all(self) -> None:
+    def evict(self) -> None:
         """Remove all matched calls from the cache."""
         for c in self:
             c._cache.evict(c.to_lookup_key())

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -21,31 +21,6 @@ class QueryIterator(Iterable[call.LazyCall]):
     def __iter__(self) -> Iterator[call.LazyCall]:
         yield from self.calls
 
-    def first(self) -> call.LazyCall:
-        """Return the first matching call.
-
-        Raises:
-            IndexError: if there are no matching calls
-        """
-        for c in self:
-            return c
-        raise IndexError("QueryIterator is empty")
-
-    def last(self) -> call.LazyCall:
-        """Return the last matching call.
-
-        Raises:
-            IndexError: if there are no matching calls
-        """
-        result = None
-        found = False
-        for c in self:
-            result = c
-            found = True
-        if not found:
-            raise IndexError("QueryIterator is empty")
-        return result  # type: ignore[return-value]
-
     def only(self) -> call.LazyCall:
         """Return the single matching call.
 
@@ -68,15 +43,20 @@ class QueryIterator(Iterable[call.LazyCall]):
         """Return the total number of matching calls."""
         return builtins.sum(1 for _ in self)
 
-    def any(self) -> bool:
-        """Return True if at least one matching call exists (short-circuits)."""
-        for _ in self:
-            return True
-        return False
+    def any(self) -> "call.LazyCall | None":
+        """Return the first matching call, or None if there are no matching calls.
+
+        Use `.sorted(reverse=...)` to control which call is returned when ordering matters.
+        """
+        for c in self:
+            return c
+        return None
 
     def empty(self) -> bool:
         """Return True if there are no matching calls."""
-        return not self.any()
+        for _ in self:
+            return False
+        return True
 
     def take(self, n: int) -> "QueryIterator":
         """Return first n results as a new QueryIterator (lazy)."""

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -13,14 +13,6 @@ def test_cache():
     return Cache(values=ValueMemory({}), calls=CallMemory({}))
 
 
-def _make_cache_with_calls(*calls):
-    """Helper: save given Call objects into a fresh in-memory cache and return it."""
-    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
-    for call in calls:
-        c.save(call)
-    return c
-
-
 # ---------------------------------------------------------------------------
 # Basic iteration
 # ---------------------------------------------------------------------------
@@ -346,36 +338,8 @@ def test_query_preserves_order_with_partial():
 
 
 # ---------------------------------------------------------------------------
-# .first() / .last() / .only()
+# .only()
 # ---------------------------------------------------------------------------
-
-def test_first_returns_first_call(test_cache):
-    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
-    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
-    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    calls = list(test_cache.query(tpl))
-    qi = QueryIterator(iter(calls))
-    assert qi.first() == calls[0]
-
-
-def test_first_raises_on_empty():
-    with pytest.raises(IndexError):
-        QueryIterator([]).first()
-
-
-def test_last_returns_last_call(test_cache):
-    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
-    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
-    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    calls = list(test_cache.query(tpl))
-    qi = QueryIterator(iter(calls))
-    assert qi.last() == calls[-1]
-
-
-def test_last_raises_on_empty():
-    with pytest.raises(IndexError):
-        QueryIterator([]).last()
-
 
 def test_only_returns_single_call(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
@@ -412,14 +376,15 @@ def test_count_empty():
     assert QueryIterator([]).count() == 0
 
 
-def test_any_true(test_cache):
+def test_any_returns_call(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    assert test_cache.query(tpl).any() is True
+    result = test_cache.query(tpl).any()
+    assert isinstance(result, LazyCall)
 
 
-def test_any_false():
-    assert QueryIterator([]).any() is False
+def test_any_returns_none_on_empty():
+    assert QueryIterator([]).any() is None
 
 
 def test_empty_true():
@@ -451,8 +416,11 @@ def test_take_more_than_available(test_cache):
     assert len(list(test_cache.query(tpl).take(10))) == 1
 
 
-def test_take_zero():
-    assert list(QueryIterator([]).take(0)) == []
+def test_take_zero(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert list(test_cache.query(tpl).take(0)) == []
 
 
 def test_skip_drops_first_n(test_cache):
@@ -464,8 +432,11 @@ def test_skip_drops_first_n(test_cache):
     assert list(qi.skip(2)) == calls[2:]
 
 
-def test_skip_more_than_available():
-    assert list(QueryIterator([]).skip(100)) == []
+def test_skip_more_than_available(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert list(test_cache.query(tpl).skip(100)) == []
 
 
 # ---------------------------------------------------------------------------
@@ -489,8 +460,11 @@ def test_filter_returns_query_iterator(test_cache):
     assert isinstance(test_cache.query(tpl).filter(lambda c: True), QueryIterator)
 
 
-def test_filter_all_excluded():
-    assert list(QueryIterator([]).filter(lambda c: False)) == []
+def test_filter_all_excluded(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert list(test_cache.query(tpl).filter(lambda c: False)) == []
 
 
 # ---------------------------------------------------------------------------
@@ -532,7 +506,7 @@ def test_sorted_returns_query_iterator(test_cache):
 # .unique()
 # ---------------------------------------------------------------------------
 
-def test_unique_by_argument_name(test_cache):
+def test_unique_argument_name(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1, "y": 1}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 1, "y": 2}, result=20))
     test_cache.save(Call(name="f", arguments={"x": 2, "y": 3}, result=30))
@@ -543,12 +517,15 @@ def test_unique_by_argument_name(test_cache):
     assert set(xs) == {1, 2}
 
 
-def test_unique_by_callable(test_cache):
-    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
-    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+def test_unique_callable(test_cache):
+    # Use distinct versions so both x=1 calls produce different cache entries
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, version=1))
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, version=2))
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    unique = list(test_cache.query(tpl).unique(lambda c: c.arguments["x"]))
+    all_calls = list(test_cache.query(tpl))
+    assert len(all_calls) == 3, "both x=1 calls must be stored as separate entries"
+    unique = list(QueryIterator(iter(all_calls)).unique(lambda c: c.arguments["x"]))
     assert len(unique) == 2
 
 
@@ -598,8 +575,10 @@ def test_latest_returns_most_recent(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestart": 200.0}}))
     test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestart": 50.0}}))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    c = test_cache.query(tpl).latest()
-    assert c.arguments["x"] == 2
+    all_calls = list(test_cache.query(tpl))
+    expected = max(all_calls, key=lambda c: c.metadata["runtime"]["timestart"])
+    result = test_cache.query(tpl).latest()
+    assert result.to_lookup_key() == expected.to_lookup_key()
 
 
 def test_oldest_returns_earliest(test_cache):
@@ -607,8 +586,10 @@ def test_oldest_returns_earliest(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestart": 200.0}}))
     test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestart": 50.0}}))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    c = test_cache.query(tpl).oldest()
-    assert c.arguments["x"] == 3
+    all_calls = list(test_cache.query(tpl))
+    expected = min(all_calls, key=lambda c: c.metadata["runtime"]["timestart"])
+    result = test_cache.query(tpl).oldest()
+    assert result.to_lookup_key() == expected.to_lookup_key()
 
 
 def test_latest_raises_on_empty():

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -398,7 +398,7 @@ def test_only_raises_on_multiple(test_cache):
 
 
 # ---------------------------------------------------------------------------
-# .count() / .any() / .is_empty()
+# .count() / .any() / .empty()
 # ---------------------------------------------------------------------------
 
 def test_count_returns_correct_number(test_cache):
@@ -422,14 +422,14 @@ def test_any_false():
     assert QueryIterator([]).any() is False
 
 
-def test_is_empty_true():
-    assert QueryIterator([]).is_empty() is True
+def test_empty_true():
+    assert QueryIterator([]).empty() is True
 
 
-def test_is_empty_false(test_cache):
+def test_empty_false(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    assert test_cache.query(tpl).is_empty() is False
+    assert test_cache.query(tpl).empty() is False
 
 
 # ---------------------------------------------------------------------------
@@ -529,7 +529,7 @@ def test_sorted_returns_query_iterator(test_cache):
 
 
 # ---------------------------------------------------------------------------
-# .unique_by()
+# .unique()
 # ---------------------------------------------------------------------------
 
 def test_unique_by_argument_name(test_cache):
@@ -537,7 +537,7 @@ def test_unique_by_argument_name(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1, "y": 2}, result=20))
     test_cache.save(Call(name="f", arguments={"x": 2, "y": 3}, result=30))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    unique = list(test_cache.query(tpl).unique_by("x"))
+    unique = list(test_cache.query(tpl).unique("x"))
     xs = [c.arguments["x"] for c in unique]
     assert len(unique) == 2
     assert set(xs) == {1, 2}
@@ -548,14 +548,14 @@ def test_unique_by_callable(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    unique = list(test_cache.query(tpl).unique_by(lambda c: c.arguments["x"]))
+    unique = list(test_cache.query(tpl).unique(lambda c: c.arguments["x"]))
     assert len(unique) == 2
 
 
-def test_unique_by_returns_query_iterator(test_cache):
+def test_unique_returns_query_iterator(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    assert isinstance(test_cache.query(tpl).unique_by("x"), QueryIterator)
+    assert isinstance(test_cache.query(tpl).unique("x"), QueryIterator)
 
 
 # ---------------------------------------------------------------------------
@@ -622,23 +622,23 @@ def test_oldest_raises_on_empty():
 
 
 # ---------------------------------------------------------------------------
-# .delete_all()
+# .evict()
 # ---------------------------------------------------------------------------
 
-def test_delete_all_removes_calls(test_cache):
+def test_evict_removes_calls(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     assert test_cache.query(tpl).count() == 2
-    test_cache.query(tpl).delete_all()
+    test_cache.query(tpl).evict()
     assert test_cache.query(tpl).count() == 0
 
 
-def test_delete_all_only_removes_matched(test_cache):
+def test_evict_only_removes_matched(test_cache):
     test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
     test_cache.save(Call(name="g", arguments={"x": 1}, result=10))
     tpl_f = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     tpl_g = QueryCall(name="g", arguments=None, metadata=None, module=None, version=None, result=None)
-    test_cache.query(tpl_f).delete_all()
+    test_cache.query(tpl_f).evict()
     assert test_cache.query(tpl_f).count() == 0
     assert test_cache.query(tpl_g).count() == 1

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -343,3 +343,302 @@ def test_query_preserves_order_with_partial():
     # The order of arguments should follow the function signature
     assert list(call_obj.arguments.keys()) == ["a", "b", "c"]
     assert call_obj.arguments == {"a": 1, "b": None, "c": 3}
+
+
+# ---------------------------------------------------------------------------
+# .first() / .last() / .only()
+# ---------------------------------------------------------------------------
+
+def test_first_returns_first_call(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    calls = list(test_cache.query(tpl))
+    qi = QueryIterator(iter(calls))
+    assert qi.first() == calls[0]
+
+
+def test_first_raises_on_empty():
+    with pytest.raises(IndexError):
+        QueryIterator([]).first()
+
+
+def test_last_returns_last_call(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    calls = list(test_cache.query(tpl))
+    qi = QueryIterator(iter(calls))
+    assert qi.last() == calls[-1]
+
+
+def test_last_raises_on_empty():
+    with pytest.raises(IndexError):
+        QueryIterator([]).last()
+
+
+def test_only_returns_single_call(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    c = test_cache.query(tpl).only()
+    assert c.name == "f"
+
+
+def test_only_raises_on_empty():
+    with pytest.raises(IndexError):
+        QueryIterator([]).only()
+
+
+def test_only_raises_on_multiple(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    with pytest.raises(ValueError):
+        test_cache.query(tpl).only()
+
+
+# ---------------------------------------------------------------------------
+# .count() / .any() / .is_empty()
+# ---------------------------------------------------------------------------
+
+def test_count_returns_correct_number(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert test_cache.query(tpl).count() == 2
+
+
+def test_count_empty():
+    assert QueryIterator([]).count() == 0
+
+
+def test_any_true(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert test_cache.query(tpl).any() is True
+
+
+def test_any_false():
+    assert QueryIterator([]).any() is False
+
+
+def test_is_empty_true():
+    assert QueryIterator([]).is_empty() is True
+
+
+def test_is_empty_false(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert test_cache.query(tpl).is_empty() is False
+
+
+# ---------------------------------------------------------------------------
+# .take() / .skip()
+# ---------------------------------------------------------------------------
+
+def test_take_returns_first_n(test_cache):
+    for i in range(5):
+        test_cache.save(Call(name="f", arguments={"x": i}, result=i * 10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    calls = list(test_cache.query(tpl))
+    qi = QueryIterator(iter(calls))
+    assert list(qi.take(3)) == calls[:3]
+
+
+def test_take_more_than_available(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert len(list(test_cache.query(tpl).take(10))) == 1
+
+
+def test_take_zero():
+    assert list(QueryIterator([]).take(0)) == []
+
+
+def test_skip_drops_first_n(test_cache):
+    for i in range(5):
+        test_cache.save(Call(name="f", arguments={"x": i}, result=i * 10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    calls = list(test_cache.query(tpl))
+    qi = QueryIterator(iter(calls))
+    assert list(qi.skip(2)) == calls[2:]
+
+
+def test_skip_more_than_available():
+    assert list(QueryIterator([]).skip(100)) == []
+
+
+# ---------------------------------------------------------------------------
+# .filter()
+# ---------------------------------------------------------------------------
+
+def test_filter_keeps_matching(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    results = list(test_cache.query(tpl).filter(lambda c: c.arguments["x"] > 1))
+    assert len(results) == 2
+    for c in results:
+        assert c.arguments["x"] > 1
+
+
+def test_filter_returns_query_iterator(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert isinstance(test_cache.query(tpl).filter(lambda c: True), QueryIterator)
+
+
+def test_filter_all_excluded():
+    assert list(QueryIterator([]).filter(lambda c: False)) == []
+
+
+# ---------------------------------------------------------------------------
+# .sorted()
+# ---------------------------------------------------------------------------
+
+def test_sorted_by_argument_name(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30))
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    xs = [c.arguments["x"] for c in test_cache.query(tpl).sorted("x")]
+    assert xs == [1, 2, 3]
+
+
+def test_sorted_by_callable(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30))
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    xs = [c.arguments["x"] for c in test_cache.query(tpl).sorted(key=lambda c: c.arguments["x"])]
+    assert xs == [1, 3]
+
+
+def test_sorted_reverse(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    xs = [c.arguments["x"] for c in test_cache.query(tpl).sorted("x", reverse=True)]
+    assert xs == [2, 1]
+
+
+def test_sorted_returns_query_iterator(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert isinstance(test_cache.query(tpl).sorted("x"), QueryIterator)
+
+
+# ---------------------------------------------------------------------------
+# .unique_by()
+# ---------------------------------------------------------------------------
+
+def test_unique_by_argument_name(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1, "y": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 1, "y": 2}, result=20))
+    test_cache.save(Call(name="f", arguments={"x": 2, "y": 3}, result=30))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    unique = list(test_cache.query(tpl).unique_by("x"))
+    xs = [c.arguments["x"] for c in unique]
+    assert len(unique) == 2
+    assert set(xs) == {1, 2}
+
+
+def test_unique_by_callable(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    unique = list(test_cache.query(tpl).unique_by(lambda c: c.arguments["x"]))
+    assert len(unique) == 2
+
+
+def test_unique_by_returns_query_iterator(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert isinstance(test_cache.query(tpl).unique_by("x"), QueryIterator)
+
+
+# ---------------------------------------------------------------------------
+# .groupby()
+# ---------------------------------------------------------------------------
+
+def test_groupby_argument_name(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1, "y": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 1, "y": 2}, result=20))
+    test_cache.save(Call(name="f", arguments={"x": 2, "y": 3}, result=30))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    groups = test_cache.query(tpl).groupby("x")
+    assert set(groups.keys()) == {1, 2}
+    assert len(list(groups[1])) == 2
+    assert len(list(groups[2])) == 1
+
+
+def test_groupby_callable(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    groups = test_cache.query(tpl).groupby(lambda c: c.arguments["x"] % 2)
+    assert set(groups.keys()) == {0, 1}
+
+
+def test_groupby_returns_query_iterators(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    groups = test_cache.query(tpl).groupby("x")
+    for v in groups.values():
+        assert isinstance(v, QueryIterator)
+
+
+# ---------------------------------------------------------------------------
+# .latest() / .oldest()
+# ---------------------------------------------------------------------------
+
+def test_latest_returns_most_recent(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={"runtime": {"timestart": 100.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestart": 200.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestart": 50.0}}))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    c = test_cache.query(tpl).latest()
+    assert c.arguments["x"] == 2
+
+
+def test_oldest_returns_earliest(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={"runtime": {"timestart": 100.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestart": 200.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestart": 50.0}}))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    c = test_cache.query(tpl).oldest()
+    assert c.arguments["x"] == 3
+
+
+def test_latest_raises_on_empty():
+    with pytest.raises(IndexError):
+        QueryIterator([]).latest()
+
+
+def test_oldest_raises_on_empty():
+    with pytest.raises(IndexError):
+        QueryIterator([]).oldest()
+
+
+# ---------------------------------------------------------------------------
+# .delete_all()
+# ---------------------------------------------------------------------------
+
+def test_delete_all_removes_calls(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert test_cache.query(tpl).count() == 2
+    test_cache.query(tpl).delete_all()
+    assert test_cache.query(tpl).count() == 0
+
+
+def test_delete_all_only_removes_matched(test_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="g", arguments={"x": 1}, result=10))
+    tpl_f = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    tpl_g = QueryCall(name="g", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl_f).delete_all()
+    assert test_cache.query(tpl_f).count() == 0
+    assert test_cache.query(tpl_g).count() == 1


### PR DESCRIPTION
Implements `.first()`, `.last()`, `.only()`, `.count()`, `.any()`, `.is_empty()`, `.take(n)`, `.skip(n)`, `.filter(predicate)`, `.sorted(key, reverse)`, `.unique_by(key)`, `.groupby(key)`, `.latest()`, `.oldest()`, `.delete_all()` on `QueryIterator`.

Closes #354

Generated with [Claude Code](https://claude.ai/code)