### PR TITLE
Make pickle file reads format-agnostic; add compress_all/decompress_all

### DIFF
--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
-from .file import FileStorage
+from .file import FileStorage, file_write_lock
 from .base import ValueMixin, CallMixin
 from .destructuring import DestructuringMixin
 from ..security import get_secret_key, normalize_secret_key, SignedBytes, SignatureError
@@ -72,7 +72,7 @@ class PickleFileBackend(FileStorage):
     def _from_file(self, path: Path) -> Any:
         try:
             content = path.read_bytes()
-            if self.compress:
+            if content[:2] == b"\x1f\x8b":
                 content = gzip.decompress(content)
             signer = SignedBytes(self.secret_key)
             data = signer.loads(content)
@@ -81,6 +81,32 @@ class PickleFileBackend(FileStorage):
             raise KeyError(path) from None
         except SignatureError:
             raise KeyError(path, "Value present but failed signature check.")
+
+    def compress_all(self) -> None:
+        """Rewrite all stored files in gzip-compressed form."""
+        for key in list(self.list()):
+            path = self._path(key)
+            lock_path = self._path(f"{key}.lock")
+            with file_write_lock(lock_path):
+                try:
+                    content = path.read_bytes()
+                except FileNotFoundError:
+                    continue
+                if content[:2] != b"\x1f\x8b":
+                    path.write_bytes(gzip.compress(content))
+
+    def decompress_all(self) -> None:
+        """Rewrite all stored files in uncompressed form."""
+        for key in list(self.list()):
+            path = self._path(key)
+            lock_path = self._path(f"{key}.lock")
+            with file_write_lock(lock_path):
+                try:
+                    content = path.read_bytes()
+                except FileNotFoundError:
+                    continue
+                if content[:2] == b"\x1f\x8b":
+                    path.write_bytes(gzip.decompress(content))
 
 
 @dataclass(frozen=True)

--- a/tests/unit/storage/test_pickle_file.py
+++ b/tests/unit/storage/test_pickle_file.py
@@ -74,3 +74,89 @@ def test_post_init_str_key_roundtrip(tmp_path):
     value = {"hello": "world"}
     digest_key = storage.save(value)
     assert storage.load(digest_key) == value
+
+
+def test_read_compressed_file_with_compress_false(tmp_path):
+    """A storage with compress=False can still read files written with compress=True."""
+    writer = PickleFile.with_pickle(root=tmp_path, compress=True)
+    reader = PickleFile.with_pickle(root=tmp_path, compress=False)
+    value = {"x": 42}
+    key = writer.save(value)
+    assert reader.load(key) == value
+
+
+def test_read_uncompressed_file_with_compress_true(tmp_path):
+    """A storage with compress=True can still read files written with compress=False."""
+    writer = PickleFile.with_pickle(root=tmp_path, compress=False)
+    reader = PickleFile.with_pickle(root=tmp_path, compress=True)
+    value = {"x": 42}
+    key = writer.save(value)
+    assert reader.load(key) == value
+
+
+def test_compress_all(tmp_path):
+    """compress_all() rewrites uncompressed files as gzip-compressed."""
+    storage = PickleFile.with_pickle(root=tmp_path, compress=False)
+    value = {"a": 1}
+    key = storage.save(value)
+
+    raw = (tmp_path / str(key)).read_bytes()
+    assert raw[:2] != b"\x1f\x8b"
+
+    storage.compress_all()
+
+    raw = (tmp_path / str(key)).read_bytes()
+    assert raw[:2] == b"\x1f\x8b"
+    assert storage.load(key) == value
+
+
+def test_compress_all_idempotent(tmp_path):
+    """compress_all() on already-compressed files leaves them unchanged."""
+    storage = PickleFile.with_pickle(root=tmp_path, compress=True)
+    value = {"a": 1}
+    key = storage.save(value)
+
+    storage.compress_all()
+    storage.compress_all()
+
+    assert storage.load(key) == value
+
+
+def test_decompress_all(tmp_path):
+    """decompress_all() rewrites gzip-compressed files as uncompressed."""
+    storage = PickleFile.with_pickle(root=tmp_path, compress=True)
+    value = {"a": 1}
+    key = storage.save(value)
+
+    raw = (tmp_path / str(key)).read_bytes()
+    assert raw[:2] == b"\x1f\x8b"
+
+    storage.decompress_all()
+
+    raw = (tmp_path / str(key)).read_bytes()
+    assert raw[:2] != b"\x1f\x8b"
+    assert storage.load(key) == value
+
+
+def test_decompress_all_idempotent(tmp_path):
+    """decompress_all() on already-uncompressed files leaves them unchanged."""
+    storage = PickleFile.with_pickle(root=tmp_path, compress=False)
+    value = {"a": 1}
+    key = storage.save(value)
+
+    storage.decompress_all()
+    storage.decompress_all()
+
+    assert storage.load(key) == value
+
+
+def test_compress_then_decompress_roundtrip(tmp_path):
+    """compress_all() followed by decompress_all() preserves values."""
+    storage = PickleFile.with_pickle(root=tmp_path, compress=False)
+    values = {storage.save({"n": i}): {"n": i} for i in range(5)}
+
+    storage.compress_all()
+    storage.decompress_all()
+
+    for key, value in values.items():
+        assert storage.load(key) == value


### PR DESCRIPTION
## Summary

- `_from_file` now detects gzip magic bytes (`\x1f\x8b`) to decompress on read, regardless of the `compress` flag — files written compressed are always readable by an uncompressed backend and vice versa
- Added `compress_all()` to rewrite all stored files as gzip-compressed in place
- Added `decompress_all()` to rewrite all stored files as uncompressed in place

Both bulk methods operate at the raw bytes level (no pickle round-trip) and use `file_write_lock` for safety. The `compress` flag now only controls the write path.

## Test plan

- [ ] `test_read_compressed_file_with_compress_false` — cross-format read (written compressed, read with `compress=False`)
- [ ] `test_read_uncompressed_file_with_compress_true` — cross-format read (written uncompressed, read with `compress=True`)
- [ ] `test_compress_all` — bulk compress rewrites files and they remain loadable
- [ ] `test_compress_all_idempotent` — double compress doesn't corrupt
- [ ] `test_decompress_all` — bulk decompress rewrites files and they remain loadable
- [ ] `test_decompress_all_idempotent` — double decompress doesn't corrupt
- [ ] `test_compress_then_decompress_roundtrip` — compress → decompress preserves all values

https://claude.ai/code/session_01QQSj2EFP11NVBeHw6fyuK9