### PR TITLE
docs(configuration): document missing version_validator option for bagofholding_hdf

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -156,6 +156,10 @@ Available storage types
     a concurrent write lock before attempting a read anyway.
     Optional: ``lock_wait_start`` (float, default ``0.001``) — initial wait interval
     (seconds) for exponential backoff while polling the write lock.
+    Optional: ``version_validator`` (str, default omitted) — version validation
+    strategy passed to ``bagofholding``'s ``H5Bag.load``.  One of ``"exact"``,
+    ``"semantic-minor"``, ``"semantic-major"``, or ``"none"``.  When omitted,
+    ``bagofholding``'s own default applies.
     Optional (value backend): ``remaining_depth`` — see `Destructuring`_ below.
 
 ``"sql"``


### PR DESCRIPTION
## Summary

The `"bagofholding_hdf"` storage backend accepts an optional `version_validator` parameter that is passed through to `bagofholding`'s `H5Bag.load`. This option controls how stored object versions are validated on load and accepts the values `"exact"`, `"semantic-minor"`, `"semantic-major"`, or `"none"`.

The option is documented in the `config.py` module docstring and is wired up in `storage/bagofholding_file.py`:

```python
# bagofholding_file.py
if self.version_validator is not None:
    kwargs["version_validator"] = self.version_validator
return H5Bag(path).load(**kwargs)
```

It was simply absent from the `configuration.rst` reference page, leaving users who need it with no way to discover it from the docs.

## What was checked

- `BagOfHoldingH5FileBackend` in `storage/bagofholding_file.py` accepts `version_validator: VersionValidator | None = None` and passes it to `H5Bag.load` when non-`None`.
- `storage_from_config` in `config.py` passes all remaining dict keys as keyword arguments to the backend constructor, so TOML entries like `values.version_validator = "exact"` are forwarded correctly.
- The valid values are taken directly from the `VersionValidator = Literal["exact", "semantic-minor", "semantic-major", "none"]` type alias in `bagofholding_file.py`.

## Test plan

- [ ] Confirm the four valid `version_validator` values match the `VersionValidator` literal in `storage/bagofholding_file.py`.
- [ ] Confirm that adding `version_validator = "exact"` to a `bagofholding_hdf` cache section in `fleche.toml` does not raise a configuration error.

https://claude.ai/code/session_011P4f5LdU91WrGsyCpv9kCq