### PR TITLE
docs(helpers, query): fix .query() signature — metadata must precede **kwargs

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -28,8 +28,8 @@ Attempts to load the result of a specific call from the cache. If the result is 
 
 Returns ``True`` if the result for the given call is already present in the cache, ``False`` otherwise.
 
-``.query(*args, **kwargs, metadata={})``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``.query(*args, metadata={}, **kwargs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Returns matching cached calls from the active cache. Any argument passed as ``None`` acts as a wildcard, matching any stored value for that parameter. The ``metadata`` keyword argument accepts a dictionary of metadata tags to further filter results (e.g., ``metadata={"tags": {"project": "alpha"}}``).
 

--- a/docs/query.rst
+++ b/docs/query.rst
@@ -5,7 +5,7 @@ Overview
 --------
 Fleche lets you retrieve previously cached calls that "match" a template using the query method. You can query either:
 
-- From a function wrapper (recommended): ``myfunc.query(*args, **kwargs, metadata={...})``
+- From a function wrapper (recommended): ``myfunc.query(*args, metadata={...}, **kwargs)``
 - From the active cache directly via a Call template: ``cache().query(Call(...))``
 
 When querying, any field in the template set to ``None`` acts as a wildcard. For arguments and result, values are compared using digest semantics (i.e., digest(template_value) == digest(stored_value)).


### PR DESCRIPTION
## Summary

Both `helpers.rst` and `query.rst` documented the `.query()` method signature as:

```
myfunc.query(*args, **kwargs, metadata={...})
```

This is **invalid Python syntax**: no parameter may appear after `**kwargs`. The actual function signature in `wrapper.py` is:

```python
def _query_func(*args, metadata={}, **kwargs) -> Iterable[AnyCall]:
```

Here `metadata` is an explicit keyword-only parameter positioned *between* `*args` and `**kwargs`. The corrected signature in both pages is:

```
myfunc.query(*args, metadata={...}, **kwargs)
```

This issue affects two pages (`helpers.rst` and `query.rst`) because they both describe the same function signature, so they are fixed together in one PR.

## Why it matters

A reader who copies the documented signature into their own code or type stubs will get a `SyntaxError`. The incorrect ordering also obscures the fact that `metadata` is captured as an independent keyword-only argument rather than being collected into `**kwargs`.

## What was checked

- `wrapper.py` line defining `_query_func`: `def _query_func(*args, metadata={}, **kwargs)` — confirms correct ordering.
- All call-site examples in `query.rst` already use `metadata` correctly (e.g. `add.query(1, 2, metadata={...})`); only the summary signature line was wrong.

## Test plan

- [ ] Confirm the updated signature matches `wrapper.py`.
- [ ] Run the query example from `query.rst` locally and confirm it produces expected results.

https://claude.ai/code/session_011P4f5LdU91WrGsyCpv9kCq