### PR TITLE
Convert docstring examples to executable doctests

### DIFF
--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -308,33 +308,23 @@ def cache_from_config(d: "dict[str, Any] | list[dict[str, Any]]") -> caches.Base
 
     The input dict is **not** mutated.
 
-    Examples::
+    Examples:
 
-        # Plain cache with in-memory storage
-        cache_from_config({
-            "values": {"type": "memory"},
-            "calls": {"type": "memory"},
-        })
+        >>> c = cache_from_config({"values": {"type": "memory"}, "calls": {"type": "memory"}})
+        >>> type(c).__name__
+        'Cache'
 
-        # Size-limited cache — presence of max_size selects SizeLimitedCache
-        cache_from_config({
-            "values": {"type": "memory"},
-            "calls": {"type": "memory"},
-            "max_size": 100,
-        })
+        >>> c = cache_from_config({"values": {"type": "memory"}, "calls": {"type": "memory"}, "max_size": 100})
+        >>> isinstance(c, caches.SizeLimitedCache)
+        True
 
-        # Read-only cache — read_only: true wraps the cache in ReadOnlyCache
-        cache_from_config({
-            "values": {"type": "memory"},
-            "calls": {"type": "memory"},
-            "read_only": True,
-        })
+        >>> c = cache_from_config({"values": {"type": "memory"}, "calls": {"type": "memory"}, "read_only": True})
+        >>> isinstance(c, caches.ReadOnlyCache)
+        True
 
-        # CacheStack — a list of dicts is implicitly treated as a stack
-        cache_from_config([
-            {"values": {"type": "memory"}, "calls": {"type": "memory"}},
-            {"values": {"type": "void"}, "calls": {"type": "void"}},
-        ])
+        >>> c = cache_from_config([{"values": {"type": "memory"}, "calls": {"type": "memory"}}, {"values": {"type": "void"}, "calls": {"type": "void"}}])
+        >>> isinstance(c, caches.CacheStack)
+        True
     """
     if isinstance(d, list):
         return caches.CacheStack(tuple(cache_from_config(c) for c in d))

--- a/src/fleche/storage/destructuring.py
+++ b/src/fleche/storage/destructuring.py
@@ -86,14 +86,16 @@ class DestructuringMixin(base.StorageBackend):
     element is stored independently; on load the original structure is
     reassembled.
 
-    Example::
+    Example:
 
-        @dataclass(frozen=True)
-        class ValueMemory(ValueMixin, DestructuringMixin, MemoryBackend): ...
-
-        vm = ValueMemory(storage={})
-        key = vm.save([1, [2, 3]])
-        assert vm.load(key) == [1, [2, 3]]
+        >>> from fleche.storage.base import ValueMixin
+        >>> from fleche.storage.memory import MemoryBackend
+        >>> @dataclass(frozen=True)
+        ... class MyValueStorage(ValueMixin, DestructuringMixin, MemoryBackend): ...
+        >>> vm = MyValueStorage(storage={})
+        >>> key = vm.save([1, [2, 3]])
+        >>> vm.load(key) == [1, [2, 3]]
+        True
     """
 
     remaining_depth: int = 0
@@ -179,14 +181,16 @@ class DestructuringMixin(base.StorageBackend):
             A :class:`~collections.Counter` mapping each :class:`~fleche.digest.Digest` key
             to the number of times it is referenced by other stored entries.
 
-        Example::
+        Example:
 
-            ds = ValueMemory(storage={})
-            shared = [2, 3]
-            ds.save([1, shared])
-            ds.save([4, shared])
-            hits = ds.count_reuses()
-            # The key for [2, 3] will have count 2; the two outer lists will have count 0.
+            >>> from fleche.storage.memory import ValueMemory
+            >>> ds = ValueMemory(storage={})
+            >>> shared = [2, 3]
+            >>> _ = ds.save([1, shared])
+            >>> _ = ds.save([4, shared])
+            >>> hits = ds.count_reuses()
+            >>> hits[ds.save(shared)]  # [2, 3] is referenced by both outer lists
+            2
         """
         counts: Counter[digest.Digest] = Counter({key: 0 for key in self.list()})
         for key in list(counts):


### PR DESCRIPTION
This PR converts informal code examples in docstrings to executable doctests that can be validated by doctest runners.

## Summary
Updated docstring examples in two modules to follow doctest format, making them executable and verifiable as part of the test suite.

## Key Changes
- **src/fleche/config.py**: Converted `cache_from_config()` docstring examples from code blocks to executable doctests with assertions
  - Changed from `::` code block format to `>>>` doctest format
  - Added assertions to verify expected behavior (type checks, isinstance checks)
  
- **src/fleche/storage/destructuring.py**: Converted examples in `DestructuringMixin` and `count_reuses()` docstrings to executable doctests
  - Updated `DestructuringMixin` example to use proper imports and verify the round-trip behavior
  - Updated `count_reuses()` example to demonstrate actual usage with assertions
  - Added necessary imports and fixed class references to use actual available classes

## Benefits
- Examples are now validated automatically by doctest
- Ensures documentation examples stay in sync with actual API behavior
- Improves documentation quality by making examples executable and testable

https://claude.ai/code/session_01HuJ7JMFyRKYWiKmC88j3wQ