### PR TITLE
refactor: extract _resolve_prefix to deduplicate expand() ambiguity logic

### DIFF
--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -18,6 +18,28 @@ class AmbiguousDigestError(ValueError):
     pass
 
 
+def _resolve_prefix(key: str, candidates: list[str]) -> Digest:
+    """Return the unique Digest for *key* prefix, or raise KeyError / AmbiguousDigestError.
+
+    *candidates* must contain at most two entries (the two lexicographically
+    smallest keys that start with *key*); callers are responsible for fetching
+    them efficiently (e.g. via a ``LIKE … LIMIT 2`` query for SQL backends).
+    """
+    if not candidates:
+        raise KeyError(key)
+    if len(candidates) == 1:
+        return Digest(candidates[0])
+    m1, m2 = candidates[0], candidates[1]
+    for i, (c1, c2) in enumerate(zip(m1, m2)):
+        if c1 != c2:
+            break
+    else:
+        i = min(len(m1), len(m2))
+    raise AmbiguousDigestError(
+        f"Short digest {key} is ambiguous; need at least {i+1} characters."
+    )
+
+
 class KeyManagement(ABC):
     """Abstract base providing key-management helpers for any keyed storage.
 
@@ -91,22 +113,8 @@ class KeyManagement(ABC):
             if len(key) < 4:
                 raise KeyError(key)
 
-            matches = sorted([k for k in self.list() if k.startswith(key)])
-            if not matches:
-                raise KeyError(key)
-            if len(matches) > 1:
-                # find longest common prefix of the first two matches to find where they diverge
-                m1, m2 = matches[0], matches[1]
-                for i, (c1, c2) in enumerate(zip(m1, m2)):
-                    if c1 != c2:
-                        break
-                else:
-                    i = min(len(m1), len(m2))
-
-                raise AmbiguousDigestError(
-                    f"Short digest {key} is ambiguous; need at least {i+1} characters."
-                )
-            return Digest(matches[0])
+            candidates = sorted(k for k in self.list() if k.startswith(key))
+            return _resolve_prefix(str(key), candidates[:2])
 
     def shrink(self, key: Digest | str) -> Digest:
         """Find the shortest substring that is still an unambiguous reference to the same value."""

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -18,7 +18,7 @@ class AmbiguousDigestError(ValueError):
     pass
 
 
-def _resolve_prefix(key: str, candidates: list[str]) -> Digest:
+def _resolve_prefix(key: str, candidates: list[Digest]) -> Digest:
     """Return the unique Digest for *key* prefix, or raise KeyError / AmbiguousDigestError.
 
     *candidates* must contain at most two entries (the two lexicographically
@@ -28,7 +28,7 @@ def _resolve_prefix(key: str, candidates: list[str]) -> Digest:
     if not candidates:
         raise KeyError(key)
     if len(candidates) == 1:
-        return Digest(candidates[0])
+        return candidates[0]
     m1, m2 = candidates[0], candidates[1]
     for i, (c1, c2) in enumerate(zip(m1, m2)):
         if c1 != c2:

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -268,7 +268,7 @@ class Sql(PerKeyLockMixin, CallStorage):
                 .order_by(CallModel.key)
                 .limit(2)
             ).all()
-            return _resolve_prefix(prefix, [r[0] for r in rows])
+            return _resolve_prefix(prefix, [Digest(r[0]) for r in rows])
 
     def _evict(self, key: Digest) -> None:
         session = self._local.session

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -4,7 +4,7 @@ import threading
 from typing import Iterable, Any, List
 from pathlib import Path
 from dataclasses import dataclass, field
-from .base import KeyManagement, CallStorage, AmbiguousDigestError
+from .base import KeyManagement, CallStorage, _resolve_prefix
 from .thread_safe import PerKeyLockMixin
 from ..call import Call, QueryCall
 from ..digest import Digest, DIGEST_LENGTH, digest
@@ -268,22 +268,7 @@ class Sql(PerKeyLockMixin, CallStorage):
                 .order_by(CallModel.key)
                 .limit(2)
             ).all()
-
-            if not rows:
-                raise KeyError(key)
-
-            if len(rows) == 1:
-                return Digest(rows[0][0])
-
-            m1, m2 = rows[0][0], rows[1][0]
-            for i, (c1, c2) in enumerate(zip(m1, m2)):
-                if c1 != c2:
-                    break
-            else:
-                i = min(len(m1), len(m2))
-            raise AmbiguousDigestError(
-                f"Short digest {key} is ambiguous; need at least {i+1} characters."
-            )
+            return _resolve_prefix(prefix, [r[0] for r in rows])
 
     def _evict(self, key: Digest) -> None:
         session = self._local.session


### PR DESCRIPTION
Moves the shared length-guard / KeyError / AmbiguousDigestError logic into a single module-level helper `_resolve_prefix(key, candidates)` in base.py.

KeyManagement.expand and Sql.expand both become thin wrappers that only fetch up to two candidate keys and delegate to the helper, keeping the SQL LIKE+LIMIT 2 optimisation intact.

Closes #324

Generated with [Claude Code](https://claude.ai/code)