### PR TITLE
Add DigestedCall and Call.dehydrate (first step #335)

### DIFF
--- a/docs/lazy_call.rst
+++ b/docs/lazy_call.rst
@@ -21,15 +21,11 @@ When you call ``cache().load(key)`` or iterate over ``cache().query(...)``, you 
    print(lazy_call.result)          # Triggers a load from value storage
    print(lazy_call.arguments['x'])  # Triggers a load for argument 'x'
 
-To load everything upfront, pass ``lazy=False`` or call ``.fetch()`` on an existing ``LazyCall``:
+To load everything upfront, call ``.fetch()`` on an existing ``LazyCall``:
 
 .. code-block:: python
 
-   # Eager load: deserializes everything immediately
-   call = cache().load(key, lazy=False)
-   print(call.result)  # Already in memory
-
-   # Or fetch from a lazy call you already have
+   # Fetch everything from a lazy call you already have
    call = lazy_call.fetch()
 
 Parity with Call

--- a/notebooks/GettingStarted.ipynb
+++ b/notebooks/GettingStarted.ipynb
@@ -1831,30 +1831,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "To load everything upfront instead, pass `lazy=False` or call `.fetch()` on a lazy call you already have.\n"
-   ]
+   "source": "To load everything upfront, call `.fetch()` on a lazy call you already have.\n"
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Both of these produce a fully-loaded Call:\n",
-    "cache().load(key, lazy=False) == lazy_call.fetch()\n"
-   ]
+   "outputs": [],
+   "source": "# Fetch everything upfront from a lazy call:\nlazy_call.fetch()\n"
   }
  ],
  "metadata": {

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -11,7 +11,7 @@ import pandas as pd
 from . import digest as _digest
 from .digest import Digest  # type hint convenience
 from . import storage
-from .call import Call, LazyCall, QueryCall
+from .call import Call, DigestedCall, LazyCall, QueryCall
 from . import call
 from . import query
 
@@ -276,27 +276,33 @@ class Cache(BaseCache):
         return self.calls.save(call)
 
     @overload
-    def _decode_call(self, call: Call, lazy: bool = False) -> Call: ...
+    def _decode_call(self, dc: DigestedCall, lazy: bool = False) -> Call: ...
 
     @overload
-    def _decode_call(self, call: Call, lazy: bool = True) -> LazyCall: ...
+    def _decode_call(self, dc: DigestedCall, lazy: bool = True) -> LazyCall: ...
 
-    def _decode_call(self, call: Call, lazy: bool) -> Call | LazyCall:
+    def _decode_call(self, dc: DigestedCall, lazy: bool) -> Call | LazyCall:
         if lazy:
             return LazyCall(
-                name=call.name,
-                _arguments=call.arguments,
-                _result=call.result,
+                name=dc.name,
+                _arguments=dc.arguments,
+                _result=dc.result,
                 _cache=self,
-                metadata=call.metadata,
-                module=call.module,
-                version=call.version,
-                code_digest=call.code_digest,
+                metadata=dc.metadata,
+                module=dc.module,
+                version=dc.version,
+                code_digest=dc.code_digest,
             )
 
-        call.arguments = {k: self._handle_args_load(v) for k, v in call.arguments.items()}
-        call.result = self.load_value(call.result)
-        return call
+        return Call(
+            name=dc.name,
+            arguments={k: self._handle_args_load(v) for k, v in dc.arguments.items()},
+            result=self.load_value(dc.result) if isinstance(dc.result, Digest) else dc.result,
+            metadata=dc.metadata,
+            module=dc.module,
+            version=dc.version,
+            code_digest=dc.code_digest,
+        )
 
     @overload
     def load(self, key: str, lazy: bool = False) -> Call: ...
@@ -305,8 +311,8 @@ class Cache(BaseCache):
     def load(self, key: str, lazy: bool = True) -> LazyCall: ...
 
     def load(self, key: str, lazy: bool = True) -> Call | LazyCall:
-        call = self.calls.load(key)
-        return self._decode_call(call, lazy)
+        stored = self.calls.load(key)
+        return self._decode_call(DigestedCall.from_call(stored), lazy)
 
     def contains(self, key: str) -> bool:
         return self.calls.contains(key)
@@ -363,7 +369,7 @@ class Cache(BaseCache):
         )
         for c in self.calls.query(call):
             try:
-                yield self._decode_call(c, lazy=True)
+                yield self._decode_call(DigestedCall.from_call(c), lazy=True)
             except Exception as err:
                 logger.error(
                         f"Failed to load matching call {c.to_lookup_key()} with {err}! Indicates corrupt cache."

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -3,8 +3,7 @@ import logging
 import random
 import threading
 from dataclasses import dataclass, replace, field
-from copy import copy
-from typing import Iterable, Any, Callable, Literal, overload
+from typing import Iterable, Any, Callable, Literal
 
 import pandas as pd
 
@@ -35,16 +34,8 @@ class BaseCache(ABC):
     def save(self, call: Call) -> str:
         ...
 
-    @overload
-    def load(self, key: str, lazy: bool = False) -> Call:
-        ...
-
-    @overload
-    def load(self, key: str, lazy: bool = True) -> LazyCall:
-        ...
-
     @abstractmethod
-    def load(self, key: str, lazy: bool = True) -> Call | LazyCall:
+    def load(self, key: str) -> LazyCall:
         ...
 
     @abstractmethod
@@ -56,7 +47,7 @@ class BaseCache(ABC):
 
     def contains(self, key: str) -> bool:
         try:
-            self.load(key, lazy=True)
+            self.load(key)
             return True
         except KeyError:
             return False
@@ -244,16 +235,6 @@ class Cache(BaseCache):
 
         return self.values.load(key)
 
-    def _handle_args_save(self, value):
-        if isinstance(value, Digest):
-            return value
-        # for arguments saving is not critical, substitute digest and move on
-        try:
-            return self.values.save(value)
-        except storage.SaveError:
-            logger.warning("Failed to save argument: %s", value)
-            return _digest.digest(value)
-
     def _handle_args_load(self, key):
         if not isinstance(key, Digest):
             return key  # found a simple value
@@ -264,26 +245,14 @@ class Cache(BaseCache):
             return key
 
     def save(self, call: Call) -> str:
-        call = copy(call)
         try:
-            call.result = self.values.save(call.result)
-            call.arguments = {
-                k: self._handle_args_save(v) for k, v in call.arguments.items()
-            }
+            digested = call.stash(self.values)
         except storage.SaveError as e:
             raise Rejected(e)
+        return self.calls.save(digested)
 
-        return self.calls.save(call)
-
-    @overload
-    def load(self, key: str, lazy: bool = False) -> Call: ...
-
-    @overload
-    def load(self, key: str, lazy: bool = True) -> LazyCall: ...
-
-    def load(self, key: str, lazy: bool = True) -> Call | LazyCall:
-        lc = self.calls.load(key).fetch(self)
-        return lc if lazy else lc.fetch()
+    def load(self, key: str) -> LazyCall:
+        return self.calls.load(key).fetch(self)
 
     def contains(self, key: str) -> bool:
         return self.calls.contains(key)
@@ -370,8 +339,8 @@ class ReadOnlyCache(BaseCache):
     def save(self, call: Call):
         raise Rejected(self, call)
 
-    def load(self, key, lazy: bool = True):
-        return self.cache.load(key, lazy=lazy)
+    def load(self, key) -> LazyCall:
+        return self.cache.load(key)
 
     def expand(self, key: Digest | str) -> Digest:
         return self.cache.expand(key)
@@ -406,13 +375,11 @@ class FilteredCache(ReadOnlyCache):
 
     predicate: Callable[[Call | LazyCall], bool]
 
-    def load(self, key, lazy: bool = True):
-        call: LazyCall = self.cache.load(key, lazy=True)  # ty: ignore bug or I'm really tired
-        if self.predicate(call):
-            if not lazy:
-                return call.fetch()
-            return call
-        raise KeyError(key)
+    def load(self, key) -> LazyCall:
+        lc = self.cache.load(key)
+        if not self.predicate(lc):
+            raise KeyError(key)
+        return lc
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         for c in self.cache.query(call):
@@ -437,13 +404,7 @@ class RefreshingCache(BaseCache):
     def save(self, call: Call) -> str:
         return self.cache.save(call)
 
-    @overload
-    def load(self, key: str, lazy: bool = False) -> Call: ...
-
-    @overload
-    def load(self, key: str, lazy: bool = True) -> LazyCall: ...
-
-    def load(self, key: str, lazy: bool = True) -> Call | LazyCall:
+    def load(self, key: str) -> LazyCall:
         raise KeyError(key)
 
     def load_value(self, key: str) -> Any:
@@ -483,21 +444,20 @@ class CacheStack(BaseCache):
     def save(self, call: Call):
         self.stack[0].save(call)
 
-    def load(self, key, lazy: bool = True):
+    def load(self, key) -> LazyCall:
         for i, cache in enumerate(self.stack):
             try:
-                call = cache.load(key, lazy=lazy)
+                lc = cache.load(key)
                 if i > 0:
                     try:
-                        self.save(call.fetch() if lazy else call)  # ty: ignore
+                        self.save(lc.fetch())
                         logger.info("Transferred hit for %s from higher cache to base cache", key)
                     except Rejected as e:
                         logger.warning("Failed to transfer hit for %s to base cache: %s", key, e)
-                return call
+                return lc
             except KeyError:
                 continue
-        else:
-            raise KeyError(key)
+        raise KeyError(key)
 
     def load_value(self, key):
         for cache in self.stack:

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -276,43 +276,14 @@ class Cache(BaseCache):
         return self.calls.save(call)
 
     @overload
-    def _decode_call(self, dc: DigestedCall, lazy: bool = False) -> Call: ...
-
-    @overload
-    def _decode_call(self, dc: DigestedCall, lazy: bool = True) -> LazyCall: ...
-
-    def _decode_call(self, dc: DigestedCall, lazy: bool) -> Call | LazyCall:
-        if lazy:
-            return LazyCall(
-                name=dc.name,
-                _arguments=dc.arguments,
-                _result=dc.result,
-                _cache=self,
-                metadata=dc.metadata,
-                module=dc.module,
-                version=dc.version,
-                code_digest=dc.code_digest,
-            )
-
-        return Call(
-            name=dc.name,
-            arguments={k: self._handle_args_load(v) for k, v in dc.arguments.items()},
-            result=self.load_value(dc.result) if isinstance(dc.result, Digest) else dc.result,
-            metadata=dc.metadata,
-            module=dc.module,
-            version=dc.version,
-            code_digest=dc.code_digest,
-        )
-
-    @overload
     def load(self, key: str, lazy: bool = False) -> Call: ...
 
     @overload
     def load(self, key: str, lazy: bool = True) -> LazyCall: ...
 
     def load(self, key: str, lazy: bool = True) -> Call | LazyCall:
-        stored = self.calls.load(key)
-        return self._decode_call(DigestedCall.from_call(stored), lazy)
+        lc = self.calls.load(key).fetch(self)
+        return lc if lazy else lc.fetch()
 
     def contains(self, key: str) -> bool:
         return self.calls.contains(key)
@@ -369,7 +340,7 @@ class Cache(BaseCache):
         )
         for c in self.calls.query(call):
             try:
-                yield self._decode_call(DigestedCall.from_call(c), lazy=True)
+                yield c.fetch(self)
             except Exception as err:
                 logger.error(
                         f"Failed to load matching call {c.to_lookup_key()} with {err}! Indicates corrupt cache."

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -65,7 +65,7 @@ class Call:
             call.code_digest = digest.digest(func.__code__)
         return call
 
-    def to_lookup_key(self):
+    def to_lookup_key(self) -> "Digest":
         # Iterate explicitly in the preserved parameter order; do not sort
         arg_pairs = tuple(self.arguments.items())
         call = replace(self, arguments=arg_pairs, metadata=None, result=None)
@@ -168,7 +168,7 @@ class DigestedCall:
         )
         return digest.digest(c)
 
-    def to_lookup_key(self) -> str:
+    def to_lookup_key(self) -> "Digest":
         # Independent implementation: build a Call directly without calling Call.to_lookup_key.
         # digest(Digest(x)) == x, so digested argument values hash identically to their originals.
         arg_pairs = tuple(self.arguments.items())
@@ -300,7 +300,7 @@ class QueryCall:
             call.module = func.__module__
         return call
 
-    def matches(self, other: 'Call | LazyCall') -> bool:
+    def matches(self, other: 'Call | LazyCall | DigestedCall') -> bool:
         """Check if this call matches another call, treating None as a wildcard in this object."""
         def none_or_equal(a, b):
             if a is None:

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -140,27 +140,33 @@ class DigestedCall:
     version: int | None = None
     code_digest: str | None = None
 
-    @classmethod
-    def from_call(cls, call: "Call") -> "DigestedCall":
-        """Wrap a stored :class:`Call` whose argument and result fields are already :class:`~fleche.digest.Digest`
-        pointers as a typed :class:`DigestedCall`.
-
-        Args:
-            call: A :class:`Call` loaded from :class:`~fleche.storage.CallStorage`, where
-                ``arguments`` and ``result`` hold :class:`~fleche.digest.Digest` values.
-
-        Returns:
-            A :class:`DigestedCall` with the same field values as *call*.
-        """
-        return cls(
-            name=call.name,
-            arguments=call.arguments,
-            result=call.result,
-            metadata=call.metadata,
-            module=call.module,
-            version=call.version,
-            code_digest=call.code_digest,
+    def __eq__(self, other: object) -> bool:
+        # DigestedCall and Call with identical field values are semantically equivalent.
+        if not isinstance(other, (DigestedCall, Call)):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.arguments == other.arguments
+            and self.result == other.result
+            and self.metadata == other.metadata
+            and self.module == other.module
+            and self.version == other.version
+            and self.code_digest == other.code_digest
         )
+
+    def __digest__(self):
+        # DigestedCall must hash identically to the equivalent Call with the same fields,
+        # so that digest(DigestedCall) == digest(LazyCall) == digest(Call-with-digest-args).
+        c = Call(
+            name=self.name,
+            arguments=self.arguments,
+            metadata=self.metadata,
+            module=self.module,
+            version=self.version,
+            code_digest=self.code_digest,
+            result=self.result,
+        )
+        return digest.digest(c)
 
     def to_lookup_key(self) -> str:
         # Independent implementation: build a Call directly without calling Call.to_lookup_key.
@@ -169,19 +175,21 @@ class DigestedCall:
         c = Call(name=self.name, arguments={}, module=self.module, version=self.version, code_digest=self.code_digest)
         return digest.digest(replace(c, arguments=arg_pairs, result=None, metadata=None))
 
-    def fetch(self, values) -> "Call":
-        """Reconstruct a full :class:`Call` by loading all values from *values*.
+    def fetch(self, cache) -> "LazyCall":
+        """Wrap this :class:`DigestedCall` in a :class:`LazyCall` backed by *cache*.
 
         Args:
-            values: A :class:`~fleche.storage.ValueStorage` instance to load values from.
+            cache: A cache instance (e.g. :class:`~fleche.caches.Cache`) whose value
+                storage will be used to load argument and result values on demand.
 
         Returns:
-            A :class:`Call` with all argument and result digests replaced by their stored values.
+            A :class:`LazyCall` that loads values lazily from *cache*.
         """
-        return Call(
+        return LazyCall(
             name=self.name,
-            arguments={k: values.load(v) for k, v in self.arguments.items()},
-            result=values.load(self.result) if self.result is not None else None,
+            _arguments=self.arguments,
+            _result=self.result,
+            _cache=cache,
             metadata=self.metadata,
             module=self.module,
             version=self.version,

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -33,6 +33,37 @@ def bind(func, args, kwargs, apply_defaults=False, partial=False):
 
 
 @dataclass
+class DigestedCall:
+    """A Call where arguments and result are :class:`~fleche.digest.Digest` pointers into a value store.
+
+    Produced by :meth:`Call.dehydrate`; represents a call whose values have been
+    persisted so only their content-addressed keys remain.
+    """
+
+    name: str
+    arguments: dict[str, "digest.Digest"]
+    result: "digest.Digest"
+    metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
+    module: str | None = None
+    version: int | None = None
+    code_digest: str | None = None
+
+    def to_lookup_key(self) -> str:
+        # Delegate to Call so the key is identical to the pre-dehydration Call's key.
+        # This works because digest(Digest(x)) == x, so digested argument values
+        # hash identically to their originals.
+        return Call(
+            name=self.name,
+            arguments=self.arguments,
+            metadata=None,
+            module=self.module,
+            version=self.version,
+            code_digest=self.code_digest,
+            result=None,
+        ).to_lookup_key()
+
+
+@dataclass
 class Call:
     """
     Represents a function call, capturing its name, arguments, and keyword arguments.
@@ -66,6 +97,40 @@ class Call:
         arg_pairs = tuple(self.arguments.items())
         call = replace(self, arguments=arg_pairs, metadata=None, result=None)
         return digest.digest(call)
+
+    def dehydrate(self, values) -> "DigestedCall":
+        """Save arguments and result into *values*, returning a :class:`DigestedCall`.
+
+        Result save errors propagate to the caller.  Argument save errors fall back
+        to a digest-only reference (the value is hashed but not stored), mirroring the
+        behaviour of :meth:`Cache._handle_args_save`.
+
+        Args:
+            values: A :class:`~fleche.storage.ValueStorage` instance to persist values into.
+
+        Returns:
+            A :class:`DigestedCall` with all argument values and the result replaced by
+            their :class:`~fleche.digest.Digest` keys.
+        """
+        result = values.save(self.result)
+        arguments: dict[str, digest.Digest] = {}
+        for k, v in self.arguments.items():
+            if isinstance(v, digest.Digest):
+                arguments[k] = v
+            else:
+                try:
+                    arguments[k] = values.save(v)
+                except Exception:
+                    arguments[k] = digest.digest(v)
+        return DigestedCall(
+            name=self.name,
+            arguments=arguments,
+            result=result,
+            metadata=self.metadata,
+            module=self.module,
+            version=self.version,
+            code_digest=self.code_digest,
+        )
 
 class LazyArguments(Mapping):
     def __init__(self, cache, arg_digests):
@@ -221,6 +286,7 @@ AnyCall = Call | LazyCall
 __all__ = [
         "bind",
         "Call",
+        "DigestedCall",
         "LazyCall",
         "QueryCall",
         "AnyCall"

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, Callable
 from inspect import signature
 from collections.abc import Mapping
 
@@ -30,37 +30,6 @@ def bind(func, args, kwargs, apply_defaults=False, partial=False):
     if apply_defaults:
         bound.apply_defaults()
     return bound.arguments
-
-
-@dataclass
-class DigestedCall:
-    """A Call where arguments and result are :class:`~fleche.digest.Digest` pointers into a value store.
-
-    Produced by :meth:`Call.dehydrate`; represents a call whose values have been
-    persisted so only their content-addressed keys remain.
-    """
-
-    name: str
-    arguments: dict[str, "digest.Digest"]
-    result: "digest.Digest"
-    metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
-    module: str | None = None
-    version: int | None = None
-    code_digest: str | None = None
-
-    def to_lookup_key(self) -> str:
-        # Delegate to Call so the key is identical to the pre-dehydration Call's key.
-        # This works because digest(Digest(x)) == x, so digested argument values
-        # hash identically to their originals.
-        return Call(
-            name=self.name,
-            arguments=self.arguments,
-            metadata=None,
-            module=self.module,
-            version=self.version,
-            code_digest=self.code_digest,
-            result=None,
-        ).to_lookup_key()
 
 
 @dataclass
@@ -98,7 +67,29 @@ class Call:
         call = replace(self, arguments=arg_pairs, metadata=None, result=None)
         return digest.digest(call)
 
-    def dehydrate(self, values) -> "DigestedCall":
+    def _to_digested(self, save_fn: Callable[[Any], "digest.Digest"]) -> "DigestedCall":
+        """Generic conversion to DigestedCall using *save_fn* to handle each value."""
+        result = save_fn(self.result)
+        arguments: dict[str, digest.Digest] = {}
+        for k, v in self.arguments.items():
+            if isinstance(v, digest.Digest):
+                arguments[k] = v
+            else:
+                try:
+                    arguments[k] = save_fn(v)
+                except Exception:
+                    arguments[k] = digest.digest(v)
+        return DigestedCall(
+            name=self.name,
+            arguments=arguments,
+            result=result,
+            metadata=self.metadata,
+            module=self.module,
+            version=self.version,
+            code_digest=self.code_digest,
+        )
+
+    def stash(self, values) -> "DigestedCall":
         """Save arguments and result into *values*, returning a :class:`DigestedCall`.
 
         Result save errors propagate to the caller.  Argument save errors fall back
@@ -112,25 +103,59 @@ class Call:
             A :class:`DigestedCall` with all argument values and the result replaced by
             their :class:`~fleche.digest.Digest` keys.
         """
-        result = values.save(self.result)
-        arguments: dict[str, digest.Digest] = {}
-        for k, v in self.arguments.items():
-            if isinstance(v, digest.Digest):
-                arguments[k] = v
-            else:
-                try:
-                    arguments[k] = values.save(v)
-                except Exception:
-                    arguments[k] = digest.digest(v)
-        return DigestedCall(
+        return self._to_digested(values.save)
+
+    def freeze(self) -> "DigestedCall":
+        """Digest arguments and result without saving to storage, returning a :class:`DigestedCall`.
+
+        Equivalent to :meth:`stash` but uses :func:`~fleche.digest.digest` instead of
+        ``values.save``, so no data is written anywhere.
+        """
+        return self._to_digested(digest.digest)
+
+
+@dataclass
+class DigestedCall:
+    """A Call where arguments and result are :class:`~fleche.digest.Digest` pointers into a value store.
+
+    Produced by :meth:`Call.stash` or :meth:`Call.freeze`; represents a call whose values have been
+    replaced by their content-addressed keys.
+    """
+
+    name: str
+    arguments: dict[str, "digest.Digest"]
+    result: "digest.Digest | None" = None
+    metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
+    module: str | None = None
+    version: int | None = None
+    code_digest: str | None = None
+
+    def to_lookup_key(self) -> str:
+        # Independent implementation: build a Call directly without calling Call.to_lookup_key.
+        # digest(Digest(x)) == x, so digested argument values hash identically to their originals.
+        arg_pairs = tuple(self.arguments.items())
+        c = Call(name=self.name, arguments={}, module=self.module, version=self.version, code_digest=self.code_digest)
+        return digest.digest(replace(c, arguments=arg_pairs, result=None, metadata=None))
+
+    def fetch(self, values) -> "Call":
+        """Reconstruct a full :class:`Call` by loading all values from *values*.
+
+        Args:
+            values: A :class:`~fleche.storage.ValueStorage` instance to load values from.
+
+        Returns:
+            A :class:`Call` with all argument and result digests replaced by their stored values.
+        """
+        return Call(
             name=self.name,
-            arguments=arguments,
-            result=result,
+            arguments={k: values.load(v) for k, v in self.arguments.items()},
+            result=values.load(self.result) if self.result is not None else None,
             metadata=self.metadata,
             module=self.module,
             version=self.version,
             code_digest=self.code_digest,
         )
+
 
 class LazyArguments(Mapping):
     def __init__(self, cache, arg_digests):
@@ -176,17 +201,13 @@ class LazyCall:
         return self._cache.load_value(self._result)
 
     def to_lookup_key(self) -> str:
-        # Reconstruct a Call object to ensure identical key calculation
-        c = Call(
+        return DigestedCall(
             name=self.name,
             arguments=self._arguments,
-            metadata=self.metadata,
             module=self.module,
             version=self.version,
             code_digest=self.code_digest,
-            result=None
-        )
-        return c.to_lookup_key()
+        ).to_lookup_key()
 
     def fetch(self) -> Call:
         """Reconstruct a full Call object by loading all values from the cache."""

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -93,8 +93,7 @@ class Call:
         """Save arguments and result into *values*, returning a :class:`DigestedCall`.
 
         Result save errors propagate to the caller.  Argument save errors fall back
-        to a digest-only reference (the value is hashed but not stored), mirroring the
-        behaviour of :meth:`Cache._handle_args_save`.
+        to a digest-only reference (the value is hashed but not stored).
 
         Args:
             values: A :class:`~fleche.storage.ValueStorage` instance to persist values into.
@@ -102,10 +101,13 @@ class Call:
         Returns:
             A :class:`DigestedCall` with all argument values and the result replaced by
             their :class:`~fleche.digest.Digest` keys.
+
+        See Also:
+            :meth:`digest` for a variant that does not write to storage.
         """
         return self._to_digested(values.save)
 
-    def freeze(self) -> "DigestedCall":
+    def digest(self) -> "DigestedCall":
         """Digest arguments and result without saving to storage, returning a :class:`DigestedCall`.
 
         Equivalent to :meth:`stash` but uses :func:`~fleche.digest.digest` instead of
@@ -118,7 +120,7 @@ class Call:
 class DigestedCall:
     """A Call where arguments and result are :class:`~fleche.digest.Digest` pointers into a value store.
 
-    Produced by :meth:`Call.stash` or :meth:`Call.freeze`; represents a call whose values have been
+    Produced by :meth:`Call.stash` or :meth:`Call.digest`; represents a call whose values have been
     replaced by their content-addressed keys.
     """
 
@@ -129,6 +131,28 @@ class DigestedCall:
     module: str | None = None
     version: int | None = None
     code_digest: str | None = None
+
+    @classmethod
+    def from_call(cls, call: "Call") -> "DigestedCall":
+        """Wrap a stored :class:`Call` whose argument and result fields are already :class:`~fleche.digest.Digest`
+        pointers as a typed :class:`DigestedCall`.
+
+        Args:
+            call: A :class:`Call` loaded from :class:`~fleche.storage.CallStorage`, where
+                ``arguments`` and ``result`` hold :class:`~fleche.digest.Digest` values.
+
+        Returns:
+            A :class:`DigestedCall` with the same field values as *call*.
+        """
+        return cls(
+            name=call.name,
+            arguments=call.arguments,
+            result=call.result,
+            metadata=call.metadata,
+            module=call.module,
+            version=call.version,
+            code_digest=call.code_digest,
+        )
 
     def to_lookup_key(self) -> str:
         # Independent implementation: build a Call directly without calling Call.to_lookup_key.

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -1,9 +1,13 @@
+import logging
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable
 from inspect import signature
 from collections.abc import Mapping
 
 from . import digest
+from .digest import Digest
+
+logger = logging.getLogger("fleche.call")
 
 
 def bind(func, args, kwargs, apply_defaults=False, partial=False):
@@ -67,17 +71,21 @@ class Call:
         call = replace(self, arguments=arg_pairs, metadata=None, result=None)
         return digest.digest(call)
 
-    def _to_digested(self, save_fn: Callable[[Any], "digest.Digest"]) -> "DigestedCall":
+    def _to_digested(self, save_fn: Callable[[Any], Digest]) -> "DigestedCall":
         """Generic conversion to DigestedCall using *save_fn* to handle each value."""
         result = save_fn(self.result)
-        arguments: dict[str, digest.Digest] = {}
+        arguments: dict[str, Digest] = {}
         for k, v in self.arguments.items():
-            if isinstance(v, digest.Digest):
+            if isinstance(v, Digest):
                 arguments[k] = v
             else:
                 try:
                     arguments[k] = save_fn(v)
-                except Exception:
+                except Exception as exc:
+                    from .storage.base import SaveError  # lazy import: storage.base depends on call
+                    if not isinstance(exc, SaveError):
+                        raise
+                    logger.warning("Failed to save argument %r: falling back to digest-only reference", k)
                     arguments[k] = digest.digest(v)
         return DigestedCall(
             name=self.name,

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Iterable, Any, Callable
 
 from ..digest import digest, Digest, DIGEST_LENGTH
-from ..call import Call, QueryCall
+from ..call import Call, DigestedCall, QueryCall
 
 logger = logging.getLogger("fleche.storage")
 
@@ -187,21 +187,20 @@ class CallStorage(KeyManagement):
     """Abstract domain interface for call storage."""
 
     @abstractmethod
-    def save(self, call: Call) -> Digest: ...
+    def save(self, call: Call | DigestedCall) -> Digest: ...
 
     @abstractmethod
-    def load(self, key: Digest | str) -> Call: ...
+    def load(self, key: Digest | str) -> DigestedCall: ...
 
     @abstractmethod
-    def query(self, template: QueryCall) -> Iterable[Call]: ...
+    def query(self, template: QueryCall) -> Iterable[DigestedCall]: ...
 
-    def transform(self, func: Callable[[Call], Call] | None = None) -> None:
-        """Applies a transformation function to all Call objects in the storage.
+    def transform(self, func: Callable[[DigestedCall], DigestedCall] | None = None) -> None:
+        """Applies a transformation function to all DigestedCall objects in the storage.
 
         Args:
-            func (Callable[[Call], Call] | None): A function that takes a Call
-                and returns a transformed Call.  If None, the identity function
-                is used (useful for re-calculating keys).
+            func: A function that takes a :class:`DigestedCall` and returns a transformed
+                one.  If ``None``, the identity is used (useful for re-calculating keys).
         """
         for k in list(self.list()):
             try:
@@ -218,6 +217,21 @@ class CallStorage(KeyManagement):
                 self.save(new_call)
 
 
+def _to_digested_call(raw: Call | DigestedCall) -> DigestedCall:
+    """Wrap a raw stored call (whose argument/result fields are Digest values) as a DigestedCall."""
+    if isinstance(raw, DigestedCall):
+        return raw
+    return DigestedCall(
+        name=raw.name,
+        arguments=raw.arguments,
+        result=raw.result,
+        metadata=raw.metadata,
+        module=raw.module,
+        version=raw.version,
+        code_digest=raw.code_digest,
+    )
+
+
 class CallMixin(CallStorage, StorageBackend):
     """Bridges :class:`CallStorage` with :class:`StorageBackend` primitives.
 
@@ -229,7 +243,7 @@ class CallMixin(CallStorage, StorageBackend):
     implementation to get a fully functional call storage.
     """
 
-    def save(self, call: Call) -> Digest:
+    def save(self, call: Call | DigestedCall) -> Digest:
         key = call.to_lookup_key()
         with self._operation_context(key):
             logger.debug("Saving call %s", key)
@@ -237,13 +251,13 @@ class CallMixin(CallStorage, StorageBackend):
                 self.evict(key)
             return self.put(call, key)
 
-    def load(self, key: Digest | str) -> Call:
+    def load(self, key: Digest | str) -> DigestedCall:
         with self._operation_context(key):
             key = self._normalize_key(key)
             logger.debug("Loading call with key %s", key)
-            return self.get(key)
+            return _to_digested_call(self.get(key))
 
-    def query(self, template: QueryCall) -> Iterable[Call]:
+    def query(self, template: QueryCall) -> Iterable[DigestedCall]:
         """Find cached calls that 'match' the template.
 
         Returns all calls where the given arguments, results or metadata match exactly the stored ones.  Values may be
@@ -253,7 +267,7 @@ class CallMixin(CallStorage, StorageBackend):
             template (Call): specification for calls to return; use `None` as wildcard.
 
         Returns:
-            Iterable[Call]: an iterable over all matching call objects
+            Iterable[DigestedCall]: an iterable over all matching digested call objects
         """
 
         for key in self.list():

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -217,21 +217,6 @@ class CallStorage(KeyManagement):
                 self.save(new_call)
 
 
-def _to_digested_call(raw: Call | DigestedCall) -> DigestedCall:
-    """Wrap a raw stored call (whose argument/result fields are Digest values) as a DigestedCall."""
-    if isinstance(raw, DigestedCall):
-        return raw
-    return DigestedCall(
-        name=raw.name,
-        arguments=raw.arguments,
-        result=raw.result,
-        metadata=raw.metadata,
-        module=raw.module,
-        version=raw.version,
-        code_digest=raw.code_digest,
-    )
-
-
 class CallMixin(CallStorage, StorageBackend):
     """Bridges :class:`CallStorage` with :class:`StorageBackend` primitives.
 
@@ -255,7 +240,7 @@ class CallMixin(CallStorage, StorageBackend):
         with self._operation_context(key):
             key = self._normalize_key(key)
             logger.debug("Loading call with key %s", key)
-            return _to_digested_call(self.get(key))
+            return self.get(key)
 
     def query(self, template: QueryCall) -> Iterable[DigestedCall]:
         """Find cached calls that 'match' the template.

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Iterable, Any, Callable
 
 from ..digest import digest, Digest, DIGEST_LENGTH
-from ..call import Call, DigestedCall, QueryCall
+from ..call import DigestedCall, QueryCall
 
 logger = logging.getLogger("fleche.storage")
 
@@ -187,7 +187,7 @@ class CallStorage(KeyManagement):
     """Abstract domain interface for call storage."""
 
     @abstractmethod
-    def save(self, call: Call | DigestedCall) -> Digest: ...
+    def save(self, call: DigestedCall) -> Digest: ...
 
     @abstractmethod
     def load(self, key: Digest | str) -> DigestedCall: ...
@@ -228,7 +228,7 @@ class CallMixin(CallStorage, StorageBackend):
     implementation to get a fully functional call storage.
     """
 
-    def save(self, call: Call | DigestedCall) -> Digest:
+    def save(self, call: DigestedCall) -> Digest:
         key = call.to_lookup_key()
         with self._operation_context(key):
             logger.debug("Saving call %s", key)

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from dataclasses import dataclass, field
 from .base import KeyManagement, CallStorage, AmbiguousDigestError
 from .thread_safe import PerKeyLockMixin
-from ..call import Call, DigestedCall, QueryCall
+from ..call import DigestedCall, QueryCall
 from ..digest import Digest, DIGEST_LENGTH, digest
 
 from pyiron_snippets.import_alarm import ImportAlarm
@@ -177,7 +177,7 @@ class Sql(PerKeyLockMixin, CallStorage):
             with super()._operation_context(key):
                 yield
 
-    def put(self, call: Any, key: Digest) -> Digest:
+    def put(self, call: DigestedCall, key: Digest) -> Digest:
         session = self._local.session
         existing = session.get(CallModel, str(key))
         if existing is not None:
@@ -293,12 +293,12 @@ class Sql(PerKeyLockMixin, CallStorage):
         session.delete(instance)
         session.commit()
 
-    def save(self, call: Call) -> Digest:
+    def save(self, call: DigestedCall) -> Digest:
         key = call.to_lookup_key()
         with self._operation_context(key):
             logger.debug("Saving call %s", key)
-            if self.contains(str(key)):
-                self.evict(str(key))
+            if self.contains(key):
+                self.evict(key)
             return self.put(call, key)
 
     def load(self, key: Digest | str) -> DigestedCall:
@@ -426,7 +426,7 @@ class Sql(PerKeyLockMixin, CallStorage):
             keys = [Digest(k) for (k,) in self._local.session.execute(stmt).all()]
 
         # Yield loaded calls using existing loader (ensures metadata returned too)
-        def meta_matches(call: Call) -> bool:
+        def meta_matches(call: DigestedCall) -> bool:
             specs = template.metadata
             if not specs:
                 return True

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -4,9 +4,9 @@ import threading
 from typing import Iterable, Any, List
 from pathlib import Path
 from dataclasses import dataclass, field
-from .base import KeyManagement, CallStorage, AmbiguousDigestError
+from .base import KeyManagement, CallStorage, AmbiguousDigestError, _to_digested_call
 from .thread_safe import PerKeyLockMixin
-from ..call import Call, QueryCall
+from ..call import Call, DigestedCall, QueryCall
 from ..digest import Digest, DIGEST_LENGTH, digest
 
 from pyiron_snippets.import_alarm import ImportAlarm
@@ -301,11 +301,11 @@ class Sql(PerKeyLockMixin, CallStorage):
                 self.evict(str(key))
             return self.put(call, key)
 
-    def load(self, key: Digest | str) -> Call:
+    def load(self, key: Digest | str) -> DigestedCall:
         with self._operation_context(key):
             key = self._normalize_key(key)
             logger.debug("Loading call with key %s", key)
-            return self.get(key)
+            return _to_digested_call(self.get(key))
 
     def _normalize_value(self, v: Any) -> str:
         """Return the stored form used in SQL for argument/result matching.
@@ -387,7 +387,7 @@ class Sql(PerKeyLockMixin, CallStorage):
                         stmt = stmt.where(M.data[k].as_string() == v)
         return stmt
 
-    def query(self, template: QueryCall) -> Iterable[Call]:
+    def query(self, template: QueryCall) -> Iterable[DigestedCall]:
         """Find cached calls matching a template using SQL-side filtering.
 
         Semantics match CallStorage.query:

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -4,7 +4,7 @@ import threading
 from typing import Iterable, Any, List
 from pathlib import Path
 from dataclasses import dataclass, field
-from .base import KeyManagement, CallStorage, AmbiguousDigestError, _to_digested_call
+from .base import KeyManagement, CallStorage, AmbiguousDigestError
 from .thread_safe import PerKeyLockMixin
 from ..call import Call, DigestedCall, QueryCall
 from ..digest import Digest, DIGEST_LENGTH, digest
@@ -215,7 +215,7 @@ class Sql(PerKeyLockMixin, CallStorage):
         # Always return a Digest instance, not a plain str
         return key
 
-    def get(self, key: Digest) -> Call:
+    def get(self, key: Digest) -> DigestedCall:
         session = self._local.session
         call_model = session.execute(
             select(CallModel).where(CallModel.key == str(key))
@@ -230,7 +230,7 @@ class Sql(PerKeyLockMixin, CallStorage):
             .scalars()
             .all()
         )
-        return Call(
+        return DigestedCall(
             name=call_model.name,
             arguments=arguments,
             metadata={row.name: (row.data or {}) for row in meta_rows},
@@ -305,7 +305,7 @@ class Sql(PerKeyLockMixin, CallStorage):
         with self._operation_context(key):
             key = self._normalize_key(key)
             logger.debug("Loading call with key %s", key)
-            return _to_digested_call(self.get(key))
+            return self.get(key)
 
     def _normalize_value(self, v: Any) -> str:
         """Return the stored form used in SQL for argument/result matching.

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -241,7 +241,7 @@ def test_base_cache_transfer_no_overwrite_and_pop(caplog):
     assert c2.contains(str(call2.to_lookup_key()))
     assert not c1.contains(str(call2.to_lookup_key()))
     # call1 in c2 should retain the original value, not be overwritten
-    assert c2.load(str(call1.to_lookup_key()), lazy=False).result == "existing"
+    assert c2.load(str(call1.to_lookup_key())).result == "existing"
     # call1 should still be in c1 — NOT evicted because it conflicted
     assert c1.contains(str(call1.to_lookup_key()))
     # a warning should have been emitted for the skipped eviction

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -1,7 +1,7 @@
 import logging
 from unittest.mock import Mock, MagicMock
 from fleche import fleche, cache
-from fleche.call import Call, QueryCall
+from fleche.call import Call, DigestedCall, QueryCall
 from fleche.digest import Digest
 from fleche.caches import Cache, CacheStack
 
@@ -35,7 +35,7 @@ def test_cache_load():
     calls_storage = Mock()
 
     calls_storage.load = Mock(
-        return_value=Call(
+        return_value=DigestedCall(
             name="test",
             arguments={
                 "arg1": Digest("arg1" + "0" * 60),

--- a/tests/unit/caches/test_cache_stack.py
+++ b/tests/unit/caches/test_cache_stack.py
@@ -22,15 +22,12 @@ def test_cache_stack_load_hit():
     from fleche.call import Call
 
     c1 = Mock()
-    c1.load.side_effect = KeyError
-    c2 = Mock()
+    # c1 hits immediately — no transfer needed (i == 0)
     call = Call(name="test", arguments={"x": 1}, result="result")
-    c2.load.return_value = call
-    stack = CacheStack((c1, c2))
-    # avoid mocking a lazycall
-    result = stack.load("key", lazy=False)
-    c1.load.assert_called_once_with("key", lazy=False)
-    c2.load.assert_called_once_with("key", lazy=False)
+    c1.load.return_value = call
+    stack = CacheStack((c1,))
+    result = stack.load("key")
+    c1.load.assert_called_once_with("key")
     assert result == call
 
 
@@ -125,20 +122,20 @@ def test_cache_stack_load_transfers_call():
 
     # Verify c1 doesn't have it
     with pytest.raises(KeyError):
-        c1.load(key, lazy=False)
+        c1.load(key)
 
     # Load from stack
-    res_call = stack.load(key, lazy=False)
+    res_call = stack.load(key)
 
     assert res_call.result == "result"
 
     # Now c1 SHOULD have it due to automatic transfer
     assert c1.contains(key)
-    assert c1.load(key, lazy=False).result == "result"
+    assert c1.load(key).result == "result"
 
 
 def test_cache_stack_load_lazy_transfers_call():
-    """Verify that a lazy hit in a higher cache is transferred to the base cache."""
+    """Verify that a load from a higher cache is transferred to the base cache."""
     # Setup two caches
     c1 = Cache(ValueMemory({}), CallMemory({}))
     c2 = Cache(ValueMemory({}), CallMemory({}))
@@ -151,14 +148,14 @@ def test_cache_stack_load_lazy_transfers_call():
 
     stack = CacheStack((c1, c2))
 
-    # Load lazy from stack
-    lazy_call = stack.load(key, lazy=True)
+    # Load from stack (always lazy now)
+    lazy_call = stack.load(key)
 
     assert lazy_call.result == "result"
 
     # Now c1 SHOULD have it
     assert c1.contains(key)
-    assert c1.load(key, lazy=False).result == "result"
+    assert c1.load(key).result == "result"
 
 
 def test_cache_stack_load_value_does_not_transfer():
@@ -202,12 +199,12 @@ def test_cache_stack_multi_level_transfer():
 
     # Verify c1 and c2 don't have it
     with pytest.raises(KeyError):
-        c1.load(key, lazy=False)
+        c1.load(key)
     with pytest.raises(KeyError):
-        c2.load(key, lazy=False)
+        c2.load(key)
 
     # Load from stack. Should hit c3 and transfer to c1 (via stack.save())
-    stack.load(key, lazy=False)
+    stack.load(key)
 
     # c1 should have it
     assert c1.contains(key)

--- a/tests/unit/caches/test_lazy_call.py
+++ b/tests/unit/caches/test_lazy_call.py
@@ -18,8 +18,7 @@ def test_lazy_call_load():
     original = Call(name="test_func", arguments={"a": 1, "b": 2}, result=3)
     key = cache.save(original)
 
-    # Load with lazy=True
-    lazy = cache.load(key, lazy=True)
+    lazy = cache.load(key)
     assert isinstance(lazy, LazyCall)
     assert lazy.name == "test_func"
 
@@ -62,7 +61,7 @@ def test_lazy_call_to_lookup_key():
     original = Call(name="test_func", arguments={"a": [1, 2]}, result=42)
     key = cache.save(original)
 
-    lazy = cache.load(key, lazy=True)
+    lazy = cache.load(key)
     assert lazy.to_lookup_key() == key
 
 
@@ -79,7 +78,7 @@ def test_lazy_call_digest():
     # The saved call in storage has Digests.
     saved_call = calls_storage.load(key)
 
-    lazy = cache.load(key, lazy=True)
+    lazy = cache.load(key)
 
     # 1. LazyCall digest should match the saved Call (which has Digests)
     assert digest(lazy) == digest(saved_call)
@@ -105,7 +104,6 @@ def test_cache_query_lazy():
         name="f", arguments=None, metadata=None, module=None, version=None, result=None
     )
 
-    # Query with lazy=True
     results = list(cache.query(tpl))
     assert len(results) == 2
     for r in results:
@@ -148,7 +146,7 @@ def test_lazy_call_maintains_cache_reference():
     key = cache1.save(Call(name="f", arguments={"x": "val1"}, result="res1"))
 
     # Obtain a lazy call from cache1
-    lazy = cache1.load(key, lazy=True)
+    lazy = cache1.load(key)
 
     # Set up second cache
     cache2 = Cache(ValueMemory({}), CallMemory({}))
@@ -172,7 +170,7 @@ def test_lazy_call_fetch():
     original = Call(name="test_func", arguments={"a": 1, "b": 2}, result=3)
     key = cache.save(original)
 
-    lazy = cache.load(key, lazy=True)
+    lazy = cache.load(key)
     full_call = lazy.fetch()
 
     assert isinstance(full_call, Call)
@@ -199,7 +197,7 @@ def test_lazy_call_to_lookup_key_consistency(args):
     key = cache.save(original)
 
     # Load as LazyCall
-    lazy = cache.load(key, lazy=True)
+    lazy = cache.load(key)
 
     assert isinstance(lazy, LazyCall)
     assert lazy.to_lookup_key() == original.to_lookup_key()

--- a/tests/unit/caches/test_size_limited.py
+++ b/tests/unit/caches/test_size_limited.py
@@ -30,7 +30,7 @@ def test_save_and_load():
     cache = make_slcache(max_size=5)
     c = make_call("f", 42, 84)
     key = cache.save(c)
-    loaded = cache.load(key, lazy=False)
+    loaded = cache.load(key)
     assert loaded.name == "f"
     assert loaded.arguments["x"] == 42
     assert loaded.result == 84

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -1,4 +1,4 @@
-"""Tests for Call.stash, Call.freeze, DigestedCall, and related methods."""
+"""Tests for Call.stash, Call.digest, DigestedCall, and related methods."""
 import pytest
 from unittest.mock import MagicMock
 
@@ -15,6 +15,29 @@ def _call(**kwargs):
     defaults = dict(name="f", arguments={"x": 1, "y": 2}, result=42)
     defaults.update(kwargs)
     return Call(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# DigestedCall.from_call
+# ---------------------------------------------------------------------------
+
+class TestDigestedCallFromCall:
+    def test_wraps_stored_call(self):
+        call = _call(module="m", version=2, code_digest="abc")
+        dc = DigestedCall.from_call(call)
+        assert isinstance(dc, DigestedCall)
+        assert dc.name == call.name
+        assert dc.arguments is call.arguments
+        assert dc.result is call.result
+        assert dc.metadata is call.metadata
+        assert dc.module == call.module
+        assert dc.version == call.version
+        assert dc.code_digest == call.code_digest
+
+    def test_lookup_key_matches(self):
+        call = _call()
+        dc = DigestedCall.from_call(call)
+        assert dc.to_lookup_key() == call.to_lookup_key()
 
 
 # ---------------------------------------------------------------------------
@@ -35,9 +58,9 @@ class TestDigestedCallLookupKey:
         d2 = call.stash(values)
         assert d1.to_lookup_key() == d2.to_lookup_key()
 
-    def test_matches_freeze(self):
+    def test_matches_digest(self):
         call = _call()
-        assert call.freeze().to_lookup_key() == call.to_lookup_key()
+        assert call.digest().to_lookup_key() == call.to_lookup_key()
 
     def test_metadata_not_in_key(self):
         values = _mem()
@@ -162,51 +185,32 @@ class TestCallStash:
         with pytest.raises(RuntimeError, match="storage full"):
             call.stash(values)
 
-    def test_roundtrip_lookup_key(self):
-        """Saving and reloading via in-memory storage preserves the lookup key."""
-        from fleche.storage.memory import CallMemory
-        from fleche.caches import Cache
-
-        values = _mem()
-        calls = CallMemory({})
-        cache = Cache(values, calls)
-
-        call = Call(name="g", arguments={"a": [1, 2], "b": {"k": 10}}, result=("x", 5))
-        key = cache.save(call)
-        loaded = cache.load(key, lazy=False)
-        assert loaded.to_lookup_key() == key
-
 
 # ---------------------------------------------------------------------------
-# Call.freeze
+# Call.digest
 # ---------------------------------------------------------------------------
 
-class TestCallFreeze:
+class TestCallDigest:
     def test_returns_digested_call(self):
-        assert isinstance(_call().freeze(), DigestedCall)
+        assert isinstance(_call().digest(), DigestedCall)
 
     def test_arguments_are_digests(self):
-        for v in _call().freeze().arguments.values():
+        for v in _call().digest().arguments.values():
             assert isinstance(v, Digest)
 
     def test_result_is_digest(self):
-        assert isinstance(_call().freeze().result, Digest)
-
-    def test_no_storage_written(self):
-        values = MagicMock()
-        _call().freeze()
-        values.save.assert_not_called()
+        assert isinstance(_call().digest().result, Digest)
 
     def test_same_lookup_key_as_stash(self):
         values = _mem()
         call = _call()
-        assert call.freeze().to_lookup_key() == call.stash(values).to_lookup_key()
+        assert call.digest().to_lookup_key() == call.stash(values).to_lookup_key()
 
     def test_already_digest_argument_preserved(self):
         existing = Digest("a" * 64)
-        digested = _call(arguments={"x": existing}).freeze()
+        digested = _call(arguments={"x": existing}).digest()
         assert digested.arguments["x"] == existing
 
     def test_metadata_preserved(self):
         call = _call(metadata={"Tags": {"env": "prod"}})
-        assert call.freeze().metadata == {"Tags": {"env": "prod"}}
+        assert call.digest().metadata == {"Tags": {"env": "prod"}}

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -2,43 +2,26 @@
 import pytest
 from unittest.mock import MagicMock
 
-from fleche.call import Call, DigestedCall
+from fleche.call import Call, DigestedCall, LazyCall
+from fleche.caches import Cache
 from fleche.digest import Digest
 from fleche.storage.base import SaveError
-from fleche.storage.memory import ValueMemory
+from fleche.storage.memory import ValueMemory, CallMemory
 
 
 def _mem():
     return ValueMemory({})
 
 
+def _cache(values=None):
+    values = values or _mem()
+    return Cache(values, CallMemory({}))
+
+
 def _call(**kwargs):
     defaults = dict(name="f", arguments={"x": 1, "y": 2}, result=42)
     defaults.update(kwargs)
     return Call(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# DigestedCall.from_call
-# ---------------------------------------------------------------------------
-
-class TestDigestedCallFromCall:
-    def test_wraps_stored_call(self):
-        call = _call(module="m", version=2, code_digest="abc")
-        dc = DigestedCall.from_call(call)
-        assert isinstance(dc, DigestedCall)
-        assert dc.name == call.name
-        assert dc.arguments is call.arguments
-        assert dc.result is call.result
-        assert dc.metadata is call.metadata
-        assert dc.module == call.module
-        assert dc.version == call.version
-        assert dc.code_digest == call.code_digest
-
-    def test_lookup_key_matches(self):
-        call = _call()
-        dc = DigestedCall.from_call(call)
-        assert dc.to_lookup_key() == call.to_lookup_key()
 
 
 # ---------------------------------------------------------------------------
@@ -89,46 +72,52 @@ class TestDigestedCallLookupKey:
 # ---------------------------------------------------------------------------
 
 class TestDigestedCallFetch:
-    def test_fetch_returns_call(self):
+    def test_fetch_returns_lazy_call(self):
         values = _mem()
+        cache = _cache(values)
         call = _call()
         digested = call.stash(values)
-        restored = digested.fetch(values)
-        assert isinstance(restored, Call)
+        lazy = digested.fetch(cache)
+        assert isinstance(lazy, LazyCall)
 
     def test_fetch_restores_arguments(self):
         values = _mem()
+        cache = _cache(values)
         call = _call(arguments={"x": 10, "y": 20})
         digested = call.stash(values)
-        restored = digested.fetch(values)
+        restored = digested.fetch(cache).fetch()
         assert restored.arguments == {"x": 10, "y": 20}
 
     def test_fetch_restores_result(self):
         values = _mem()
+        cache = _cache(values)
         call = _call(result=99)
         digested = call.stash(values)
-        restored = digested.fetch(values)
+        restored = digested.fetch(cache).fetch()
         assert restored.result == 99
 
     def test_fetch_preserves_metadata(self):
         values = _mem()
+        cache = _cache(values)
         call = _call(metadata={"Runtime": {"elapsed": 2.5}})
         digested = call.stash(values)
-        restored = digested.fetch(values)
-        assert restored.metadata == {"Runtime": {"elapsed": 2.5}}
+        lazy = digested.fetch(cache)
+        assert lazy.metadata == {"Runtime": {"elapsed": 2.5}}
 
     def test_fetch_roundtrip_lookup_key(self):
         values = _mem()
+        cache = _cache(values)
         call = _call()
-        restored = call.stash(values).fetch(values)
-        assert restored.to_lookup_key() == call.to_lookup_key()
+        lazy = call.stash(values).fetch(cache)
+        assert lazy.to_lookup_key() == call.to_lookup_key()
 
     def test_fetch_none_result(self):
         """fetch handles DigestedCall with no result (result=None)."""
         dc = DigestedCall(name="f", arguments={})
-        values = _mem()
-        restored = dc.fetch(values)
-        assert restored.result is None
+        cache = _cache()
+        lazy = dc.fetch(cache)
+        assert isinstance(lazy, LazyCall)
+        assert lazy._result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from fleche.call import Call, DigestedCall, LazyCall
 from fleche.caches import Cache
-from fleche.digest import Digest
+from fleche.digest import Digest, digest
 from fleche.storage.base import SaveError
 from fleche.storage.memory import ValueMemory, CallMemory
 
@@ -212,3 +212,65 @@ class TestCallDigest:
     def test_metadata_preserved(self):
         call = _call(metadata={"Tags": {"env": "prod"}})
         assert call.digest().metadata == {"Tags": {"env": "prod"}}
+
+
+# ---------------------------------------------------------------------------
+# DigestedCall.__digest__  —  cross-type digest equivalence
+#
+# DigestedCall.__digest__ ensures that digest(DigestedCall) == digest(Call) for
+# semantically equivalent objects.  This invariant is load-bearing: it allows
+# LazyCall.to_lookup_key() to delegate to DigestedCall without re-hashing raw
+# values, and it means stored DigestedCall objects hash the same way as the
+# original Call from which they were produced.
+#
+# The three-way equivalence that must hold:
+#   digest(original_Call) == digest(DigestedCall) == digest(LazyCall)
+# for objects representing the same function call.
+# ---------------------------------------------------------------------------
+
+class TestDigestedCallDigestEquivalence:
+    """digest(DigestedCall) must equal digest(equivalent Call) and digest(equivalent LazyCall)."""
+
+    def test_digested_call_digest_matches_original_call(self):
+        """digest(dc) == digest(call) — Digest pass-through makes value vs pointer transparent."""
+        call = _call(arguments={"x": 10, "y": 20}, result=99)
+        dc = call.digest()
+        assert digest(dc) == digest(call)
+
+    def test_stash_digest_matches_original_call(self):
+        """digest(stash) == digest(call) — stash stores values but same hash as original."""
+        values = _mem()
+        call = _call(arguments={"x": 10, "y": 20}, result=99)
+        stashed = call.stash(values)
+        assert digest(stashed) == digest(call)
+
+    def test_digested_call_digest_matches_lazy_call(self):
+        """digest(DigestedCall) == digest(LazyCall) — three-way equivalence."""
+        values = _mem()
+        cache = _cache(values)
+        call = _call(arguments={"x": 10, "y": 20}, result=99)
+        stashed = call.stash(values)
+        lazy = stashed.fetch(cache)
+        assert digest(stashed) == digest(lazy)
+        assert digest(lazy) == digest(call)
+
+    def test_digested_call_digest_stable_across_stash_fetch(self):
+        """digest is stable after a full stash → fetch → fetch round-trip."""
+        values = _mem()
+        cache = _cache(values)
+        call = _call(arguments={"x": 42}, result="hello")
+        stashed = call.stash(values)
+        restored = stashed.fetch(cache).fetch()
+        assert digest(stashed) == digest(restored)
+
+    def test_digested_call_digest_varies_with_arguments(self):
+        """Different arguments produce different digests."""
+        call_a = _call(arguments={"x": 1})
+        call_b = _call(arguments={"x": 2})
+        assert digest(call_a.digest()) != digest(call_b.digest())
+
+    def test_digested_call_digest_varies_with_metadata(self):
+        """Different metadata produces different full digests (metadata is NOT excluded from digest)."""
+        call_a = _call(metadata={"Runtime": {"elapsed": 1.0}})
+        call_b = _call(metadata={"Runtime": {"elapsed": 9.9}})
+        assert digest(call_a.digest()) != digest(call_b.digest())

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -1,4 +1,4 @@
-"""Tests for Call.dehydrate and DigestedCall."""
+"""Tests for Call.stash, Call.freeze, DigestedCall, and related methods."""
 import pytest
 from unittest.mock import MagicMock
 
@@ -18,67 +18,124 @@ def _call(**kwargs):
 
 
 # ---------------------------------------------------------------------------
-# DigestedCall
+# DigestedCall.to_lookup_key
 # ---------------------------------------------------------------------------
 
-class TestDigestedCall:
-    def test_to_lookup_key_matches_original_call(self):
+class TestDigestedCallLookupKey:
+    def test_matches_original_call(self):
         values = _mem()
         call = _call()
-        digested = call.dehydrate(values)
+        digested = call.stash(values)
         assert digested.to_lookup_key() == call.to_lookup_key()
 
-    def test_to_lookup_key_stable_across_dehydrations(self):
+    def test_stable_across_stashes(self):
         values = _mem()
         call = _call()
-        d1 = call.dehydrate(values)
-        d2 = call.dehydrate(values)
+        d1 = call.stash(values)
+        d2 = call.stash(values)
         assert d1.to_lookup_key() == d2.to_lookup_key()
+
+    def test_matches_freeze(self):
+        call = _call()
+        assert call.freeze().to_lookup_key() == call.to_lookup_key()
+
+    def test_metadata_not_in_key(self):
+        values = _mem()
+        call_a = _call(metadata={"Runtime": {"elapsed": 1.0}})
+        call_b = _call(metadata={"Runtime": {"elapsed": 9.9}})
+        assert call_a.stash(values).to_lookup_key() == call_b.stash(values).to_lookup_key()
 
     def test_metadata_preserved(self):
         values = _mem()
         call = _call(metadata={"Runtime": {"elapsed": 1.5}})
-        digested = call.dehydrate(values)
+        digested = call.stash(values)
         assert digested.metadata == {"Runtime": {"elapsed": 1.5}}
 
     def test_module_version_code_digest_preserved(self):
         values = _mem()
         call = _call(module="mymod", version=3, code_digest="abc123")
-        digested = call.dehydrate(values)
+        digested = call.stash(values)
         assert digested.module == "mymod"
         assert digested.version == 3
         assert digested.code_digest == "abc123"
 
 
 # ---------------------------------------------------------------------------
-# Call.dehydrate
+# DigestedCall.fetch
 # ---------------------------------------------------------------------------
 
-class TestCallDehydrate:
+class TestDigestedCallFetch:
+    def test_fetch_returns_call(self):
+        values = _mem()
+        call = _call()
+        digested = call.stash(values)
+        restored = digested.fetch(values)
+        assert isinstance(restored, Call)
+
+    def test_fetch_restores_arguments(self):
+        values = _mem()
+        call = _call(arguments={"x": 10, "y": 20})
+        digested = call.stash(values)
+        restored = digested.fetch(values)
+        assert restored.arguments == {"x": 10, "y": 20}
+
+    def test_fetch_restores_result(self):
+        values = _mem()
+        call = _call(result=99)
+        digested = call.stash(values)
+        restored = digested.fetch(values)
+        assert restored.result == 99
+
+    def test_fetch_preserves_metadata(self):
+        values = _mem()
+        call = _call(metadata={"Runtime": {"elapsed": 2.5}})
+        digested = call.stash(values)
+        restored = digested.fetch(values)
+        assert restored.metadata == {"Runtime": {"elapsed": 2.5}}
+
+    def test_fetch_roundtrip_lookup_key(self):
+        values = _mem()
+        call = _call()
+        restored = call.stash(values).fetch(values)
+        assert restored.to_lookup_key() == call.to_lookup_key()
+
+    def test_fetch_none_result(self):
+        """fetch handles DigestedCall with no result (result=None)."""
+        dc = DigestedCall(name="f", arguments={})
+        values = _mem()
+        restored = dc.fetch(values)
+        assert restored.result is None
+
+
+# ---------------------------------------------------------------------------
+# Call.stash
+# ---------------------------------------------------------------------------
+
+class TestCallStash:
     def test_returns_digested_call(self):
         values = _mem()
         call = _call()
-        result = call.dehydrate(values)
+        result = call.stash(values)
         assert isinstance(result, DigestedCall)
 
     def test_arguments_are_digests(self):
         values = _mem()
         call = _call()
-        digested = call.dehydrate(values)
+        digested = call.stash(values)
         for v in digested.arguments.values():
             assert isinstance(v, Digest)
 
     def test_result_is_digest(self):
         values = _mem()
         call = _call()
-        digested = call.dehydrate(values)
+        digested = call.stash(values)
         assert isinstance(digested.result, Digest)
 
     def test_already_digest_argument_preserved(self):
         values = _mem()
         existing_digest = Digest("a" * 64)
         call = _call(arguments={"x": existing_digest})
-        digested = call.dehydrate(values)
+        digested = call.stash(values)
         assert digested.arguments["x"] == existing_digest
 
     def test_already_digest_argument_not_saved(self):
@@ -86,7 +143,7 @@ class TestCallDehydrate:
         values.save.return_value = Digest("b" * 64)
         existing_digest = Digest("a" * 64)
         call = _call(arguments={"x": existing_digest})
-        call.dehydrate(values)
+        call.stash(values)
         # values.save should only be called for the result, not for the Digest arg
         assert values.save.call_count == 1
 
@@ -95,8 +152,7 @@ class TestCallDehydrate:
         result_digest = Digest("r" * 64)
         values.save.side_effect = [result_digest, Exception("cannot save")]
         call = _call(arguments={"x": 99})
-        digested = call.dehydrate(values)
-        # Should not raise; argument falls back to a Digest
+        digested = call.stash(values)
         assert isinstance(digested.arguments["x"], Digest)
 
     def test_result_save_failure_propagates(self):
@@ -104,7 +160,7 @@ class TestCallDehydrate:
         values.save.side_effect = RuntimeError("storage full")
         call = _call()
         with pytest.raises(RuntimeError, match="storage full"):
-            call.dehydrate(values)
+            call.stash(values)
 
     def test_roundtrip_lookup_key(self):
         """Saving and reloading via in-memory storage preserves the lookup key."""
@@ -119,3 +175,38 @@ class TestCallDehydrate:
         key = cache.save(call)
         loaded = cache.load(key, lazy=False)
         assert loaded.to_lookup_key() == key
+
+
+# ---------------------------------------------------------------------------
+# Call.freeze
+# ---------------------------------------------------------------------------
+
+class TestCallFreeze:
+    def test_returns_digested_call(self):
+        assert isinstance(_call().freeze(), DigestedCall)
+
+    def test_arguments_are_digests(self):
+        for v in _call().freeze().arguments.values():
+            assert isinstance(v, Digest)
+
+    def test_result_is_digest(self):
+        assert isinstance(_call().freeze().result, Digest)
+
+    def test_no_storage_written(self):
+        values = MagicMock()
+        _call().freeze()
+        values.save.assert_not_called()
+
+    def test_same_lookup_key_as_stash(self):
+        values = _mem()
+        call = _call()
+        assert call.freeze().to_lookup_key() == call.stash(values).to_lookup_key()
+
+    def test_already_digest_argument_preserved(self):
+        existing = Digest("a" * 64)
+        digested = _call(arguments={"x": existing}).freeze()
+        assert digested.arguments["x"] == existing
+
+    def test_metadata_preserved(self):
+        call = _call(metadata={"Tags": {"env": "prod"}})
+        assert call.freeze().metadata == {"Tags": {"env": "prod"}}

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from fleche.call import Call, DigestedCall
 from fleche.digest import Digest
+from fleche.storage.base import SaveError
 from fleche.storage.memory import ValueMemory
 
 
@@ -173,10 +174,18 @@ class TestCallStash:
     def test_arg_save_failure_falls_back_to_digest(self):
         values = MagicMock()
         result_digest = Digest("r" * 64)
-        values.save.side_effect = [result_digest, Exception("cannot save")]
+        values.save.side_effect = [result_digest, SaveError("cannot save")]
         call = _call(arguments={"x": 99})
         digested = call.stash(values)
         assert isinstance(digested.arguments["x"], Digest)
+
+    def test_arg_save_non_save_error_propagates(self):
+        values = MagicMock()
+        result_digest = Digest("r" * 64)
+        values.save.side_effect = [result_digest, RuntimeError("unexpected")]
+        call = _call(arguments={"x": 99})
+        with pytest.raises(RuntimeError, match="unexpected"):
+            call.stash(values)
 
     def test_result_save_failure_propagates(self):
         values = MagicMock()

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -1,0 +1,121 @@
+"""Tests for Call.dehydrate and DigestedCall."""
+import pytest
+from unittest.mock import MagicMock
+
+from fleche.call import Call, DigestedCall
+from fleche.digest import Digest
+from fleche.storage.memory import ValueMemory
+
+
+def _mem():
+    return ValueMemory({})
+
+
+def _call(**kwargs):
+    defaults = dict(name="f", arguments={"x": 1, "y": 2}, result=42)
+    defaults.update(kwargs)
+    return Call(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# DigestedCall
+# ---------------------------------------------------------------------------
+
+class TestDigestedCall:
+    def test_to_lookup_key_matches_original_call(self):
+        values = _mem()
+        call = _call()
+        digested = call.dehydrate(values)
+        assert digested.to_lookup_key() == call.to_lookup_key()
+
+    def test_to_lookup_key_stable_across_dehydrations(self):
+        values = _mem()
+        call = _call()
+        d1 = call.dehydrate(values)
+        d2 = call.dehydrate(values)
+        assert d1.to_lookup_key() == d2.to_lookup_key()
+
+    def test_metadata_preserved(self):
+        values = _mem()
+        call = _call(metadata={"Runtime": {"elapsed": 1.5}})
+        digested = call.dehydrate(values)
+        assert digested.metadata == {"Runtime": {"elapsed": 1.5}}
+
+    def test_module_version_code_digest_preserved(self):
+        values = _mem()
+        call = _call(module="mymod", version=3, code_digest="abc123")
+        digested = call.dehydrate(values)
+        assert digested.module == "mymod"
+        assert digested.version == 3
+        assert digested.code_digest == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Call.dehydrate
+# ---------------------------------------------------------------------------
+
+class TestCallDehydrate:
+    def test_returns_digested_call(self):
+        values = _mem()
+        call = _call()
+        result = call.dehydrate(values)
+        assert isinstance(result, DigestedCall)
+
+    def test_arguments_are_digests(self):
+        values = _mem()
+        call = _call()
+        digested = call.dehydrate(values)
+        for v in digested.arguments.values():
+            assert isinstance(v, Digest)
+
+    def test_result_is_digest(self):
+        values = _mem()
+        call = _call()
+        digested = call.dehydrate(values)
+        assert isinstance(digested.result, Digest)
+
+    def test_already_digest_argument_preserved(self):
+        values = _mem()
+        existing_digest = Digest("a" * 64)
+        call = _call(arguments={"x": existing_digest})
+        digested = call.dehydrate(values)
+        assert digested.arguments["x"] == existing_digest
+
+    def test_already_digest_argument_not_saved(self):
+        values = MagicMock()
+        values.save.return_value = Digest("b" * 64)
+        existing_digest = Digest("a" * 64)
+        call = _call(arguments={"x": existing_digest})
+        call.dehydrate(values)
+        # values.save should only be called for the result, not for the Digest arg
+        assert values.save.call_count == 1
+
+    def test_arg_save_failure_falls_back_to_digest(self):
+        values = MagicMock()
+        result_digest = Digest("r" * 64)
+        values.save.side_effect = [result_digest, Exception("cannot save")]
+        call = _call(arguments={"x": 99})
+        digested = call.dehydrate(values)
+        # Should not raise; argument falls back to a Digest
+        assert isinstance(digested.arguments["x"], Digest)
+
+    def test_result_save_failure_propagates(self):
+        values = MagicMock()
+        values.save.side_effect = RuntimeError("storage full")
+        call = _call()
+        with pytest.raises(RuntimeError, match="storage full"):
+            call.dehydrate(values)
+
+    def test_roundtrip_lookup_key(self):
+        """Saving and reloading via in-memory storage preserves the lookup key."""
+        from fleche.storage.memory import CallMemory
+        from fleche.caches import Cache
+
+        values = _mem()
+        calls = CallMemory({})
+        cache = Cache(values, calls)
+
+        call = Call(name="g", arguments={"a": [1, 2], "b": {"k": 10}}, result=("x", 5))
+        key = cache.save(call)
+        loaded = cache.load(key, lazy=False)
+        assert loaded.to_lookup_key() == key

--- a/tests/unit/call/test_matches.py
+++ b/tests/unit/call/test_matches.py
@@ -29,7 +29,7 @@ def test_query_call_matches_lazy():
 
     original = Call(name="f", arguments={"x": 1}, result=10)
     key = cache.save(original)
-    lazy = cache.load(key, lazy=True)
+    lazy = cache.load(key)
 
     # Template matching
     assert QueryCall(name="f", arguments=None).matches(lazy)

--- a/tests/unit/config/test_cache_to_config.py
+++ b/tests/unit/config/test_cache_to_config.py
@@ -93,7 +93,7 @@ def test_cache_to_config_unknown_raises():
         def save(self, call):
             return ""
 
-        def load(self, key, lazy=True):
+        def load(self, key):
             raise KeyError(key)
 
         def load_value(self, key):

--- a/tests/unit/storage/test_sql_query.py
+++ b/tests/unit/storage/test_sql_query.py
@@ -274,7 +274,10 @@ def test_sql_call_digest_persistence(store):
 
     assert loaded.code_digest == "some_code_digest"
     assert loaded.to_lookup_key() == original.to_lookup_key()
-    assert loaded == original
+    assert loaded.metadata == original.metadata
+    assert loaded.module == original.module
+    assert loaded.version == original.version
+    assert str(loaded.result) == str(original.result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pickle.py
+++ b/tests/unit/test_pickle.py
@@ -140,7 +140,7 @@ def test_cache_functional_roundtrip(value_storage, call_storage, call):
     except Rejected:
         return
     restored = roundtrip(cache)
-    loaded = restored.load(key, lazy=False)
+    loaded = restored.load(key).fetch()
     assert loaded == call
 
 
@@ -155,7 +155,7 @@ def test_cache_stack_functional_roundtrip(value_storage, call_storage, call):
         return
     stack = CacheStack((cache, Cache(ValueMemory({}), CallMemory({}))))
     restored = roundtrip(stack)
-    loaded = restored.load(key, lazy=False)
+    loaded = restored.load(key).fetch()
     assert loaded == call
 
 


### PR DESCRIPTION
Introduce `DigestedCall`, a dataclass that holds a call where every argument value and the result have been replaced by their Digest pointers into a value store. Add `Call.dehydrate(values)` to produce one.

This is the first step toward the consolidation described in #335, and relates to #81.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/pmrv/fleche/actions/runs/24668125505