### PR TITLE
Refactor fleche decorator to extract helper functions

### DIFF
--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -157,6 +157,166 @@ def _attach(wrapper, fn, *, name, doc_prefix, ret=None, extra_doc=""):
 
 _T = TypeVar("_T")
 
+
+_QUERY_DOC = """Return matching results from current cache.
+
+See :class:`CallStorage.query' for details, except that calls returned from here will have their arguments
+and results restored from the value storage via :class:`Cache.query`.
+
+Args:
+    *args, **kwargs: function arguments that should be matched in returned calls; pass `None` as a wildcard
+    metadata (dict[str, dict[str, json]]): metadata tags to additionall filter on; if this shadows a
+        function kwargs of the same name, you must pass it by position instead.
+
+Returns:
+    iterable of matching :class:`.Call`
+"""
+
+
+def make_get_call(func, policy, hash_version, hash_module, hash_code):
+    """Build the `.call` helper that produces a :class:`.Call` for the given arguments."""
+    @wraps(func)
+    def get_call(*args, **kwargs):
+        call = Call.from_call(func, *args, **kwargs)
+        # drop ignored arguments for the saved call object to make our lives much simpler when hashing or saving it
+        # if we leave them in, then Cache.save needs to know about them indirectly to ensure correct digest key
+        # generation, but then we'd also have to save it somehow and that just seems bothersome in particular for
+        # Sql Callstorage.  We could add a new table there connecting unique functions and their ignored args, but
+        # meh.
+        policy.strip_for_key(call.arguments)
+        if not hash_version:
+            call.version = None
+        if not hash_module:
+            call.module = None
+        if not hash_code:
+            call.code_digest = None
+        return call
+    return get_call
+
+
+def make_digest(func, get_call):
+    """Build the `.digest` helper that returns the lookup key for given arguments."""
+    @wraps(func)
+    def _digest_func(*args, **kwargs):
+        return get_call(*args, **kwargs).to_lookup_key()
+    return _digest_func
+
+
+def make_query(func, policy):
+    """Build the `.query` helper that yields matching calls from the active cache."""
+    def _query_func(
+        *args, metadata={}, **kwargs
+    ) -> Iterable[AnyCall]:
+        call = QueryCall.from_call(func, *args, **kwargs)
+        policy.strip_for_key(call.arguments)
+        if "metadata" in call.arguments:
+            logger.warning(
+                "Function argument 'metadata' shadowed by query argument"
+            )
+        call.metadata = metadata
+        return state._CACHE.get().query(call)
+
+    wraps(func)(_query_func)  # ty: ignore
+    return _query_func
+
+
+def make_load(func, digest_func):
+    """Build the `.load` helper that retrieves a cached result for given arguments."""
+    @wraps(func)
+    def _load_func(*args, **kwargs):
+        return state._CACHE.get().load(digest_func(*args, **kwargs)).result
+    return _load_func
+
+
+def make_contains(func, digest_func):
+    """Build the `.contains` helper that checks cache membership for given arguments."""
+    @wraps(func)
+    def _contains_func(*args, **kwargs):
+        return state._CACHE.get().contains(digest_func(*args, **kwargs))
+    return _contains_func
+
+
+def make_rerun(func, wrapper):
+    """Build the `.rerun` helper that forces recursive reevaluation through a :class:`RefreshingCache`."""
+    @wraps(func)
+    def _rerun_func(*args, **kwargs):
+        cache: BaseCache = state._CACHE.get()
+        with state.cache(RefreshingCache(cache)):
+            return wrapper(*args, **kwargs)
+    return _rerun_func
+
+
+def make_wrapper(func, policy, meta, isolate, get_call):
+    """Build the cached wrapper returned by :func:`fleche`."""
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> _T:
+        cache: BaseCache = state._CACHE.get()
+
+        # expand args passed as digest early so that everything else below sees the real values
+        args = tuple(
+            cache.load_value(arg) if isinstance(arg, digest.Digest) else arg
+            for arg in args
+        )
+        kwargs = {
+            k: (cache.load_value(v) if isinstance(v, digest.Digest) else v)
+            for k, v in kwargs.items()
+        }
+
+        try:
+            call = get_call(*args, **kwargs)
+            key = call.to_lookup_key()
+        except digest.Unhashable as e:
+            logger.warning("No hash for argument: %s", e.args[0])
+            return func(*args, **kwargs)
+
+        missing = policy.check_required(func, args, kwargs)
+        if missing:
+            logger.warning(
+                "Missing required keyword arguments for caching: %s", missing
+            )
+            return func(*args, **kwargs)
+
+        try:
+            result = cache.load(key).result
+            logger.debug("Cache hit for %s with key %s", call.name, key)
+            return result
+        except KeyError:
+            logger.debug("Cache miss for %s with key %s", call.name, key)
+
+        def _run_and_cache():
+            active_meta = state._METADATA.get() + tuple(meta)
+            metadata: Dict[str, Any] = defaultdict(dict)
+            for m in active_meta:
+                metadata[m.name] |= m.pre(replace(call, metadata={}))
+
+            call.result: _T = func(*args, **kwargs)
+            if call.result is None:
+                logger.warning("Function returned None, not caching")
+                return None
+            for m in active_meta:
+                metadata[m.name] |= m.post(
+                    metadata[m.name], replace(call, metadata={})
+                )
+            try:
+                call.metadata = metadata
+                logger.debug("Saving result for %s with key %s", call.name, key)
+                cache.save(call)
+            except Rejected as e:
+                logger.warning("Cache rejected save: %s", e.args)
+            return call.result
+
+        if isolate:
+            root = _get_working_directory_root()
+            # Create a unique working directory to avoid race conditions during concurrent execution.
+            # NOTE: os.chdir is process-wide and not thread-safe.
+            with tempfile.TemporaryDirectory(dir=root, prefix=f"{key}_") as workdir:
+                with contextlib.chdir(workdir):
+                    return _run_and_cache()
+        else:
+            return _run_and_cache()
+    return wrapper
+
+
 def fleche(
     _func=None,
     *,
@@ -202,143 +362,21 @@ def fleche(
 
         policy = process_ignore_required_args(func, ignore, require)
 
-        @wraps(func)
-        def get_call(*args, **kwargs):
-            call = Call.from_call(func, *args, **kwargs)
-            # drop ignored arguments for the saved call object to make our lives much simpler when hashing or saving it
-            # if we leave them in, then Cache.save needs to know about them indirectly to ensure correct digest key
-            # generation, but then we'd also have to save it somehow and that just seems bothersome in particular for
-            # Sql Callstorage.  We could add a new table there connecting unique functions and their ignored args, but
-            # meh.
-            policy.strip_for_key(call.arguments)
-            if not hash_version:
-                call.version = None
-            if not hash_module:
-                call.module = None
-            if not hash_code:
-                call.code_digest = None
-            return call
-
-        @wraps(func)
-        def _digest_func(*args, **kwargs):
-            return get_call(*args, **kwargs).to_lookup_key()
-
-        def _query_func(
-            *args, metadata={}, **kwargs
-        ) -> Iterable[AnyCall]:
-            """Return matching results from current cache.
-
-            See :class:`CallStorage.query' for details, except that calls returned from here will have their arguments
-            and results restored from the value storage via :class:`Cache.query`.
-
-            Args:
-                *args, **kwargs: function arguments that should be matched in returned calls; pass `None` as a wildcard
-                metadata (dict[str, dict[str, json]]): metadata tags to additionall filter on; if this shadows a
-                    function kwargs of the same name, you must pass it by position instead.
-
-            Returns:
-                iterable of matching :class:`.Call`
-            """
-            call = QueryCall.from_call(func, *args, **kwargs)
-            policy.strip_for_key(call.arguments)
-            if "metadata" in call.arguments:
-                logger.warning(
-                    "Function argument 'metadata' shadowed by query argument"
-                )
-            call.metadata = metadata
-            return state._CACHE.get().query(call)
-
-        _query_doc = _query_func.__doc__
-        wraps(func)(_query_func)  # ty: ignore
-
-        @wraps(func)
-        def _load_func(*args, **kwargs):
-            return state._CACHE.get().load(_digest_func(*args, **kwargs)).result
-
-        @wraps(func)
-        def _contains_func(*args, **kwargs):
-            return state._CACHE.get().contains(_digest_func(*args, **kwargs))
-
-        @wraps(func)
-        def _rerun_func(*args, **kwargs):
-            cache: BaseCache = state._CACHE.get()
-            with state.cache(RefreshingCache(cache)):
-                return wrapper(*args, **kwargs)
-
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> _T:
-            cache: BaseCache = state._CACHE.get()
-
-            # expand args passed as digest early so that everything else below sees the real values
-            args = tuple(
-                cache.load_value(arg) if isinstance(arg, digest.Digest) else arg
-                for arg in args
-            )
-            kwargs = {
-                k: (cache.load_value(v) if isinstance(v, digest.Digest) else v)
-                for k, v in kwargs.items()
-            }
-
-            try:
-                call = get_call(*args, **kwargs)
-                key = call.to_lookup_key()
-            except digest.Unhashable as e:
-                logger.warning("No hash for argument: %s", e.args[0])
-                return func(*args, **kwargs)
-
-            missing = policy.check_required(func, args, kwargs)
-            if missing:
-                logger.warning(
-                    "Missing required keyword arguments for caching: %s", missing
-                )
-                return func(*args, **kwargs)
-
-            try:
-                result = cache.load(key).result
-                logger.debug("Cache hit for %s with key %s", call.name, key)
-                return result
-            except KeyError:
-                logger.debug("Cache miss for %s with key %s", call.name, key)
-
-            def _run_and_cache():
-                active_meta = state._METADATA.get() + tuple(meta)
-                metadata: Dict[str, Any] = defaultdict(dict)
-                for m in active_meta:
-                    metadata[m.name] |= m.pre(replace(call, metadata={}))
-
-                call.result: _T = func(*args, **kwargs)
-                if call.result is None:
-                    logger.warning("Function returned None, not caching")
-                    return None
-                for m in active_meta:
-                    metadata[m.name] |= m.post(
-                        metadata[m.name], replace(call, metadata={})
-                    )
-                try:
-                    call.metadata = metadata
-                    logger.debug("Saving result for %s with key %s", call.name, key)
-                    cache.save(call)
-                except Rejected as e:
-                    logger.warning("Cache rejected save: %s", e.args)
-                return call.result
-
-            if isolate:
-                root = _get_working_directory_root()
-                # Create a unique working directory to avoid race conditions during concurrent execution.
-                # NOTE: os.chdir is process-wide and not thread-safe.
-                with tempfile.TemporaryDirectory(dir=root, prefix=f"{key}_") as workdir:
-                    with contextlib.chdir(workdir):
-                        return _run_and_cache()
-            else:
-                return _run_and_cache()
+        get_call = make_get_call(func, policy, hash_version, hash_module, hash_code)
+        digest_func = make_digest(func, get_call)
+        query_func = make_query(func, policy)
+        load_func = make_load(func, digest_func)
+        contains_func = make_contains(func, digest_func)
+        wrapper = make_wrapper(func, policy, meta, isolate, get_call)
+        rerun_func = make_rerun(func, wrapper)
 
         _attach(wrapper, get_call, name="call", doc_prefix="Get the Call object for", ret=Call)
-        _attach(wrapper, _digest_func, name="digest", doc_prefix="Get the cache key for", ret=digest.Digest)
-        _attach(wrapper, _query_func, name="query", doc_prefix="Return matching results from current cache for",
-                ret=Iterable[Call], extra_doc=_query_doc)
-        _attach(wrapper, _load_func, name="load", doc_prefix="Load result from cache for")
-        _attach(wrapper, _contains_func, name="contains", doc_prefix="Check if result is in cache for", ret=bool)
-        _attach(wrapper, _rerun_func, name="rerun", doc_prefix="Force reevaluation recursively for")
+        _attach(wrapper, digest_func, name="digest", doc_prefix="Get the cache key for", ret=digest.Digest)
+        _attach(wrapper, query_func, name="query", doc_prefix="Return matching results from current cache for",
+                ret=Iterable[Call], extra_doc=_QUERY_DOC)
+        _attach(wrapper, load_func, name="load", doc_prefix="Load result from cache for")
+        _attach(wrapper, contains_func, name="contains", doc_prefix="Check if result is in cache for", ret=bool)
+        _attach(wrapper, rerun_func, name="rerun", doc_prefix="Force reevaluation recursively for")
         return wrapper
 
     if callable(_func):


### PR DESCRIPTION
## Summary
Extracted the internal helper functions from the `fleche` decorator into standalone factory functions to improve code organization, testability, and maintainability.

## Key Changes
- Created `make_get_call()` factory function to build the `.call` helper that produces `Call` objects for given arguments
- Created `make_digest()` factory function to build the `.digest` helper that returns lookup keys
- Created `make_query()` factory function to build the `.query` helper that yields matching calls from cache
- Created `make_load()` factory function to build the `.load` helper that retrieves cached results
- Created `make_contains()` factory function to build the `.contains` helper that checks cache membership
- Created `make_rerun()` factory function to build the `.rerun` helper for forced recursive reevaluation
- Created `make_wrapper()` factory function to build the main cached wrapper function
- Extracted query documentation string to module-level `_QUERY_DOC` constant
- Refactored the `fleche` decorator to use these factory functions instead of defining helpers inline

## Implementation Details
- All factory functions maintain the same behavior as the original inline implementations
- The extracted functions follow a consistent naming pattern (`make_*`) for clarity
- Documentation strings are preserved, with the query function's docstring moved to a module-level constant for reusability
- The refactoring reduces the `fleche` decorator from ~143 lines to ~21 lines, improving readability
- No functional changes to the caching behavior or API

https://claude.ai/code/session_01VzyB6MKKWLTSS59sBW1uKV