### PR TITLE
refactor(tests): move hypothesis+parametrized storage tests to StorageBackend interface

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,6 +8,9 @@ from fleche.storage import (
     CallBagOfHoldingH5File,
     Sql,
 )
+from fleche.storage.memory import MemoryBackend
+from fleche.storage.pickle_file import PickleFileBackend
+from fleche.storage.bagofholding_file import BagOfHoldingH5FileBackend
 from fleche.caches import Cache
 
 secret_key = [b"test_secret_key_32_bytes_long!!!!"]
@@ -44,6 +47,20 @@ def value_storage(request, tmp_path):
         return ValuePickleFile.with_pickle(tmp_path / "pickle", secret_key=secret_key)
     elif request.param == "h5":
         return ValueBagOfHoldingH5File(tmp_path / "h5")
+
+@pytest.fixture(params=["memory", "cloudpickle", "dill", "pickle", "h5"])
+def storage_backend(request, tmp_path):
+    if request.param == "memory":
+        return MemoryBackend({})
+    elif request.param == "cloudpickle":
+        return PickleFileBackend.with_cloudpickle(tmp_path / "cloudpickle")
+    elif request.param == "dill":
+        return PickleFileBackend.with_dill(tmp_path / "dill")
+    elif request.param == "pickle":
+        return PickleFileBackend.with_pickle(tmp_path / "pickle")
+    elif request.param == "h5":
+        return BagOfHoldingH5FileBackend(tmp_path / "h5")
+
 
 @pytest.fixture
 def clean_cache():

--- a/tests/unit/storage/test_storage.py
+++ b/tests/unit/storage/test_storage.py
@@ -5,71 +5,53 @@ import numpy as np
 from fleche.storage import SaveError
 from fleche.storage.sql import Sql
 from fleche.call import Call
-from fleche.digest import digest, Digest
-from fleche.storage.destructuring import DigestedIterable
+from fleche.digest import digest
 
 from tests.strategies import st_data, st_digested_calls
 
 
+# ------------------------
+# StorageBackend property tests
+# ------------------------
+
+
 @settings(deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(st_data)
-def test_storage(value_storage, value):
+@given(value=st_data)
+def test_backend_put_get_roundtrip(storage_backend, value):
+    key = digest(value)
     try:
-        key = value_storage.save(value)
+        returned_key = storage_backend.put(value, key)
     except SaveError:
-        return  # not everyone can save everyone and that's ok, too
-    loaded_value = value_storage.load(key)
+        return
+    assert returned_key == key
+    loaded = storage_backend.get(key)
     if isinstance(value, np.ndarray):
-        np.testing.assert_array_equal(loaded_value, value)
+        np.testing.assert_array_equal(loaded, value)
     else:
-        assert loaded_value == value
-
-
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(st_data)
-def test_storage_given_key(value_storage, value):
-    # make up a unique key by hashing hash
-    given_key = digest(str(digest(value)))
-    try:
-        key = value_storage.save(value, key=given_key)
-    except SaveError:
-        return  # not everyone can save everyone and that's ok, too
-    assert key == given_key, "When forcing a key, storage must return the same key"
-
-    loaded_value = value_storage.load(given_key)
-    if isinstance(value, np.ndarray):
-        np.testing.assert_array_equal(loaded_value, value)
-    else:
-        assert loaded_value == value, "value not available under given key"
-
-
-# ------------------------
-# CallStorage property tests
-# ------------------------
+        assert loaded == value
 
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(call=st_digested_calls)
-def test_callstorages_random_calls_roundtrip(call_storage, call):
+def test_backend_stores_call_objects(storage_backend, call):
+    key = call.to_lookup_key()
     try:
-        key = call_storage.save(call)
+        storage_backend.put(call, key)
     except SaveError:
-        # Some backends may not support serializing arbitrary dataclasses; skip in that case
         return
-    loaded = call_storage.load(key)
+    loaded = storage_backend.get(key)
     assert loaded == call
 
 
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(call=st_digested_calls)
-def test_callstorages_short_prefix_load(call_storage, call):
+@given(value=st_data)
+def test_backend_short_prefix_expand(storage_backend, value):
+    key = digest(value)
     try:
-        key = call_storage.save(call)
+        storage_backend.put(value, key)
     except SaveError:
         return
-    short = key[:8]
-    loaded = call_storage.load(short)
-    assert loaded == call
+    assert storage_backend.expand(key[:8]) == key
 
 
 def test_callstorages_evict(call_storage):


### PR DESCRIPTION
Replace the four @given tests that targeted ValueStorage/CallStorage save/load with three property tests that exercise the primitive StorageBackend put/get interface directly. A new storage_backend fixture provides the five concrete backends (MemoryBackend, PickleFileBackend ×3, BagOfHoldingH5FileBackend) without mixin stacking, keeping backend correctness separate from domain-level mixin logic.

Closes #282 (first step)

Generated with [Claude Code](https://claude.ai/code)