### PR TITLE
feat(state): proxy .fleche namespace on BoundWrapper

### DIFF
--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -1,7 +1,7 @@
 from contextlib import AbstractContextManager
 import contextvars
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import overload, Callable
 
@@ -127,6 +127,16 @@ def project(name):
     return tags(project=name)
 
 
+def _reconstruct_bound_wrapper(func, bound_cache, bound_meta):
+    """Module-level factory used by BoundWrapper.__reduce__ (contextvars.Context is not picklable)."""
+    def _setup():
+        _CACHE.set(bound_cache)
+        _METADATA.set(bound_meta)
+    ctx = contextvars.copy_context()
+    ctx.run(_setup)
+    return BoundWrapper(func, bound_cache, bound_meta, ctx)
+
+
 @dataclass(frozen=True, eq=True)
 class BoundWrapper:
     """Utility class that freezes global state for the cache and metadata config.
@@ -139,6 +149,7 @@ class BoundWrapper:
     func: Callable
     cache: caches.BaseCache
     meta: tuple[metadata.MetaData, ...]
+    ctx: contextvars.Context = field(compare=False, repr=False)
 
     @classmethod
     def bind(cls, func):
@@ -152,20 +163,23 @@ class BoundWrapper:
 
         Returns:
             :class:`.BoundWrapper`: instance with the bound cache and metadata state"""
-        return cls(func, _CACHE.get(), _METADATA.get())
+        return cls(func, _CACHE.get(), _METADATA.get(), contextvars.copy_context())
 
     @property
     def fleche(self):
         """Return a .fleche namespace whose helpers run in the bound cache/meta context."""
+        if not hasattr(self.func, 'fleche'):
+            raise AttributeError(
+                f"BoundWrapper.fleche requires a fleche-decorated function; "
+                f"{self.func!r} has no .fleche namespace"
+            )
         ns = self.func.fleche  # ty: ignore[unresolved-attribute]
-        return SimpleNamespace(**{
-            name: BoundWrapper(helper, self.cache, self.meta)
-            for name, helper in vars(ns).items()
-        })
+        def _bind_helpers():
+            return {name: BoundWrapper.bind(helper) for name, helper in vars(ns).items()}
+        return SimpleNamespace(**self.ctx.run(_bind_helpers))
 
     def __call__(self, *args, **kwargs):
-        def _call():
-            _CACHE.set(self.cache)
-            _METADATA.set(self.meta)
-            return self.func(*args, **kwargs)
-        return contextvars.copy_context().run(_call)
+        return self.ctx.run(self.func, *args, **kwargs)
+
+    def __reduce__(self):
+        return (_reconstruct_bound_wrapper, (self.func, self.cache, self.meta))

--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -125,6 +125,33 @@ def project(name):
     return tags(project=name)
 
 
+class _BoundFlecheNamespace:
+    """Wraps a .fleche SimpleNamespace so every helper activates the bound cache/meta state."""
+
+    __slots__ = ('_ns', '_cache', '_meta')
+
+    def __init__(self, ns, bound_cache, bound_meta):
+        self._ns = ns
+        self._cache = bound_cache
+        self._meta = bound_meta
+
+    def __getattr__(self, name):
+        helper = getattr(self._ns, name)
+        bound_cache = self._cache
+        bound_meta = self._meta
+
+        def _bound(*args, **kwargs):
+            token_cache = _CACHE.set(bound_cache)
+            token_meta = _METADATA.set(bound_meta)
+            try:
+                return helper(*args, **kwargs)
+            finally:
+                _METADATA.reset(token_meta)
+                _CACHE.reset(token_cache)
+
+        return _bound
+
+
 @dataclass(frozen=True, eq=True)
 class BoundWrapper:
     """Utility class that freezes global state for the cache and metadata config.
@@ -154,8 +181,8 @@ class BoundWrapper:
 
     @property
     def fleche(self):
-        """Proxy the ``.fleche`` helper namespace from the wrapped function."""
-        return self.func.fleche
+        """Return a .fleche namespace whose helpers activate the bound cache/meta state."""
+        return _BoundFlecheNamespace(self.func.fleche, self.cache, self.meta)
 
     def __call__(self, *args, **kwargs):
         token_cache = _CACHE.set(self.cache)

--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -1,6 +1,8 @@
 from contextlib import AbstractContextManager
+import contextvars
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import overload, Callable
 
 from . import caches, config, metadata
@@ -125,33 +127,6 @@ def project(name):
     return tags(project=name)
 
 
-class _BoundFlecheNamespace:
-    """Wraps a .fleche SimpleNamespace so every helper activates the bound cache/meta state."""
-
-    __slots__ = ('_ns', '_cache', '_meta')
-
-    def __init__(self, ns, bound_cache, bound_meta):
-        self._ns = ns
-        self._cache = bound_cache
-        self._meta = bound_meta
-
-    def __getattr__(self, name):
-        helper = getattr(self._ns, name)
-        bound_cache = self._cache
-        bound_meta = self._meta
-
-        def _bound(*args, **kwargs):
-            token_cache = _CACHE.set(bound_cache)
-            token_meta = _METADATA.set(bound_meta)
-            try:
-                return helper(*args, **kwargs)
-            finally:
-                _METADATA.reset(token_meta)
-                _CACHE.reset(token_cache)
-
-        return _bound
-
-
 @dataclass(frozen=True, eq=True)
 class BoundWrapper:
     """Utility class that freezes global state for the cache and metadata config.
@@ -181,14 +156,16 @@ class BoundWrapper:
 
     @property
     def fleche(self):
-        """Return a .fleche namespace whose helpers activate the bound cache/meta state."""
-        return _BoundFlecheNamespace(self.func.fleche, self.cache, self.meta)
+        """Return a .fleche namespace whose helpers run in the bound cache/meta context."""
+        ns = self.func.fleche  # ty: ignore[unresolved-attribute]
+        return SimpleNamespace(**{
+            name: BoundWrapper(helper, self.cache, self.meta)
+            for name, helper in vars(ns).items()
+        })
 
     def __call__(self, *args, **kwargs):
-        token_cache = _CACHE.set(self.cache)
-        token_meta = _METADATA.set(self.meta)
-        try:
+        def _call():
+            _CACHE.set(self.cache)
+            _METADATA.set(self.meta)
             return self.func(*args, **kwargs)
-        finally:
-            _METADATA.reset(token_meta)
-            _CACHE.reset(token_cache)
+        return contextvars.copy_context().run(_call)

--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -152,6 +152,11 @@ class BoundWrapper:
             :class:`.BoundWrapper`: instance with the bound cache and metadata state"""
         return cls(func, _CACHE.get(), _METADATA.get())
 
+    @property
+    def fleche(self):
+        """Proxy the ``.fleche`` helper namespace from the wrapped function."""
+        return self.func.fleche
+
     def __call__(self, *args, **kwargs):
         token_cache = _CACHE.set(self.cache)
         token_meta = _METADATA.set(self.meta)

--- a/tests/unit/fleche/test_bound_wrapper.py
+++ b/tests/unit/fleche/test_bound_wrapper.py
@@ -246,9 +246,10 @@ def test_bound_wrapper_pickle_nested_fleche_in_plain():
 # ---------------------------------------------------------------------------
 
 
-def test_bound_wrapper_proxies_fleche_namespace():
-    """bound.fleche should forward to the wrapped function's .fleche namespace."""
+def test_bound_wrapper_fleche_uses_bound_cache():
+    """bound.fleche helpers should activate the bound cache outside any cache context manager."""
     bound_cache = _make_cache()
+    outer_cache = _make_cache()
 
     @fleche
     def my_func(x):
@@ -256,11 +257,12 @@ def test_bound_wrapper_proxies_fleche_namespace():
 
     with cache(bound_cache):
         bound = fleche_state.BoundWrapper.bind(my_func)
-        bound(5)
+        bound(5)  # populate bound_cache
 
-    assert bound.fleche is my_func.fleche
+    # digest is cache-independent; result must match
+    assert bound.fleche.digest(5) == my_func.fleche.digest(5)
 
-    with cache(bound_cache):
-        assert bound.fleche.contains(5)
-        key = bound.fleche.digest(5)
-        assert key == my_func.fleche.digest(5)
+    # helpers activate the bound cache, not the outer cache
+    with cache(outer_cache):
+        assert bound.fleche.contains(5)       # bound_cache has the result
+        assert not my_func.contains(5)         # outer_cache is empty

--- a/tests/unit/fleche/test_bound_wrapper.py
+++ b/tests/unit/fleche/test_bound_wrapper.py
@@ -239,3 +239,28 @@ def test_bound_wrapper_pickle_nested_fleche_in_plain():
 
     with cache(restored.cache):
         assert _pickle_inner.contains(3)
+
+
+# ---------------------------------------------------------------------------
+# 4. .fleche namespace proxy
+# ---------------------------------------------------------------------------
+
+
+def test_bound_wrapper_proxies_fleche_namespace():
+    """bound.fleche should forward to the wrapped function's .fleche namespace."""
+    bound_cache = _make_cache()
+
+    @fleche
+    def my_func(x):
+        return x + 1
+
+    with cache(bound_cache):
+        bound = fleche_state.BoundWrapper.bind(my_func)
+        bound(5)
+
+    assert bound.fleche is my_func.fleche
+
+    with cache(bound_cache):
+        assert bound.fleche.contains(5)
+        key = bound.fleche.digest(5)
+        assert key == my_func.fleche.digest(5)

--- a/tests/unit/fleche/test_bound_wrapper.py
+++ b/tests/unit/fleche/test_bound_wrapper.py
@@ -266,3 +266,34 @@ def test_bound_wrapper_fleche_uses_bound_cache():
     with cache(outer_cache):
         assert bound.fleche.contains(5)       # bound_cache has the result
         assert not my_func.contains(5)         # outer_cache is empty
+
+
+def test_bound_wrapper_fleche_raises_for_plain_function():
+    """BoundWrapper.fleche raises AttributeError when func is not fleche-decorated."""
+    def plain(x):
+        return x
+
+    bound_cache = _make_cache()
+    with cache(bound_cache):
+        bound = fleche_state.BoundWrapper.bind(plain)
+
+    import pytest
+    with pytest.raises(AttributeError, match="fleche-decorated"):
+        _ = bound.fleche
+
+
+def test_bound_wrapper_fleche_helpers_have_no_fleche():
+    """Helpers exposed via bound.fleche should not recursively expose .fleche."""
+    bound_cache = _make_cache()
+
+    @fleche
+    def my_func(x):
+        return x + 1
+
+    with cache(bound_cache):
+        bound = fleche_state.BoundWrapper.bind(my_func)
+        bound(5)
+
+    import pytest
+    with pytest.raises(AttributeError):
+        _ = bound.fleche.contains.fleche


### PR DESCRIPTION
Add a fleche property to BoundWrapper that forwards to self.func.fleche, so bound.fleche.digest(...) etc. work without needing bound.func.fleche.

Closes #374