### PR TITLE
Add .bind() helper method on wrapped functions

### DIFF
--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from functools import wraps
+from functools import wraps, partial
 from inspect import signature
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, Iterable, TypeVar, Annotated, get_type_hints, get_origin, get_args
@@ -249,6 +249,14 @@ def make_rerun(func, wrapper):
     return _rerun_func
 
 
+def make_bind(wrapper):
+    """Build the `.bind` helper that creates a :class:`.BoundWrapper` with optionally pre-applied arguments."""
+    def _bind_func(*args, **kwargs):
+        target = partial(wrapper, *args, **kwargs) if (args or kwargs) else wrapper
+        return state.BoundWrapper.bind(target)
+    return _bind_func
+
+
 def make_wrapper(func, policy, meta, isolate, get_call):
     """Build the cached wrapper returned by :func:`fleche`."""
     @wraps(func)
@@ -357,6 +365,8 @@ def fleche(
     - .contains(*args, **kwargs): Check if result is in cache.
     - .query(*args, **kwargs): Return matching calls from the active cache.
     - .rerun(*args, **kwargs): Forces reevaluation recursively.
+    - .bind(*args, **kwargs): Create a :class:`.BoundWrapper` that freezes the current cache/metadata state.
+      Optionally pre-applies *args*/*kwargs* via :func:`functools.partial`.
     The original function is available via .__wrapped__.
 
     .. warning::
@@ -388,6 +398,7 @@ def fleche(
         contains_func = make_contains(func, digest_func)
         wrapper = make_wrapper(func, policy, meta, isolate, get_call)
         rerun_func = make_rerun(func, wrapper)
+        bind_func = make_bind(wrapper)
 
         wrapper.fleche = SimpleNamespace()
 
@@ -398,6 +409,8 @@ def fleche(
         _attach(wrapper, load_func, name="load", doc_prefix="Load result from cache for")
         _attach(wrapper, contains_func, name="contains", doc_prefix="Check if result is in cache for", ret=bool)
         _attach(wrapper, rerun_func, name="rerun", doc_prefix="Force reevaluation recursively for")
+        _attach(wrapper, bind_func, name="bind", doc_prefix="Create a BoundWrapper for",
+                ret=state.BoundWrapper)
         return wrapper
 
     if callable(_func):

--- a/tests/unit/fleche/test_bound_wrapper.py
+++ b/tests/unit/fleche/test_bound_wrapper.py
@@ -239,3 +239,106 @@ def test_bound_wrapper_pickle_nested_fleche_in_plain():
 
     with cache(restored.cache):
         assert _pickle_inner.contains(3)
+
+
+# ---------------------------------------------------------------------------
+# 4. .bind helper on wrapped functions
+# ---------------------------------------------------------------------------
+
+
+def test_bind_helper_no_args_returns_bound_wrapper():
+    """.bind() with no args returns a BoundWrapper bound to the current state."""
+    bound_cache = _make_cache()
+
+    @fleche
+    def my_func(x):
+        return x + 1
+
+    with cache(bound_cache):
+        bound = my_func.bind()
+
+    assert isinstance(bound, fleche_state.BoundWrapper)
+    assert bound.func is my_func
+
+
+def test_bind_helper_uses_bound_cache():
+    """.bind() captures the cache active at call time, not at invocation time."""
+    bound_cache = _make_cache()
+    outer_cache = _make_cache()
+
+    @fleche
+    def my_func(x):
+        return x * 3
+
+    with cache(bound_cache):
+        bound = my_func.bind()
+
+    with cache(outer_cache):
+        result = bound(4)
+
+    assert result == 12
+    with cache(bound_cache):
+        assert my_func.contains(4)
+    with cache(outer_cache):
+        assert not my_func.contains(4)
+
+
+def test_bind_helper_partial_args():
+    """.bind(x) pre-applies x so the returned BoundWrapper only needs remaining args."""
+    bound_cache = _make_cache()
+
+    @fleche
+    def add(a, b):
+        return a + b
+
+    with cache(bound_cache):
+        bound = my_func = add.bind(10)
+
+    result = bound(5)
+    assert result == 15
+
+
+def test_bind_helper_partial_kwargs():
+    """.bind(b=2) pre-applies a keyword argument."""
+    bound_cache = _make_cache()
+
+    @fleche
+    def add(a, b):
+        return a + b
+
+    with cache(bound_cache):
+        bound = add.bind(b=2)
+
+    result = bound(8)
+    assert result == 10
+
+
+def test_bind_helper_partial_stores_in_bound_cache():
+    """Partial .bind() result stores entries under the bound cache, not the active one."""
+    bound_cache = _make_cache()
+    outer_cache = _make_cache()
+
+    @fleche
+    def add(a, b):
+        return a + b
+
+    with cache(bound_cache):
+        bound = add.bind(a=1)
+
+    with cache(outer_cache):
+        result = bound(b=9)
+
+    assert result == 10
+    with cache(bound_cache):
+        assert add.contains(1, 9)
+    with cache(outer_cache):
+        assert not add.contains(1, 9)
+
+
+def test_bind_helper_accessible_via_fleche_namespace():
+    """.fleche.bind is the same object as .bind."""
+    @fleche
+    def my_func(x):
+        return x
+
+    assert my_func.bind is my_func.fleche.bind

--- a/tests/unit/fleche/test_bound_wrapper.py
+++ b/tests/unit/fleche/test_bound_wrapper.py
@@ -247,7 +247,7 @@ def test_bound_wrapper_pickle_nested_fleche_in_plain():
 
 
 def test_bind_helper_no_args_returns_bound_wrapper():
-    """.bind() with no args returns a BoundWrapper bound to the current state."""
+    """.fleche.bind() with no args returns a BoundWrapper bound to the current state."""
     bound_cache = _make_cache()
 
     @fleche
@@ -255,14 +255,14 @@ def test_bind_helper_no_args_returns_bound_wrapper():
         return x + 1
 
     with cache(bound_cache):
-        bound = my_func.bind()
+        bound = my_func.fleche.bind()
 
     assert isinstance(bound, fleche_state.BoundWrapper)
     assert bound.func is my_func
 
 
 def test_bind_helper_uses_bound_cache():
-    """.bind() captures the cache active at call time, not at invocation time."""
+    """.fleche.bind() captures the cache active at call time, not at invocation time."""
     bound_cache = _make_cache()
     outer_cache = _make_cache()
 
@@ -271,7 +271,7 @@ def test_bind_helper_uses_bound_cache():
         return x * 3
 
     with cache(bound_cache):
-        bound = my_func.bind()
+        bound = my_func.fleche.bind()
 
     with cache(outer_cache):
         result = bound(4)
@@ -284,7 +284,7 @@ def test_bind_helper_uses_bound_cache():
 
 
 def test_bind_helper_partial_args():
-    """.bind(x) pre-applies x so the returned BoundWrapper only needs remaining args."""
+    """.fleche.bind(x) pre-applies x so the returned BoundWrapper only needs remaining args."""
     bound_cache = _make_cache()
 
     @fleche
@@ -292,14 +292,14 @@ def test_bind_helper_partial_args():
         return a + b
 
     with cache(bound_cache):
-        bound = my_func = add.bind(10)
+        bound = add.fleche.bind(10)
 
     result = bound(5)
     assert result == 15
 
 
 def test_bind_helper_partial_kwargs():
-    """.bind(b=2) pre-applies a keyword argument."""
+    """.fleche.bind(b=2) pre-applies a keyword argument."""
     bound_cache = _make_cache()
 
     @fleche
@@ -307,14 +307,14 @@ def test_bind_helper_partial_kwargs():
         return a + b
 
     with cache(bound_cache):
-        bound = add.bind(b=2)
+        bound = add.fleche.bind(b=2)
 
     result = bound(8)
     assert result == 10
 
 
 def test_bind_helper_partial_stores_in_bound_cache():
-    """Partial .bind() result stores entries under the bound cache, not the active one."""
+    """Partial .fleche.bind() result stores entries under the bound cache, not the active one."""
     bound_cache = _make_cache()
     outer_cache = _make_cache()
 
@@ -323,7 +323,7 @@ def test_bind_helper_partial_stores_in_bound_cache():
         return a + b
 
     with cache(bound_cache):
-        bound = add.bind(a=1)
+        bound = add.fleche.bind(a=1)
 
     with cache(outer_cache):
         result = bound(b=9)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `.bind(*args, **kwargs)` helper to every `@fleche`-decorated function (also accessible via `.fleche.bind`)
- With no arguments, returns a `BoundWrapper` that freezes the current cache and metadata state — equivalent to calling `BoundWrapper.bind(func)` directly but ergonomically available on the wrapper
- With positional/keyword arguments, pre-applies them via `functools.partial` before binding, enabling partial application with frozen state

## Usage

```python
@fleche
def add(a, b):
    return a + b

# Bind current cache/meta state
with cache(my_cache):
    bound = add.bind()          # BoundWrapper(func=add, cache=my_cache, ...)

# Partial application + bind
with cache(my_cache):
    add_one = add.bind(a=1)     # pre-applies a=1

result = add_one(b=9)           # calls add(1, 9), stored in my_cache
```

## Test plan

- [ ] `test_bind_helper_no_args_returns_bound_wrapper` — returns `BoundWrapper` pointing at the wrapper
- [ ] `test_bind_helper_uses_bound_cache` — cache at bind time is used, not the active cache at invocation time
- [ ] `test_bind_helper_partial_args` — positional partial application works
- [ ] `test_bind_helper_partial_kwargs` — keyword partial application works
- [ ] `test_bind_helper_partial_stores_in_bound_cache` — cache isolation holds with partial args
- [ ] `test_bind_helper_accessible_via_fleche_namespace` — `.fleche.bind is .bind`

https://claude.ai/code/session_015BnHsfMLicmVDSi6sBo1KA
EOF
)