### PR TITLE
Add wrap_executor to automatically bind fleche functions at submission

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ Welcome to the **Fleche** library documentation.
    notebooks/StorageBackends
    notebooks/SecureStorage
    notebooks/CacheStack
+   notebooks/ConcurrentExecution
 
 .. toctree::
    :maxdepth: 2

--- a/docs/notebooks/ConcurrentExecution.ipynb
+++ b/docs/notebooks/ConcurrentExecution.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/ConcurrentExecution.ipynb

--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -5,6 +5,21 @@ Fleche-decorated functions work with Python's ``concurrent.futures`` executors
 and other process-/thread-based parallelism libraries.  This page explains the
 recommended patterns for each executor type.
 
+Three complementary APIs cover the common cases:
+
+- :class:`~fleche.BoundWrapper` — freeze the active cache and metadata into a
+  picklable callable that a worker can invoke without any further setup.  Use
+  when you own the submission site and want explicit control.
+- **Future pass-through** — a fleche-decorated function that internally
+  returns a :class:`~concurrent.futures.Future` is cached automatically when
+  the future completes.  Use when the decorated function *is* the one that
+  submits work.
+- :func:`~fleche.wrap_executor` — a one-line wrapper around an executor
+  instance that transparently binds fleche-decorated functions on ``submit``
+  **and** short-circuits cache hits without ever touching the executor.  Use
+  when you want the most compact call site, or to avoid submit/serialise
+  overhead on cached inputs.
+
 .. contents:: On this page
    :local:
    :depth: 2
@@ -188,33 +203,112 @@ automatically caches the result once the future completes:
 On the next call, ``compute(4)`` returns the cached value directly (no
 ``Future`` is created).
 
-When to prefer each pattern
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. list-table::
-   :header-rows: 1
-   :widths: 45 55
-
-   * - Future pass-through
-     - :class:`~fleche.BoundWrapper`
-   * - The decorated function owns its own executor and naturally returns a
-       ``Future``
-     - You submit a fleche-decorated function to an *external* executor
-   * - No need to change the call site — callers already handle ``Future``
-       objects
-     - You want to fan out many calls to the same decorated function across a
-       pool
-   * - Works with ``ThreadPoolExecutor``; for ``ProcessPoolExecutor`` the
-       cache context must still be available in the worker (use file/SQL
-       storage)
-     - Works with both thread- and process-based executors; the cache is
-       embedded in the callable
-
 .. note::
 
    When a decorated function with future pass-through is called and a cached
    value already exists, the function is **not** invoked and no ``Future`` is
    created — the cached result is returned directly.
+
+``wrap_executor`` — Transparent Submit Interception
+---------------------------------------------------
+
+:func:`fleche.wrap_executor` monkey-patches ``executor.submit`` on an existing
+executor **instance** (no subclassing — callers pass us instances of
+third-party executors) so that fleche-decorated functions are handled
+automatically:
+
+- Non-fleche callables pass straight through to the original ``submit``.
+- Cache hits are served from an already-completed
+  :class:`~concurrent.futures.Future` without ever touching the executor,
+  avoiding submit/serialise overhead on cached inputs.
+- Cache misses are bound via :meth:`~fleche.BoundWrapper.bind` so the parent's
+  cache and metadata travel with the call into the worker.
+
+.. code-block:: python
+
+   import concurrent.futures
+   import fleche
+
+   @fleche.fleche
+   def heavy_computation(x):
+       return x ** 3
+
+   with fleche.cache(file_cache):
+       with concurrent.futures.ProcessPoolExecutor() as executor:
+           fleche.wrap_executor(executor)             # patch once
+
+           # Submit exactly as you would a plain function.
+           futures = [executor.submit(heavy_computation, i) for i in range(8)]
+           results = [f.result() for f in futures]
+
+       # A second round with the same inputs never enters the worker pool:
+       with concurrent.futures.ProcessPoolExecutor() as executor:
+           fleche.wrap_executor(executor)
+           fut = executor.submit(heavy_computation, 3)
+           assert fut.done()                          # already-completed future
+           assert fut.result() == 27
+
+Executor-specific keyword arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some executors (e.g. `executorlib
+<https://executorlib.readthedocs.io/>`_'s ``resource_dict``, dask's
+``resources=``/``key=``) define their own keyword-only parameters on
+``submit``.  :func:`~fleche.wrap_executor` introspects the signature with
+:func:`inspect.signature` and splits those off automatically — they are
+forwarded to ``submit`` while the rest are bound as part of the callable's
+payload:
+
+.. code-block:: python
+
+   from executorlib import SingleNodeExecutor
+
+   with fleche.cache(file_cache):
+       with SingleNodeExecutor() as executor:
+           fleche.wrap_executor(executor)
+           future = executor.submit(
+               heavy_computation, 5,
+               resource_dict={"cores": 4},   # goes to SingleNodeExecutor.submit
+           )
+           assert future.result() == 125
+
+.. note::
+
+   :func:`~fleche.wrap_executor` mutates the instance it is given; it does
+   not return a proxy.  The call is idempotent: wrapping an already-wrapped
+   executor a second time is a no-op.
+
+When to prefer each pattern
+---------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * -
+     - :class:`~fleche.BoundWrapper`
+     - Future pass-through
+     - :func:`~fleche.wrap_executor`
+   * - Who owns the executor?
+     - Caller
+     - The decorated function
+     - Caller
+   * - Call-site change
+     - Wrap callable: ``executor.submit(BoundWrapper.bind(func), ...)``
+     - None (decorated function returns a ``Future``)
+     - Patch executor once, then ``executor.submit(func, ...)``
+   * - Cache hit behaviour
+     - Always submits; worker does the cache lookup
+     - Returns cached result directly (no ``Future`` created)
+     - Returns an already-completed ``Future`` without contacting the worker
+   * - Works across processes
+     - Yes, with file/SQL storage
+     - Yes, if the wrapping function owns the executor
+     - Yes, with file/SQL storage
+   * - Best for
+     - Fine-grained control; sharing a bound callable across modules
+     - Wrapping expensive async-style code inside a decorated helper
+     - Transparently caching existing executor-based pipelines
 
 The ``isolate`` Flag
 --------------------
@@ -245,15 +339,16 @@ Quick Reference
    * - ``ThreadPoolExecutor``
      - Yes
      - No (manual)
-     - ``BoundWrapper.bind(func)`` or future pass-through
+     - :func:`~fleche.wrap_executor` (simplest), or ``BoundWrapper.bind(func)``,
+       or future pass-through
    * - ``ProcessPoolExecutor``
      - Yes
      - No (separate process)
-     - File/SQL storage + ``BoundWrapper``
+     - File/SQL storage + :func:`~fleche.wrap_executor` (or ``BoundWrapper``)
    * - ``executorlib.SingleNodeExecutor``
      - Yes
      - No (separate process)
-     - File/SQL storage + ``BoundWrapper``
+     - File/SQL storage + :func:`~fleche.wrap_executor` (or ``BoundWrapper``)
    * - Function returns ``Future`` directly
      - Yes
      - Yes (same thread/context)

--- a/notebooks/ConcurrentExecution.ipynb
+++ b/notebooks/ConcurrentExecution.ipynb
@@ -2,76 +2,389 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "c5cac4f4",
    "metadata": {},
-   "source": "# Concurrent Execution with Fleche\n\nThis notebook shows how to use `@fleche`-decorated functions with Python's three executor types.\n\n`BoundWrapper.bind(func)` is the recommended pattern for sharing cache state across workers: it captures the active cache and metadata at bind time and restores them on every subsequent call — even in subprocesses — without requiring a hand-written wrapper function.\n\n| Executor | Required storage | Recommended pattern |\n|---|---|---|\n| `ThreadPoolExecutor` | Any (Memory or file) | `BoundWrapper.bind(func)` |\n| `ProcessPoolExecutor` | **Persistent** (file / SQL) | `BoundWrapper.bind(func)` |\n| `SingleNodeExecutor` (executorlib) | **Persistent** (file / SQL) | `BoundWrapper.bind(func)` |"
+   "source": [
+    "# Concurrent Execution with Fleche\n",
+    "\n",
+    "This notebook shows how to use `@fleche`-decorated functions with Python's three executor types using **three complementary APIs**:\n",
+    "\n",
+    "| API | What it does | When to use |\n",
+    "|-----|--------------|-------------|\n",
+    "| `BoundWrapper.bind(func)` | Freezes the current cache/metadata into a picklable callable | You want explicit control; you pass the bound callable around |\n",
+    "| **Future pass-through** | A decorated function returns a `Future`; fleche caches on completion | The decorated function *is* the one that submits work |\n",
+    "| `wrap_executor(executor)` | Monkey-patches `submit`: binds on miss, short-circuits on hit | Simplest call site; avoids submit/serialise on cached inputs |\n",
+    "\n",
+    "| Executor | Required storage | Works with |\n",
+    "|---|---|---|\n",
+    "| `ThreadPoolExecutor` | Any (Memory or file) | All three |\n",
+    "| `ProcessPoolExecutor` | **Persistent** (file / SQL) | `BoundWrapper`, `wrap_executor` |\n",
+    "| `SingleNodeExecutor` (executorlib) | **Persistent** (file / SQL) | `BoundWrapper`, `wrap_executor` |"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "id": "3157c6b5",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
-   "source": "import time\nimport tempfile\nimport os\nfrom concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor\n\nfrom fleche import fleche, cache, BoundWrapper\nfrom fleche.caches import Cache\nfrom fleche.storage.memory import ValueMemory, CallMemory\nfrom fleche.storage.pickle_file import ValuePickleFile, CallPickleFile"
+   "source": [
+    "import tempfile\n",
+    "import os\n",
+    "from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, Future\n",
+    "\n",
+    "from fleche import fleche, cache, BoundWrapper, wrap_executor\n",
+    "from fleche.caches import Cache\n",
+    "from fleche.storage.memory import ValueMemory, CallMemory\n",
+    "from fleche.storage.pickle_file import ValuePickleFile, CallPickleFile"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5d911614",
    "metadata": {},
-   "source": "## 1. ThreadPoolExecutor\n\n`BoundWrapper.bind(func)` captures the active cache at bind time and restores it on every call — including inside worker threads. Use it directly inside a `with cache(...):` block to ensure all submitted tasks write to the same store:"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "@fleche\ndef add(x, y):\n    return x + y"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": "my_cache = Cache(ValueMemory({}), CallMemory({}))\n\nwith cache(my_cache):\n    with ThreadPoolExecutor(max_workers=2) as pool:\n        futures = [pool.submit(BoundWrapper.bind(add), x, x + 1) for x in range(4)]\n        results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                          # [1, 3, 5, 7]\nprint(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True"
+   "source": [
+    "## 1. `BoundWrapper.bind` \u2014 explicit state capture\n",
+    "\n",
+    "`BoundWrapper.bind(func)` captures the active cache and metadata at bind time and restores them on every call, including inside worker threads and processes.  The returned object is a regular picklable callable \u2014 you can pass it to any executor, store it in a dict, or hand it to another module."
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e1051643",
    "metadata": {},
-   "source": "### Passing a bound function around\n\nBecause the bound callable is a regular Python object, you can bind it once and pass it to other modules, helper functions, or executor pools without re-specifying the cache. The captured state travels with the callable:"
+   "source": [
+    "### 1a. ThreadPoolExecutor"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "id": "eba0bf4d",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
-   "source": "my_cache = Cache(ValueMemory({}), CallMemory({}))\n\nwith cache(my_cache):\n    bound_add = BoundWrapper.bind(add)   # bind once, reuse anywhere\n\n# bound_add carries my_cache — the cache context manager is no longer needed at the call site\nwith ThreadPoolExecutor(max_workers=2) as pool:\n    futures = [pool.submit(bound_add, x, x + 1) for x in range(4)]\n    results = [f.result() for f in futures]\n\nprint(\"Results:\", results)                          # [1, 3, 5, 7]\nprint(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))  # True"
+   "source": [
+    "@fleche\n",
+    "def add(x, y):\n",
+    "    return x + y\n",
+    "\n",
+    "\n",
+    "my_cache = Cache(ValueMemory({}), CallMemory({}))\n",
+    "\n",
+    "with cache(my_cache):\n",
+    "    with ThreadPoolExecutor(max_workers=2) as pool:\n",
+    "        futures = [pool.submit(BoundWrapper.bind(add), x, x + 1) for x in range(4)]\n",
+    "        results = [f.result() for f in futures]\n",
+    "\n",
+    "print(\"Results:\", results)                                    # [1, 3, 5, 7]\n",
+    "print(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))   # True"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "394dbb85",
    "metadata": {},
-   "source": "---\n## 2. ProcessPoolExecutor\n\nWorker processes run in separate Python interpreters — an in-memory cache set in the parent is **not visible** inside workers. Use a **file-** or **SQL-backed** backend so that results written by workers are visible to the parent process."
+   "source": [
+    "### 1b. Passing a bound callable around\n",
+    "\n",
+    "Because the bound callable is a regular Python object, you can bind it once and pass it to other modules, helper functions, or executor pools without re-specifying the cache.  The captured state travels with the callable:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "id": "4a88effb",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
-   "source": "@fleche\ndef expensive(x):\n    return x ** 3\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    shared_cache = Cache(\n        ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n        CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n    )\n\n    with cache(shared_cache):\n        with ProcessPoolExecutor(max_workers=2) as pool:\n            results = list(pool.map(BoundWrapper.bind(expensive), range(5)))\n\n    print(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\n    print(\"Cached:\", shared_cache.contains(expensive.digest(3)))   # True"
+   "source": [
+    "my_cache = Cache(ValueMemory({}), CallMemory({}))\n",
+    "\n",
+    "with cache(my_cache):\n",
+    "    bound_add = BoundWrapper.bind(add)   # bind once, reuse anywhere\n",
+    "\n",
+    "# bound_add carries my_cache \u2014 the cache context manager is no longer needed at the call site\n",
+    "with ThreadPoolExecutor(max_workers=2) as pool:\n",
+    "    futures = [pool.submit(bound_add, x, x + 1) for x in range(4)]\n",
+    "    results = [f.result() for f in futures]\n",
+    "\n",
+    "print(\"Results:\", results)                                    # [1, 3, 5, 7]\n",
+    "print(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))   # True"
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "ky1m64wquxm",
+   "id": "8e339bd3",
    "metadata": {},
-   "source": "---\n## 3. executorlib.SingleNodeExecutor\n\n[executorlib](https://github.com/pyiron/executorlib) is a third-party library for submitting tasks to HPC schedulers and local process pools. Its `SingleNodeExecutor` uses *process-based* workers with the same isolation semantics as `ProcessPoolExecutor`.\n\n> **Note:** `executorlib` is an optional dependency. Install it with `pip install executorlib`.\n\nUse a **file-backed** cache with `BoundWrapper.bind` so that results written by workers are visible to the parent process:"
+   "source": [
+    "### 1c. ProcessPoolExecutor\n",
+    "\n",
+    "Worker processes run in separate Python interpreters \u2014 an in-memory cache set in the parent is **not visible** inside workers.  Use a **file-** or **SQL-backed** backend so that results written by workers are visible to the parent process."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "id": "0375884b",
    "metadata": {},
+   "execution_count": null,
    "outputs": [],
-   "source": "from executorlib import SingleNodeExecutor\n\n@fleche\ndef cube_sne(x):\n    return x ** 3\n\nwith tempfile.TemporaryDirectory() as tmpdir:\n    shared_cache = Cache(\n        ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n        CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n    )\n\n    with cache(shared_cache):\n        with SingleNodeExecutor() as executor:\n            futures = [executor.submit(BoundWrapper.bind(cube_sne), x) for x in range(5)]\n            results = [f.result() for f in futures]\n\n    print(\"Results:\", results)                                          # [0, 1, 8, 27, 64]\n    print(\"In shared_cache:\", shared_cache.contains(cube_sne.digest(3)))  # True"
+   "source": [
+    "@fleche\n",
+    "def expensive(x):\n",
+    "    return x ** 3\n",
+    "\n",
+    "\n",
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    shared_cache = Cache(\n",
+    "        ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n",
+    "        CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n",
+    "    )\n",
+    "\n",
+    "    with cache(shared_cache):\n",
+    "        with ProcessPoolExecutor(max_workers=2) as pool:\n",
+    "            results = list(pool.map(BoundWrapper.bind(expensive), range(5)))\n",
+    "\n",
+    "    print(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\n",
+    "    print(\"Cached:\", shared_cache.contains(expensive.digest(3)))    # True"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6a8ac14b",
    "metadata": {},
-   "source": "### Summary\n\n```\nThreadPoolExecutor\n  with cache(...): with ThreadPoolExecutor() as pool:\n    pool.submit(BoundWrapper.bind(func), ...)     ✅ workers share the same cache\n\nProcessPoolExecutor / executorlib.SingleNodeExecutor\n  In-memory cache                               ❌ not visible in worker processes\n  File/SQL cache + BoundWrapper.bind(func)      ✅ worker results visible to parent\n```\n\n**Storage reference**\n\n| Backend | Cross-process sharing |\n|---|---|\n| `Memory` | ❌ Ephemeral — process-local only |\n| `PickleFile` | ✅ Persistent — shared via filesystem |\n| `Sql` | ✅ Persistent — shared via database |\n| `BagOfHolding` | ✅ Persistent — shared via HDF5 file |"
+   "source": [
+    "### 1d. executorlib.SingleNodeExecutor\n",
+    "\n",
+    "[executorlib](https://github.com/pyiron/executorlib) provides executors that follow the same `concurrent.futures` interface but manage HPC resources.  Its `SingleNodeExecutor` uses process-based workers with the same isolation semantics as `ProcessPoolExecutor`, so the same file-backed cache pattern applies.\n",
+    "\n",
+    "> **Note:** `executorlib` is an optional dependency.  Install it with `pip install executorlib`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f28fd4ad",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from executorlib import SingleNodeExecutor\n",
+    "\n",
+    "    @fleche\n",
+    "    def cube_sne(x):\n",
+    "        return x ** 3\n",
+    "\n",
+    "    with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "        shared_cache = Cache(\n",
+    "            ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n",
+    "            CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n",
+    "        )\n",
+    "\n",
+    "        with cache(shared_cache):\n",
+    "            with SingleNodeExecutor() as executor:\n",
+    "                futures = [executor.submit(BoundWrapper.bind(cube_sne), x) for x in range(5)]\n",
+    "                results = [f.result() for f in futures]\n",
+    "\n",
+    "        print(\"Results:\", results)                                              # [0, 1, 8, 27, 64]\n",
+    "        print(\"In shared_cache:\", shared_cache.contains(cube_sne.digest(3)))    # True\n",
+    "except ImportError:\n",
+    "    print(\"executorlib not installed; skipping SingleNodeExecutor example.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebb1f3f8",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Future pass-through \u2014 cache async-style return values\n",
+    "\n",
+    "A fleche-decorated function can return a `concurrent.futures.Future` directly.  Fleche detects this, passes the future through to the caller unchanged, and **caches the result once the future completes** via a done-callback.\n",
+    "\n",
+    "This is the right pattern when the decorated function *is* the one that submits work: its caller can still `.result()` the future, and a second call with the same arguments skips the executor entirely and returns the cached value synchronously."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0b6f9de2",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "_thread_pool = ThreadPoolExecutor(max_workers=2)\n",
+    "\n",
+    "\n",
+    "@fleche\n",
+    "def square_async(x):\n",
+    "    \"\"\"Submits work and returns a Future; fleche caches on completion.\"\"\"\n",
+    "    return _thread_pool.submit(lambda: x ** 2)\n",
+    "\n",
+    "\n",
+    "my_cache = Cache(ValueMemory({}), CallMemory({}))\n",
+    "\n",
+    "with cache(my_cache):\n",
+    "    fut = square_async(4)\n",
+    "    print(\"First call returns a Future:\", isinstance(fut, Future))     # True\n",
+    "    print(\"Result:\", fut.result())                                      # 16\n",
+    "    print(\"Cached:\", my_cache.contains(square_async.digest(4)))         # True\n",
+    "\n",
+    "    # Second call: no executor submission, cached value returned directly.\n",
+    "    result = square_async(4)\n",
+    "    print(\"Second call is the cached value, not a Future:\", result)    # 16"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64942686",
+   "metadata": {},
+   "source": [
+    "When a cached value already exists, the decorated function is **not** invoked and **no** Future is created \u2014 you simply get the cached result back.  If you need the result to always behave like a Future at the call site, wrap it with an already-completed Future at that point, or use `wrap_executor` below instead."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77a5d329",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. `wrap_executor` \u2014 transparent submit interception\n",
+    "\n",
+    "`fleche.wrap_executor(executor)` monkey-patches `executor.submit` on an existing instance so that fleche-decorated functions are handled automatically.  It does three things per `submit`:\n",
+    "\n",
+    "1. **Non-fleche callables** pass straight through to the original `submit`.\n",
+    "2. **Cache hits** return an already-completed `Future` \u2014 the executor is never touched, saving submit/serialise overhead.\n",
+    "3. **Cache misses** are bound via `BoundWrapper.bind(...)` so the parent's cache and metadata travel with the call into the worker.\n",
+    "\n",
+    "No subclassing, no proxy \u2014 it replaces the `submit` attribute on the instance and returns the same instance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71e759d4",
+   "metadata": {},
+   "source": [
+    "### 3a. Thread-pool: cache hits skip the executor\n",
+    "\n",
+    "With `wrap_executor` in place, repeat submissions with the same arguments never enter the executor.  The second future is already done before we ask for its result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "fb5528cc",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "@fleche\n",
+    "def triple(x):\n",
+    "    return x * 3\n",
+    "\n",
+    "\n",
+    "my_cache = Cache(ValueMemory({}), CallMemory({}))\n",
+    "\n",
+    "with cache(my_cache):\n",
+    "    # First pass: cache is cold, work runs in workers.\n",
+    "    with ThreadPoolExecutor(max_workers=2) as pool:\n",
+    "        wrap_executor(pool)\n",
+    "        futures = [pool.submit(triple, x) for x in range(4)]\n",
+    "        results = [f.result() for f in futures]\n",
+    "\n",
+    "    print(\"First-pass results:\", results)                              # [0, 3, 6, 9]\n",
+    "\n",
+    "    # Second pass: every submission is already cached.\n",
+    "    with ThreadPoolExecutor(max_workers=2) as pool:\n",
+    "        wrap_executor(pool)\n",
+    "        futures = [pool.submit(triple, x) for x in range(4)]\n",
+    "        print(\"All already done?\", all(f.done() for f in futures))    # True\n",
+    "        print(\"Cached results:\", [f.result() for f in futures])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccbf01e0",
+   "metadata": {},
+   "source": [
+    "### 3b. Process pool with file-backed cache\n",
+    "\n",
+    "`wrap_executor` composes with the file-backed cache pattern, so users can submit fleche-decorated functions directly without needing to remember `BoundWrapper.bind` at every call site."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "9d4292dc",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    shared_cache = Cache(\n",
+    "        ValuePickleFile.with_pickle(root=os.path.join(tmpdir, \"values\")),\n",
+    "        CallPickleFile.with_pickle(root=os.path.join(tmpdir, \"calls\")),\n",
+    "    )\n",
+    "\n",
+    "    with cache(shared_cache):\n",
+    "        with ProcessPoolExecutor(max_workers=2) as pool:\n",
+    "            wrap_executor(pool)\n",
+    "            futures = [pool.submit(expensive, i) for i in range(5)]\n",
+    "            results = [f.result() for f in futures]\n",
+    "\n",
+    "    print(\"Results:\", results)                                         # [0, 1, 8, 27, 64]\n",
+    "    print(\"Cached:\", shared_cache.contains(expensive.digest(3)))       # True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "045d8559",
+   "metadata": {},
+   "source": [
+    "### 3c. Executor-specific kwargs are split automatically\n",
+    "\n",
+    "Some executors (e.g. executorlib's `resource_dict`, dask's `resources=`) declare their own keyword-only parameters on `submit`.  `wrap_executor` inspects the signature with `inspect.signature` and forwards those to `submit` while binding the rest into the function payload:\n",
+    "\n",
+    "```python\n",
+    "with cache(shared_cache):\n",
+    "    with SingleNodeExecutor() as executor:\n",
+    "        wrap_executor(executor)\n",
+    "        future = executor.submit(\n",
+    "            expensive, 5,\n",
+    "            resource_dict={\"cores\": 4},   # goes to SingleNodeExecutor.submit\n",
+    "        )\n",
+    "        future.result()                    # goes to expensive\n",
+    "```\n",
+    "\n",
+    "Plain stdlib executors (`ThreadPoolExecutor`, `ProcessPoolExecutor`) have no keyword-only parameters on `submit`, so everything is forwarded to the function as expected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d76b646",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Summary\n",
+    "\n",
+    "```\n",
+    "BoundWrapper.bind(func)                    \u2705 explicit; pass bound callable anywhere\n",
+    "    with cache(...): pool.submit(BoundWrapper.bind(func), ...)\n",
+    "\n",
+    "Future pass-through                        \u2705 cache async-style return values\n",
+    "    @fleche\n",
+    "    def f(x): return pool.submit(...)\n",
+    "\n",
+    "wrap_executor(pool)                        \u2705 transparent; cache hits never submit\n",
+    "    with cache(...):\n",
+    "        wrap_executor(pool)\n",
+    "        pool.submit(f, x)                   \u2190 ordinary submit\n",
+    "```\n",
+    "\n",
+    "**Storage reference**\n",
+    "\n",
+    "| Backend | Cross-process sharing |\n",
+    "|---|---|\n",
+    "| `Memory` | \u274c Ephemeral \u2014 process-local only |\n",
+    "| `PickleFile` | \u2705 Persistent \u2014 shared via filesystem |\n",
+    "| `Sql` | \u2705 Persistent \u2014 shared via database |\n",
+    "| `BagOfHolding` | \u2705 Persistent \u2014 shared via HDF5 file |"
+   ]
   }
  ],
  "metadata": {

--- a/src/fleche/__init__.py
+++ b/src/fleche/__init__.py
@@ -14,6 +14,7 @@ from .state import (
         BoundWrapper,
 )
 from .wrapper import fleche, Ignored, Required
+from .executor import wrap_executor
 
 
 def D(value) -> digest.Digest:
@@ -54,4 +55,5 @@ __all__ = [
         "Ignored",
         "Required",
         "D",
+        "wrap_executor",
 ]

--- a/src/fleche/executor.py
+++ b/src/fleche/executor.py
@@ -1,0 +1,92 @@
+"""Executor wrapper that intercepts ``submit`` for fleche-decorated functions.
+
+Motivation: users passing a :func:`fleche.fleche`-decorated function to
+``executor.submit(...)`` have to remember to call :meth:`.BoundWrapper.bind`
+themselves to carry the active cache/metadata state into the worker.  They also
+pay the submit/serialisation cost even when the result is already cached.
+
+:func:`wrap_executor` patches the ``submit`` method of an executor *instance*
+(we cannot subclass, since callers pass us instances of third-party executors)
+so that:
+
+* non-fleche callables are forwarded unchanged,
+* fleche callables whose result is already cached are returned via an
+  already-completed :class:`~concurrent.futures.Future` without touching the
+  executor, and
+* otherwise the call is bound via :meth:`.BoundWrapper.bind` and submitted to
+  the original ``submit``.
+
+Executors that declare their own keyword-only parameters on ``submit``
+(e.g. ``resources=`` or ``resource_dict=``) have those split off from the
+caller's ``**kwargs`` and forwarded to the underlying ``submit`` while the
+remaining keyword arguments are bound as part of the function payload.
+"""
+
+from concurrent.futures import Future
+from inspect import signature, Parameter
+from types import SimpleNamespace
+
+
+__all__ = ["wrap_executor"]
+
+
+def _is_fleche_function(func) -> bool:
+    return isinstance(getattr(func, "fleche", None), SimpleNamespace)
+
+
+def _split_submit_kwargs(submit_method, kwargs):
+    """Partition ``kwargs`` into (executor-reserved, function-payload).
+
+    Any keyword-only parameter declared on ``submit_method``'s signature is
+    reserved for the executor; everything else (including arguments matched by
+    a ``**kwargs`` catch-all) is forwarded to the callable.
+    ``concurrent.futures.Executor.submit`` has no keyword-only parameters, so
+    for stdlib executors this is a pure pass-through.
+    """
+    try:
+        sig = signature(submit_method)
+    except (TypeError, ValueError):
+        return {}, dict(kwargs)
+    submit_only = {
+        name for name, p in sig.parameters.items()
+        if p.kind is Parameter.KEYWORD_ONLY
+    }
+    for_submit, for_func = {}, {}
+    for k, v in kwargs.items():
+        if k in submit_only:
+            for_submit[k] = v
+        else:
+            for_func[k] = v
+    return for_submit, for_func
+
+
+def wrap_executor(executor):
+    """Monkey-patch ``executor.submit`` to intercept fleche-wrapped functions.
+
+    Args:
+        executor: any object with a ``submit(func, *args, **kwargs)`` method
+            (e.g. :class:`concurrent.futures.Executor` subclass instances).
+
+    Returns:
+        The same ``executor`` instance, with a replaced ``submit`` attribute.
+    """
+    original_submit = executor.submit
+
+    def submit(func, *args, **kwargs):
+        if not _is_fleche_function(func):
+            return original_submit(func, *args, **kwargs)
+
+        submit_kwargs, func_kwargs = _split_submit_kwargs(
+            original_submit, kwargs
+        )
+
+        if func.fleche.contains(*args, **func_kwargs):
+            fut: Future = Future()
+            fut.set_result(func.fleche.load(*args, **func_kwargs))
+            return fut
+
+        bound = func.fleche.bind(*args, **func_kwargs)
+        return original_submit(bound, **submit_kwargs)
+
+    executor.submit = submit
+    return executor

--- a/src/fleche/executor.py
+++ b/src/fleche/executor.py
@@ -94,6 +94,6 @@ def wrap_executor(executor):
         bound = func.fleche.bind(*args, **func_kwargs)
         return original_submit(bound, **submit_kwargs)
 
-    submit._fleche_wrapped = True
+    submit._fleche_wrapped = True  # type: ignore
     executor.submit = submit
     return executor

--- a/src/fleche/executor.py
+++ b/src/fleche/executor.py
@@ -63,6 +63,10 @@ def _split_submit_kwargs(submit_method, kwargs):
 def wrap_executor(executor):
     """Monkey-patch ``executor.submit`` to intercept fleche-wrapped functions.
 
+    Calling :func:`wrap_executor` on an executor that is already wrapped is a
+    no-op: the patch is not stacked, and the original ``submit`` continues to
+    refer to the pre-wrap method.
+
     Args:
         executor: any object with a ``submit(func, *args, **kwargs)`` method
             (e.g. :class:`concurrent.futures.Executor` subclass instances).
@@ -71,6 +75,8 @@ def wrap_executor(executor):
         The same ``executor`` instance, with a replaced ``submit`` attribute.
     """
     original_submit = executor.submit
+    if getattr(original_submit, "_fleche_wrapped", False):
+        return executor
 
     def submit(func, *args, **kwargs):
         if not _is_fleche_function(func):
@@ -88,5 +94,6 @@ def wrap_executor(executor):
         bound = func.fleche.bind(*args, **func_kwargs)
         return original_submit(bound, **submit_kwargs)
 
+    submit._fleche_wrapped = True
     executor.submit = submit
     return executor

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -65,3 +65,11 @@ def storage_backend(request, tmp_path):
 @pytest.fixture
 def clean_cache():
     yield Cache(ValueMemory({}), CallMemory({}))
+
+
+@pytest.fixture
+def file_cache(tmp_path):
+    yield Cache(
+        ValuePickleFile.with_pickle(root=tmp_path / "values"),
+        CallPickleFile.with_pickle(root=tmp_path / "calls"),
+    )

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -420,6 +420,16 @@ def test_wrap_executor_splits_submit_kwargs():
     assert cache1.contains(my_func.digest(42))
 
 
+def test_wrap_executor_is_idempotent():
+    """Wrapping the same executor twice installs a single interception layer."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        fleche.wrap_executor(executor)
+        patched_once = executor.submit
+        fleche.wrap_executor(executor)
+        # The second call must not replace or stack on the first patch.
+        assert executor.submit is patched_once
+
+
 @_skip_no_executorlib
 def test_executorlib_wrap_executor(file_cache):
     """wrap_executor works with executorlib.SingleNodeExecutor."""

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -383,31 +383,22 @@ def test_wrap_executor_cache_hit_skips_submit():
     assert future.result() == 21
 
 
-def test_process_executor_wrap_executor():
+def test_process_executor_wrap_executor(file_cache):
     """wrap_executor replaces manual BoundWrapper.bind for a ProcessPoolExecutor.
 
     Analogue of test_process_executor_bound_wrapper: the user submits the
     fleche function directly, and the patched submit takes care of binding.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        values_dir = f"{tmpdir}/values"
-        calls_dir = f"{tmpdir}/calls"
+    with fleche.cache(file_cache):
+        with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+            fleche.wrap_executor(executor)
+            result = executor.submit(double, 21).result()
 
-        file_cache = Cache(
-            ValuePickleFile.with_pickle(root=values_dir),
-            CallPickleFile.with_pickle(root=calls_dir),
-        )
-
-        with fleche.cache(file_cache):
-            with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
-                fleche.wrap_executor(executor)
-                result = executor.submit(double, 21).result()
-
-        assert result == 42, f"Expected 42, got {result}"
-        assert file_cache.contains(double.digest(21)), (
-            "wrap_executor binds the file-backed cache into the worker; "
-            "results are visible to the parent via the shared filesystem path."
-        )
+    assert result == 42, f"Expected 42, got {result}"
+    assert file_cache.contains(double.digest(21)), (
+        "wrap_executor binds the file-backed cache into the worker; "
+        "results are visible to the parent via the shared filesystem path."
+    )
 
 
 def test_wrap_executor_splits_submit_kwargs():
@@ -430,23 +421,14 @@ def test_wrap_executor_splits_submit_kwargs():
 
 
 @_skip_no_executorlib
-def test_executorlib_wrap_executor():
+def test_executorlib_wrap_executor(file_cache):
     """wrap_executor works with executorlib.SingleNodeExecutor."""
     from executorlib import SingleNodeExecutor
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        values_dir = f"{tmpdir}/values"
-        calls_dir = f"{tmpdir}/calls"
+    with fleche.cache(file_cache):
+        with SingleNodeExecutor() as executor:
+            fleche.wrap_executor(executor)
+            result = executor.submit(double, 21).result()
 
-        file_cache = Cache(
-            ValuePickleFile.with_pickle(root=values_dir),
-            CallPickleFile.with_pickle(root=calls_dir),
-        )
-
-        with fleche.cache(file_cache):
-            with SingleNodeExecutor() as executor:
-                fleche.wrap_executor(executor)
-                result = executor.submit(double, 21).result()
-
-        assert result == 42, f"Expected 42, got {result}"
-        assert file_cache.contains(double.digest(21))
+    assert result == 42, f"Expected 42, got {result}"
+    assert file_cache.contains(double.digest(21))

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -280,3 +280,173 @@ def test_executorlib_bound_wrapper():
             "BoundWrapper carries the file-backed cache into the executorlib worker; "
             "results are visible to the parent via the shared filesystem path."
         )
+
+
+# ---------------------------------------------------------------------------
+# wrap_executor tests
+# ---------------------------------------------------------------------------
+# ``fleche.wrap_executor`` monkey-patches ``executor.submit`` so that
+# fleche-wrapped functions are bound at submission time, and cache hits short-
+# circuit the executor entirely.
+
+
+@fleche.fleche
+def triple(x):
+    return x * 3
+
+
+def _plain_add(a, b):
+    return a + b
+
+
+class _NeverSubmitExecutor:
+    """Executor stub that explodes if ``submit`` is actually called.
+
+    Used to prove that a cache-hit path never reaches the underlying executor.
+    """
+
+    def submit(self, func, *args, **kwargs):
+        raise AssertionError(
+            f"submit should not have been called (func={func!r}, "
+            f"args={args}, kwargs={kwargs})"
+        )
+
+
+class _RecordingExecutor:
+    """Executor stub whose ``submit`` declares a keyword-only ``resource_dict``.
+
+    Captures what was forwarded to ``submit`` and what the callable was
+    invoked with, so tests can assert the kwarg split.
+    """
+
+    def __init__(self):
+        self.submit_args = None
+        self.submit_kwargs = None
+        self.call_args = None
+        self.call_kwargs = None
+        self.result = None
+
+    def submit(self, func, *args, resource_dict=None, **kwargs):
+        self.submit_args = args
+        self.submit_kwargs = {"resource_dict": resource_dict, **kwargs}
+
+        def _run(*a, **kw):
+            self.call_args = a
+            self.call_kwargs = kw
+            self.result = func(*a, **kw)
+            return self.result
+
+        fut = concurrent.futures.Future()
+        fut.set_result(_run(*args, **kwargs))
+        return fut
+
+
+def test_wrap_executor_passthrough_non_fleche():
+    """Non-fleche callables go straight to the original submit."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        fleche.wrap_executor(executor)
+        result = executor.submit(_plain_add, 2, 3).result()
+
+    assert result == 5
+
+
+def test_wrap_executor_thread_cache_miss():
+    """A cache miss on a wrapped ThreadPoolExecutor binds state and submits."""
+    cache1 = Cache(ValueMemory({}), CallMemory({}))
+
+    with fleche.cache(cache1):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            fleche.wrap_executor(executor)
+            future = executor.submit(my_func, 400)
+            assert future.result() == 401
+
+    assert cache1.contains(my_func.digest(400)), (
+        "wrap_executor should bind the current cache into the worker so the "
+        "result is stored in the parent's cache object."
+    )
+
+
+def test_wrap_executor_cache_hit_skips_submit():
+    """A cache hit returns a completed Future without ever calling submit."""
+    cache1 = Cache(ValueMemory({}), CallMemory({}))
+
+    with fleche.cache(cache1):
+        # seed the cache
+        assert triple(7) == 21
+
+        executor = _NeverSubmitExecutor()
+        fleche.wrap_executor(executor)
+
+        future = executor.submit(triple, 7)
+
+    assert future.done()
+    assert future.result() == 21
+
+
+def test_process_executor_wrap_executor():
+    """wrap_executor replaces manual BoundWrapper.bind for a ProcessPoolExecutor.
+
+    Analogue of test_process_executor_bound_wrapper: the user submits the
+    fleche function directly, and the patched submit takes care of binding.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        values_dir = f"{tmpdir}/values"
+        calls_dir = f"{tmpdir}/calls"
+
+        file_cache = Cache(
+            ValuePickleFile.with_pickle(root=values_dir),
+            CallPickleFile.with_pickle(root=calls_dir),
+        )
+
+        with fleche.cache(file_cache):
+            with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+                fleche.wrap_executor(executor)
+                result = executor.submit(double, 21).result()
+
+        assert result == 42, f"Expected 42, got {result}"
+        assert file_cache.contains(double.digest(21)), (
+            "wrap_executor binds the file-backed cache into the worker; "
+            "results are visible to the parent via the shared filesystem path."
+        )
+
+
+def test_wrap_executor_splits_submit_kwargs():
+    """Keyword-only params on submit are forwarded to submit, not the callable."""
+    cache1 = Cache(ValueMemory({}), CallMemory({}))
+    executor = _RecordingExecutor()
+
+    with fleche.cache(cache1):
+        fleche.wrap_executor(executor)
+        future = executor.submit(my_func, resource_dict={"cores": 4}, x=42)
+
+    assert future.result() == 43
+    assert executor.submit_kwargs == {"resource_dict": {"cores": 4}}
+    # The bound wrapper is invoked with *no* args/kwargs from the recording
+    # stub; the function payload (x=42) was baked into the BoundWrapper via
+    # ``func.fleche.bind``.
+    assert executor.call_args == ()
+    assert executor.call_kwargs == {}
+    assert cache1.contains(my_func.digest(42))
+
+
+@_skip_no_executorlib
+def test_executorlib_wrap_executor():
+    """wrap_executor works with executorlib.SingleNodeExecutor."""
+    from executorlib import SingleNodeExecutor
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        values_dir = f"{tmpdir}/values"
+        calls_dir = f"{tmpdir}/calls"
+
+        file_cache = Cache(
+            ValuePickleFile.with_pickle(root=values_dir),
+            CallPickleFile.with_pickle(root=calls_dir),
+        )
+
+        with fleche.cache(file_cache):
+            with SingleNodeExecutor() as executor:
+                fleche.wrap_executor(executor)
+                result = executor.submit(double, 21).result()
+
+        assert result == 42, f"Expected 42, got {result}"
+        assert file_cache.contains(double.digest(21))


### PR DESCRIPTION
## Summary
Introduces `fleche.wrap_executor()`, a utility function that monkey-patches an executor's `submit` method to automatically handle fleche-decorated functions. This eliminates the need for users to manually call `BoundWrapper.bind()` and enables cache-hit short-circuiting without executor overhead.

## Key Changes
- **New module `src/fleche/executor.py`**: Implements `wrap_executor()` which:
  - Intercepts `executor.submit()` calls to detect fleche-decorated functions
  - Returns cached results via completed `Future` objects without touching the executor
  - Automatically binds non-cached calls to carry cache/metadata state into workers
  - Intelligently splits keyword arguments between executor-reserved parameters (e.g., `resource_dict`) and function payload arguments
  
- **Updated `src/fleche/__init__.py`**: Exports `wrap_executor` in the public API

- **Comprehensive test coverage** in `tests/integration/test_parallel_execution.py`:
  - `test_wrap_executor_passthrough_non_fleche`: Non-fleche functions pass through unchanged
  - `test_wrap_executor_thread_cache_miss`: Cache misses bind state and submit normally
  - `test_wrap_executor_cache_hit_skips_submit`: Cache hits return completed futures without calling submit
  - `test_process_executor_wrap_executor`: Works with ProcessPoolExecutor and file-backed caches
  - `test_wrap_executor_splits_submit_kwargs`: Correctly partitions executor-specific kwargs from function arguments
  - `test_executorlib_wrap_executor`: Compatible with executorlib.SingleNodeExecutor

## Implementation Details
- Uses introspection (`inspect.signature`) to detect keyword-only parameters on executor's `submit` method, enabling compatibility with custom executors that declare their own parameters
- Handles both in-memory and file-backed caches transparently
- Works with any executor implementing the standard `submit(func, *args, **kwargs)` interface
- Non-invasive: patches the instance's `submit` attribute rather than subclassing

https://claude.ai/code/session_01SwPyQTm6foVSXLAY17KwYL