### PR TITLE
feat: descriptor-protocol fix for method helpers + BoundWrapper.flech…

### DIFF
--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -1,6 +1,9 @@
+import contextvars
 from contextlib import AbstractContextManager
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from functools import partial
+from types import SimpleNamespace
 from typing import overload, Callable
 
 from . import caches, config, metadata
@@ -125,6 +128,16 @@ def project(name):
     return tags(project=name)
 
 
+def _reconstruct_bound_wrapper(func, bound_cache, bound_meta):
+    """Module-level factory used by BoundWrapper.__reduce__ (contextvars.Context is not picklable)."""
+    def _setup():
+        _CACHE.set(bound_cache)
+        _METADATA.set(bound_meta)
+    ctx = contextvars.copy_context()
+    ctx.run(_setup)
+    return BoundWrapper(func, bound_cache, bound_meta, ctx)
+
+
 @dataclass(frozen=True, eq=True)
 class BoundWrapper:
     """Utility class that freezes global state for the cache and metadata config.
@@ -137,6 +150,7 @@ class BoundWrapper:
     func: Callable
     cache: caches.BaseCache
     meta: tuple[metadata.MetaData, ...]
+    ctx: contextvars.Context = field(compare=False, repr=False)
 
     @classmethod
     def bind(cls, func):
@@ -150,13 +164,45 @@ class BoundWrapper:
 
         Returns:
             :class:`.BoundWrapper`: instance with the bound cache and metadata state"""
-        return cls(func, _CACHE.get(), _METADATA.get())
+        return cls(func, _CACHE.get(), _METADATA.get(), contextvars.copy_context())
+
+    @property
+    def fleche(self):
+        """Return a .fleche namespace whose helpers run in the bound cache/meta context.
+
+        Also handles method-bound wrappers where ``self.func`` is ``partial(wrapper, obj, ...)``:
+        unwraps the partial chain to find the underlying fleche namespace and pre-applies the
+        captured positional/keyword prefix to each helper.
+        """
+        func = self.func
+        positional_prefix: tuple = ()
+        keyword_prefix: dict = {}
+        while isinstance(func, partial):
+            positional_prefix = func.args + positional_prefix
+            keyword_prefix = {**keyword_prefix, **func.keywords}
+            func = func.func
+
+        if not hasattr(func, 'fleche'):
+            raise AttributeError(
+                f"BoundWrapper.fleche requires a fleche-decorated function; "
+                f"{self.func!r} has no .fleche namespace"
+            )
+
+        ns = func.fleche
+
+        def _bind_helpers():
+            result = {}
+            for name in vars(ns):
+                helper = getattr(ns, name)
+                if positional_prefix or keyword_prefix:
+                    helper = partial(helper, *positional_prefix, **keyword_prefix)
+                result[name] = BoundWrapper.bind(helper)
+            return result
+
+        return SimpleNamespace(**self.ctx.run(_bind_helpers))
 
     def __call__(self, *args, **kwargs):
-        token_cache = _CACHE.set(self.cache)
-        token_meta = _METADATA.set(self.meta)
-        try:
-            return self.func(*args, **kwargs)
-        finally:
-            _METADATA.reset(token_meta)
-            _CACHE.reset(token_cache)
+        return self.ctx.run(self.func, *args, **kwargs)
+
+    def __reduce__(self):
+        return (_reconstruct_bound_wrapper, (self.func, self.cache, self.meta))

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -1,3 +1,5 @@
+import functools
+import importlib
 import os
 from pathlib import Path
 from functools import wraps, partial
@@ -160,6 +162,70 @@ def _attach(wrapper, fn, *, name, doc_prefix, ret=None, extra_doc=""):
 
 _T = TypeVar("_T")
 
+_HELPER_NAMES = frozenset(('call', 'digest', 'query', 'load', 'contains', 'rerun', 'bind'))
+
+
+def _lookup_by_qualname(module_name, qualname):
+    """Reconstruct a FlecheWrapper by importing its module and following its qualname."""
+    obj = importlib.import_module(module_name)
+    for attr in qualname.split('.'):
+        obj = getattr(obj, attr)
+    return obj
+
+
+class _BoundFlecheMethod:
+    """Returned by FlecheWrapper.__get__; pre-applies obj as first arg to __call__ and helpers."""
+
+    __slots__ = ('_wrapper', '_obj')
+
+    def __init__(self, wrapper, obj):
+        self._wrapper = wrapper
+        self._obj = obj
+
+    def __call__(self, *args, **kwargs):
+        return self._wrapper(self._obj, *args, **kwargs)
+
+    def __getattr__(self, name):
+        attr = getattr(self._wrapper, name)
+        if name in _HELPER_NAMES:
+            return partial(attr, self._obj)
+        return attr
+
+    @property
+    def fleche(self):
+        ns = self._wrapper.fleche
+        obj = self._obj
+        return SimpleNamespace(**{name: partial(getattr(ns, name), obj) for name in vars(ns)})
+
+    def __repr__(self):
+        return f"<bound fleche method {self._wrapper.__qualname__} of {self._obj!r}>"
+
+
+class FlecheWrapper:
+    """Callable class returned by @fleche; implements the descriptor protocol for method binding."""
+
+    def __init__(self, call_impl, func):
+        functools.update_wrapper(self, func)
+        # update_wrapper skips attributes absent on func (e.g. Mock objects lack __qualname__);
+        # ensure a sensible fallback so _attach's qualname formatting never fails.
+        if '__qualname__' not in self.__dict__:
+            self.__qualname__ = self.__dict__.get('__name__', repr(func))
+        self._call_impl = call_impl
+
+    def __call__(self, *args, **kwargs):
+        return self._call_impl(*args, **kwargs)
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return _BoundFlecheMethod(self, obj)
+
+    def __reduce__(self):
+        return (_lookup_by_qualname, (self.__module__, self.__qualname__))
+
+    def __repr__(self):
+        return f"<fleche function {self.__qualname__}>"
+
 
 _QUERY_DOC = """Return matching results from current cache.
 
@@ -259,8 +325,7 @@ def make_bind(wrapper):
 
 def make_wrapper(func, policy, meta, isolate, get_call):
     """Build the cached wrapper returned by :func:`fleche`."""
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> _T:
+    def _call_impl(*args: Any, **kwargs: Any) -> _T:
         cache: BaseCache = state._CACHE.get()
 
         # expand args passed as digest early so that everything else below sees the real values
@@ -337,7 +402,8 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                     return _run_and_cache()
         else:
             return _run_and_cache()
-    return wrapper
+
+    return FlecheWrapper(_call_impl, func)
 
 
 def fleche(

--- a/tests/integration/test_methods.py
+++ b/tests/integration/test_methods.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass
 from unittest.mock import Mock
 
+import pytest
 
 from fleche import fleche
+from fleche.caches import Cache
 from fleche.digest import Digest
+from fleche.state import cache
+from fleche.storage import ValueMemory, CallMemory
 
 
 class DigestibleClass:
@@ -83,3 +87,89 @@ def test_method_on_dataclass():
     obj.val = 400
     assert obj.method(5) == 405
     assert digestible_dataclass_mock.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Helper auto-binding: obj.method.helper() without explicit self=obj
+# ---------------------------------------------------------------------------
+
+
+class _HelperBindClass:
+    def __init__(self, val):
+        self.val = val
+
+    def __digest__(self):
+        return Digest(str(self.val))
+
+    @fleche
+    def compute(self, x):
+        return self.val + x
+
+
+def test_method_helpers_auto_bind_self_contains():
+    """obj.method.contains(x) should not require self=obj."""
+    c = Cache(ValueMemory({}), CallMemory({}))
+    obj = _HelperBindClass(42)
+    with cache(c):
+        obj.compute(5)
+        assert obj.compute.contains(5)
+
+
+def test_method_fleche_namespace_auto_binds():
+    """obj.method.fleche.contains(x) should not require self=obj."""
+    c = Cache(ValueMemory({}), CallMemory({}))
+    obj = _HelperBindClass(42)
+    with cache(c):
+        obj.compute(5)
+        assert obj.compute.fleche.contains(5)
+
+
+def test_method_helpers_digest_auto_bind_self():
+    """obj.method.digest(x) produces the same key as Klass.method.digest(obj, x)."""
+    obj = _HelperBindClass(42)
+    assert obj.compute.digest(5) == _HelperBindClass.compute.digest(obj, 5)
+
+
+def test_method_helpers_load_auto_bind_self():
+    """obj.method.load(x) retrieves the cached result without explicit self."""
+    c = Cache(ValueMemory({}), CallMemory({}))
+    obj = _HelperBindClass(42)
+    with cache(c):
+        obj.compute(5)
+        assert obj.compute.load(5) == 47
+
+
+def test_method_helpers_query_auto_bind_self():
+    """obj.method.query(x) returns matching calls without explicit self."""
+    c = Cache(ValueMemory({}), CallMemory({}))
+    obj = _HelperBindClass(42)
+    with cache(c):
+        obj.compute(5)
+        results = list(obj.compute.query(5))
+    assert len(results) == 1
+    assert results[0].result == 47
+
+
+def test_class_access_returns_fleche_wrapper():
+    """Accessing @fleche method on the class (not instance) returns FlecheWrapper itself."""
+    from fleche.wrapper import FlecheWrapper
+    assert isinstance(_HelperBindClass.compute, FlecheWrapper)
+
+
+def test_instance_access_returns_bound_method():
+    """Accessing @fleche method on an instance returns a bound view, not FlecheWrapper."""
+    from fleche.wrapper import FlecheWrapper
+    obj = _HelperBindClass(42)
+    assert not isinstance(obj.compute, FlecheWrapper)
+    assert obj.compute is not _HelperBindClass.compute
+
+
+def test_different_instances_get_independent_bound_methods():
+    """Each instance gets its own bound method view (helpers pre-apply the correct obj)."""
+    c = Cache(ValueMemory({}), CallMemory({}))
+    obj_a = _HelperBindClass(10)
+    obj_b = _HelperBindClass(20)
+    with cache(c):
+        obj_a.compute(5)
+        assert obj_a.compute.contains(5)
+        assert not obj_b.compute.contains(5)

--- a/tests/unit/fleche/test_bound_wrapper.py
+++ b/tests/unit/fleche/test_bound_wrapper.py
@@ -8,6 +8,8 @@ Covers:
 import pickle
 from unittest.mock import MagicMock
 
+import pytest
+
 import fleche.state as fleche_state
 from fleche import fleche
 from fleche.caches import Cache
@@ -342,3 +344,85 @@ def test_bind_helper_accessible_via_fleche_namespace():
         return x
 
     assert my_func.bind is my_func.fleche.bind
+
+
+# ---------------------------------------------------------------------------
+# 5. BoundWrapper.fleche namespace proxy
+# ---------------------------------------------------------------------------
+
+
+def test_bound_wrapper_fleche_uses_bound_cache():
+    """bound.fleche helpers should activate the bound cache outside any cache context manager."""
+    bound_cache = _make_cache()
+    outer_cache = _make_cache()
+
+    @fleche
+    def my_func(x):
+        return x + 1
+
+    with cache(bound_cache):
+        bound = fleche_state.BoundWrapper.bind(my_func)
+        bound(5)
+
+    assert bound.fleche.digest(5) == my_func.fleche.digest(5)
+
+    with cache(outer_cache):
+        assert bound.fleche.contains(5)
+        assert not my_func.contains(5)
+
+
+def test_bound_wrapper_fleche_raises_for_plain_function():
+    """BoundWrapper.fleche raises AttributeError when func has no .fleche namespace."""
+    def plain(x):
+        return x
+
+    bound_cache = _make_cache()
+    with cache(bound_cache):
+        bound = fleche_state.BoundWrapper.bind(plain)
+
+    with pytest.raises(AttributeError, match="fleche-decorated"):
+        _ = bound.fleche
+
+
+def test_bound_wrapper_fleche_with_method_binding():
+    """BoundWrapper.fleche works when created from obj.method.bind()."""
+    from fleche.digest import Digest
+
+    class MyClass:
+        def __init__(self, val):
+            self.val = val
+
+        def __digest__(self):
+            return Digest(str(self.val))
+
+        @fleche
+        def compute(self, x):
+            return self.val + x
+
+    obj = MyClass(10)
+    bound_cache = _make_cache()
+    outer_cache = _make_cache()
+
+    with cache(bound_cache):
+        bound = obj.compute.bind()
+        bound(5)
+
+    with cache(outer_cache):
+        assert bound.fleche.contains(5)
+        assert not MyClass.compute.contains(obj, 5)
+
+
+def test_bound_wrapper_fleche_helpers_are_not_recursive():
+    """Helpers exposed via bound.fleche should not themselves expose .fleche."""
+    bound_cache = _make_cache()
+
+    @fleche
+    def my_func(x):
+        return x + 1
+
+    with cache(bound_cache):
+        bound = fleche_state.BoundWrapper.bind(my_func)
+        bound(5)
+
+    with pytest.raises(AttributeError):
+        _ = bound.fleche.contains.fleche


### PR DESCRIPTION
…e (#310, #374)

Convert the wrapper returned by @fleche from a plain function to a FlecheWrapper callable class that implements __get__. Accessing obj.method now returns a _BoundFlecheMethod that pre-applies obj to __call__ and all helpers, so callers write obj.method.query(x) instead of obj.method.query(self=obj, x=...).

Also incorporates the BoundWrapper.fleche proxy from PR #375 so bound.fleche.digest(...) etc. activate the bound cache without an explicit context manager. The BoundWrapper.fleche implementation unwraps functools.partial chains to handle the method-bind case (obj.method.bind() produces a BoundWrapper whose func is partial(wrapper, obj)).

BoundWrapper.__call__ is updated to use contextvars.Context.run() for proper isolation; __reduce__ enables pickling via _reconstruct_bound_wrapper.