### PR TITLE
docs: improve custom __digest__ documentation with good pattern

### DIFF
--- a/docs/custom_digests.rst
+++ b/docs/custom_digests.rst
@@ -6,16 +6,30 @@ Customizing Digests
 The ``__digest__`` Method
 -------------------------
 
-The simplest way to customize the digest of an object is to implement a ``__digest__`` method on its class. This method should return a string representing the object's state.
+The simplest way to customize the digest of an object is to implement a ``__digest__`` method on its class.
+The method should return a :class:`~fleche.digest.Digest` (or a plain ``str``).
+
+The recommended pattern is to call :func:`~fleche.digest.digest` on a tuple of the relevant fields.
+This ensures that any field type ``fleche`` already knows how to hash (numpy arrays, dataclasses, nested objects, …) is handled correctly, and that different fields cannot accidentally collide:
 
 .. code-block:: python
 
-   class MyType:
-       def __init__(self, value):
-           self.value = value
+   from fleche.digest import digest, Digest
 
-       def __digest__(self):
-           return f"MyType:{self.value}"
+   class MyType:
+       def __init__(self, field1, field2):
+           self.field1 = field1
+           self.field2 = field2
+
+       def __digest__(self) -> Digest:
+           return digest((type(self).__name__, self.field1, self.field2))
+
+Including ``type(self).__name__`` ensures that subclasses of ``MyType`` with otherwise identical field values still receive different digests.
+
+.. note::
+
+   Only include fields that affect the *result* of cached functions.
+   Excluding irrelevant fields (e.g. display names, internal caches, attached metadata) makes more results reusable across calls.
 
 Using ``add_hook``
 ------------------
@@ -24,14 +38,14 @@ If you cannot or do not want to modify a class, you can register a custom digest
 
 .. code-block:: python
 
-   from fleche.digest import add_hook, Hook
+   from fleche.digest import add_hook, digest, Digest, Hook
 
    class ExternalType:
        def __init__(self, data):
            self.data = data
 
-   def external_digest(obj):
-       return f"External:{obj.data}"
+   def external_digest(obj: ExternalType) -> Digest:
+       return digest((type(obj).__name__, obj.data))
 
    add_hook(Hook(ExternalType, external_digest))
    # Or using a tuple
@@ -49,7 +63,7 @@ You can register your digest hooks in the ``fleche`` entry point group with the 
 .. code-block:: toml
 
    [project.entry-points."fleche"]
-   digest = "my_package.hooks:hooks"
+   digest = "my_package.hooks:digest_hooks"
 
 The entry point must resolve to one of:
 
@@ -64,11 +78,17 @@ which returns the object at the given path directly — it does **not** call it.
 .. code-block:: python
 
    # my_package/hooks.py
-   from fleche.digest import Hook
+   from fleche.digest import digest, Digest, Hook
 
-   hooks = [
-       Hook(TypeA, digest_a),
-       (TypeB, digest_b),
+   def type_a_digest(obj: TypeA) -> Digest:
+       return digest((type(obj).__name__, obj.field1, obj.field2))
+
+   def type_b_digest(obj: TypeB) -> Digest:
+       return digest((type(obj).__name__, obj.relevant_field))
+
+   digest_hooks = [
+       Hook(TypeA, type_a_digest),
+       (TypeB, type_b_digest),
    ]
 
 Lazy Loading and Retries


### PR DESCRIPTION
Show the recommended pattern of calling digest() on a tuple of relevant fields, add import examples, type annotations, subclass handling guidance, and a note on field selection. Also update hooks examples to use the same pattern and rename hooks variable to digest_hooks for clarity.