### PR TITLE
docs: document self-binding gotcha for decorated method helpers (#310)

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -53,3 +53,32 @@ The original, undecorated function is always accessible via the ``.__wrapped__``
 
    # Bypass cache
    result = my_func.__wrapped__(10)
+
+Usage with Decorated Methods
+-----------------------------
+
+.. note::
+
+   When ``@fleche`` is applied to a method, the helper methods (`.call`, `.digest`, `.query`,
+   `.load`, `.contains`, `.rerun`) do **not** automatically bind ``self``. Accessing
+   ``obj.method.query`` returns the same unbound helper as ``MyClass.method.query`` — Python's
+   descriptor protocol does not propagate through attribute lookups on bound methods.
+
+   You must pass the instance explicitly as the first positional argument:
+
+   .. code-block:: python
+
+      class MyClass:
+          @fleche
+          def compute(self, x):
+              ...
+
+      obj = MyClass()
+
+      # Correct — pass self explicitly
+      obj.compute.query(obj, x=5)
+      obj.compute.contains(obj, x=5)
+      obj.compute.digest(obj, x=5)
+
+      # Also works as a keyword argument
+      obj.compute.query(self=obj, x=5)

--- a/notebooks/ExtraMethods.ipynb
+++ b/notebooks/ExtraMethods.ipynb
@@ -227,6 +227,11 @@
     "end = time.time()\n",
     "print(f\"Result: {res} (took {end - start:.2f} seconds bypassing cache)\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Gotcha: Using Helpers with Decorated Methods\n\nWhen `@fleche` is applied to a class method, the helper methods do **not** automatically bind\n`self` the way a normal method call would. `obj.method.query` is the same unbound function as\n`MyClass.method.query` — no partial application of `self=obj` happens.\n\nYou must pass the instance explicitly as the first positional argument (or as `self=`):\n\n```python\nclass MyClass:\n    def __init__(self, val):\n        self.val = val\n\n    def __digest__(self):\n        from fleche.digest import Digest\n        return Digest(str(self.val))\n\n    @fleche\n    def compute(self, x):\n        return self.val + x\n\nobj = MyClass(10)\nobj.compute(5)  # populates cache\n\n# Correct — pass self explicitly\nobj.compute.contains(obj, x=5)  # True\nobj.compute.digest(obj, x=5)    # cache key string\nobj.compute.query(self=obj, x=5)  # also works as keyword\n\n# Incorrect — raises TypeError: missing argument 'self'\n# obj.compute.contains(x=5)\n```",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/notebooks/GettingStarted.ipynb
+++ b/notebooks/GettingStarted.ipynb
@@ -1023,6 +1023,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "### Gotcha: Helper Methods on Decorated Methods\n\nWhen `@fleche` decorates a class method, the helper methods (`.call`, `.digest`, `.query`,\n`.load`, `.contains`, `.rerun`) do **not** automatically bind `self`. Accessing\n`obj.compute.query` returns the same unbound helper as `MyClass.compute.query`.\n\nYou must pass the instance explicitly:\n\n```python\n# Pass self as the first positional argument\nobj.compute.query(obj, x=5)\nobj.compute.contains(obj, x=5)\nobj.compute.digest(obj, x=5)\n\n# Or as a keyword argument\nobj.compute.query(self=obj, x=5)\n```",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Passing Digests as Arguments\n",


### PR DESCRIPTION
Helper methods (.query, .contains, .digest, etc.) on @fleche-decorated class methods do not auto-bind self — the instance must be passed explicitly. Added a note to docs/helpers.rst, GettingStarted.ipynb, and ExtraMethods.ipynb.