### PR TITLE
Add convenience kwargs overload to BaseCache.query

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -135,10 +135,32 @@ class BaseCache(ABC):
     @abstractmethod
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]: ...
 
-    def query(self, call: call.QueryCall) -> query.QueryIterator:
+    def query(self, template: "call.QueryCall | None" = None, **kwargs) -> query.QueryIterator:
+        """Query the cache for matching calls.
+
+        Accepts either a :class:`~fleche.call.QueryCall` as the first positional argument,
+        or the same keyword arguments that :class:`~fleche.call.QueryCall` accepts.
+        Omitted fields default to ``None`` (wildcard).  Passing both a template and
+        keyword arguments raises :class:`TypeError`.
+
+        Examples::
+
+            cache.query(name="my_func")
+            cache.query(name="my_func", arguments={"x": 1})
+            cache.query(QueryCall(name="my_func"))  # existing form still works
+            cache.query()  # all calls
+
+        Returns:
+            :class:`~fleche.query.QueryIterator`
+        """
+        if template is None:
+            template = call.QueryCall(**kwargs)
+        elif kwargs:
+            raise TypeError("Cannot pass keyword arguments when a QueryCall template is provided")
+
         def _safe_iter():
             try:
-                yield from self._query(call)
+                yield from self._query(template)
             except _digest.Unhashable as e:
                 logger.warning("No hash for query argument: %s", e.args[0])
         return query.QueryIterator(_safe_iter())

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -317,6 +317,39 @@ def test_cache_load_restores_complex_arguments_and_result():
     assert loaded.result == [4, 5, 6]
 
 
+def test_cache_query_convenience_kwargs():
+    """BaseCache.query accepts QueryCall kwargs directly without constructing a QueryCall."""
+    from fleche.storage.memory import ValueMemory, CallMemory
+
+    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
+
+    call1 = Call(name="foo", arguments={"x": 1}, result=2, module="m", version=None, metadata={})
+    call2 = Call(name="bar", arguments={"x": 3}, result=4, module="m", version=None, metadata={})
+    c.save(call1)
+    c.save(call2)
+
+    results = list(c.query(name="foo"))
+    assert len(results) == 1
+    assert results[0].name == "foo"
+
+    results = list(c.query())
+    assert len(results) == 2
+
+    results = list(c.query(QueryCall(name="bar")))
+    assert len(results) == 1
+    assert results[0].name == "bar"
+
+
+def test_cache_query_kwargs_and_template_raises():
+    """Passing both a QueryCall template and kwargs should raise TypeError."""
+    import pytest
+    from fleche.storage.memory import ValueMemory, CallMemory
+
+    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
+    with pytest.raises(TypeError):
+        c.query(QueryCall(), name="foo")
+
+
 def test_hash_builtin_caches():
     """Test that all cache types respond properly to hash() builtin."""
     from fleche.caches import ReadOnlyCache, FilteredCache, RefreshingCache, SizeLimitedCache


### PR DESCRIPTION
BaseCache.query now accepts either a QueryCall as positional arg (existing API) or the same keyword arguments that QueryCall accepts, so callers can write cache.query(name="foo") instead of cache.query(QueryCall(name="foo")). Passing no arguments returns a full-wildcard iterator. Passing both a template and kwargs raises TypeError.