### PR TITLE
refactor(tests): reduce value/call storage tests to single backend

### DIFF
--- a/tests/unit/storage/test_overwrite.py
+++ b/tests/unit/storage/test_overwrite.py
@@ -1,44 +1,18 @@
 from fleche.call import Call
 from fleche.digest import Digest
+from fleche.storage import CallMemory
 
-def create_dummy_call(name, result, metadata=None):
-    return Call(
-        name=name,
-        arguments={"x": 1},
-        metadata=metadata or {},
-        module="test_module",
-        version=1,
-        code_digest="abc" * 16, # 64 chars
-        result=Digest(result)
-    )
 
-def test_call_storage_overwrite(call_storage):
-    call1 = create_dummy_call("my_func", "1" * 64)
-    key1 = call_storage.save(call1)
+def test_call_storage_overwrite_differing_metadata():
+    store = CallMemory({})
+    call1 = Call(name="my_func", arguments={"x": 1}, metadata={"tags": {"a": 1}}, result=Digest("1" * 64))
+    key1 = store.save(call1)
 
-    assert call_storage.load(key1).result == "1" * 64
+    assert store.load(key1).metadata == {"tags": {"a": 1}}
 
-    # Save a call with same lookup key (name, arguments, module, version, code_digest) but different result
-    call2 = create_dummy_call("my_func", "2" * 64)
-    key2 = call_storage.save(call2)
+    call2 = Call(name="my_func", arguments={"x": 1}, metadata={"tags": {"a": 2}}, result=Digest("1" * 64))
+    key2 = store.save(call2)
 
     assert key1 == key2
-    assert call_storage.load(key1).result == "2" * 64
-
-    # We expect overwrite behavior at the storage level, which means only 1 entry should exist for the same lookup key.
-    assert len(list(call_storage.list())) == 1
-
-def test_call_storage_overwrite_differing_metadata(call_storage):
-    call1 = create_dummy_call("my_func", "1" * 64, metadata={"tags": {"a": 1}})
-    key1 = call_storage.save(call1)
-
-    assert call_storage.load(key1).metadata == {"tags": {"a": 1}}
-
-    # Save a call with same lookup key but different metadata
-    call2 = create_dummy_call("my_func", "1" * 64, metadata={"tags": {"a": 2}})
-    key2 = call_storage.save(call2)
-
-    # Metadata is NOT part of the lookup key
-    assert key1 == key2
-    assert call_storage.load(key1).metadata == {"tags": {"a": 2}}
-    assert len(list(call_storage.list())) == 1
+    assert store.load(key1).metadata == {"tags": {"a": 2}}
+    assert len(list(store.list())) == 1

--- a/tests/unit/storage/test_short_digest.py
+++ b/tests/unit/storage/test_short_digest.py
@@ -1,68 +1,59 @@
 import pytest
-from fleche.storage import AmbiguousDigestError
+from fleche.storage import AmbiguousDigestError, ValueMemory
 from fleche.digest import DIGEST_LENGTH
 
 
-def test_short_digest_expansion(value_storage):
-    # Create two unique values
+def test_short_digest_expansion():
+    store = ValueMemory({})
     v1 = "value1"
     v2 = "value2"
 
-    k1 = value_storage.save(v1)
-    k2 = value_storage.save(v2)
+    k1 = store.save(v1)
+    k2 = store.save(v2)
 
     assert len(k1) == DIGEST_LENGTH
     assert len(k2) == DIGEST_LENGTH
 
-    # Test expansion of unique prefix
     for i in range(4, DIGEST_LENGTH):
         prefix = k1[:i]
         if not k2.startswith(prefix):
-            assert value_storage.expand(prefix) == k1
-            assert value_storage.load(prefix) == v1
+            assert store.expand(prefix) == k1
+            assert store.load(prefix) == v1
             break
     else:
         pytest.fail("Could not find a unique prefix for k1")
 
 
-def test_ambiguous_digest(value_storage):
+def test_ambiguous_digest():
+    store = ValueMemory({})
     k1 = "a" * 64
     k2 = "a" * 10 + "b" + "a" * 53
 
-    value_storage.save("val1", k1)
-    value_storage.save("val2", k2)
+    store.save("val1", k1)
+    store.save("val2", k2)
 
-    # Prefix "aaaa" should be ambiguous
     with pytest.raises(AmbiguousDigestError) as excinfo:
-        value_storage.expand("aaaa")
+        store.expand("aaaa")
     assert "need at least 11 characters" in str(excinfo.value)
 
     with pytest.raises(AmbiguousDigestError):
-        value_storage.load("aaaa")
+        store.load("aaaa")
 
 
-def test_too_short_digest(value_storage):
-    k1 = value_storage.save("value1")
-
-    # Prefix "abc" is only 3 chars, should raise KeyError
-    with pytest.raises(KeyError):
-        value_storage.expand(k1[:3])
+def test_too_short_digest():
+    store = ValueMemory({})
+    k1 = store.save("value1")
 
     with pytest.raises(KeyError):
-        value_storage.load(k1[:3])
+        store.expand(k1[:3])
 
-
-def test_missing_digest(value_storage):
-    value_storage.save("value1")
-
-    # Prefix that doesn't exist
     with pytest.raises(KeyError):
-        value_storage.expand("ffff")
+        store.load(k1[:3])
 
 
-def test_full_digest_still_works(value_storage):
-    v1 = "value1"
-    k1 = value_storage.save(v1)
+def test_missing_digest():
+    store = ValueMemory({})
+    store.save("value1")
 
-    assert value_storage.load(k1) == v1
-    assert value_storage.expand(k1) == k1
+    with pytest.raises(KeyError):
+        store.expand("ffff")

--- a/tests/unit/storage/test_storage.py
+++ b/tests/unit/storage/test_storage.py
@@ -2,7 +2,7 @@ import pytest
 from hypothesis import given, settings, HealthCheck
 import numpy as np
 
-from fleche.storage import SaveError
+from fleche.storage import SaveError, CallMemory
 from fleche.storage.sql import Sql
 from fleche.call import Call
 from fleche.digest import digest
@@ -54,7 +54,8 @@ def test_backend_short_prefix_expand(storage_backend, value):
     assert storage_backend.expand(key[:8]) == key
 
 
-def test_callstorages_evict(call_storage):
+def test_callstorages_evict():
+    store = CallMemory({})
     call = Call(
         name="evict_me",
         arguments={"a": "a" * 64},
@@ -63,29 +64,26 @@ def test_callstorages_evict(call_storage):
         version=None,
         result=None,
     )
-    try:
-        key = call_storage.save(call)
-    except SaveError:
-        return
-    assert key in set(call_storage.list())
+    key = store.save(call)
+    assert key in set(store.list())
 
     # Test short-hand eviction
     short_key = key[:8]
-    call_storage.evict(short_key)
-    assert key not in set(call_storage.list())
+    store.evict(short_key)
+    assert key not in set(store.list())
     with pytest.raises(KeyError):
-        call_storage.load(key)
+        store.load(key)
 
     # Test idempotent eviction (full key)
-    call_storage.evict(key)  # Should not raise anything
+    store.evict(key)  # Should not raise anything
 
     # Re-save and test full key eviction
-    key = call_storage.save(call)
-    assert key in set(call_storage.list())
-    call_storage.evict(key)
-    assert key not in set(call_storage.list())
+    key = store.save(call)
+    assert key in set(store.list())
+    store.evict(key)
+    assert key not in set(store.list())
     with pytest.raises(KeyError):
-        call_storage.load(key)
+        store.load(key)
 
 
 def test_sql_metadata_roundtrip_and_query(tmp_path):

--- a/tests/unit/storage/test_transform.py
+++ b/tests/unit/storage/test_transform.py
@@ -1,51 +1,52 @@
 from dataclasses import replace
 from fleche.call import Call
 from fleche.digest import Digest
+from fleche.storage import CallMemory
 
 
-def test_transform_basic(call_storage):
+def test_transform_basic():
+    store = CallMemory({})
     c1 = Call(
         name="f1",
         arguments={"a": Digest("a" * 64)},
         metadata={"table": {"m": 1}},
         result=Digest("r" * 64),
     )
-    call_storage.save(c1)
+    store.save(c1)
 
-    # Transform: update metadata, keep same key
     def update_metadata(call):
         return replace(call, metadata={"table": {"m": 2}})
 
-    call_storage.transform(update_metadata)
+    store.transform(update_metadata)
 
-    assert len(list(call_storage.list())) == 1
+    assert len(list(store.list())) == 1
     k1 = c1.to_lookup_key()
-    loaded = call_storage.load(k1)
+    loaded = store.load(k1)
     assert loaded.metadata == {"table": {"m": 2}}
     assert str(loaded.result) == "r" * 64
 
 
-def test_transform_key_change(call_storage):
+def test_transform_key_change():
+    store = CallMemory({})
     c1 = Call(
         name="f1",
         arguments={"a": Digest("a" * 64)},
         metadata={},
         result=Digest("r" * 64),
     )
-    call_storage.save(c1)
+    store.save(c1)
 
-    # Transform: change argument, change key
     def change_arg(call):
         return replace(call, arguments={"a": Digest("b" * 64)})
 
-    call_storage.transform(change_arg)
+    store.transform(change_arg)
 
-    all_keys = list(call_storage.list())
+    all_keys = list(store.list())
     assert len(all_keys) == 1
     assert c1.to_lookup_key() not in all_keys
 
     new_c = replace(c1, arguments={"a": Digest("b" * 64)})
     new_k = new_c.to_lookup_key()
     assert new_k in all_keys
-    loaded = call_storage.load(new_k)
+    loaded = store.load(new_k)
     assert str(loaded.arguments["a"]) == "b" * 64


### PR DESCRIPTION
Replace parametrized `value_storage`/`call_storage` fixtures (5–6 backends each) with inline `ValueMemory`/`CallMemory` in tests that exercise mixin behavior rather than backend-specific correctness:

- test_short_digest.py: 5×5=25 → 4×1=4 cases; drop test_full_digest_still_works (duplicate of test_value_mixin_load_full_key in test_mixins.py)
- test_overwrite.py: 2×6=12 → 1×1=1 case; drop test_call_storage_overwrite (duplicate of test_call_mixin_save_updated_result_replaces in test_mixins.py)
- test_transform.py: 2×6=12 → 2×1=2 cases
- test_storage.py::test_callstorages_evict: 1×6=6 → 1×1=1 case

The StorageBackend-level @given tests remain parametrized over all backends.