### PR TITLE
refactor: break LazyArguments -> Cache._handle_args_load backward dependency

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -257,15 +257,6 @@ class Cache(BaseCache):
 
         return self.values.load(key)
 
-    def _handle_args_load(self, key):
-        if not isinstance(key, Digest):
-            return key  # found a simple value
-        try:
-            return self.load_value(key)
-        except KeyError:
-            # if value is not in storage, leave the digest in place
-            return key
-
     def save(self, call: Call) -> str:
         try:
             digested = call.stash(self.values)

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -203,7 +203,14 @@ class LazyArguments(Mapping):
         self._arg_digests = arg_digests
 
     def __getitem__(self, key):
-        return self._cache._handle_args_load(self._arg_digests[key])
+        value = self._arg_digests[key]
+        if not isinstance(value, Digest):
+            return value
+        try:
+            return self._cache.load_value(value)
+        except KeyError:
+            # Value not in storage; leave the digest in place.
+            return value
 
     def __iter__(self):
         return iter(self._arg_digests)

--- a/tests/unit/caches/test_lazy_call.py
+++ b/tests/unit/caches/test_lazy_call.py
@@ -22,33 +22,29 @@ def test_lazy_call_load():
     assert isinstance(lazy, LazyCall)
     assert lazy.name == "test_func"
 
-    # Check that it's NOT yet loaded. We mock the internal load handlers to track calls.
-    with patch.object(Cache, '_handle_args_load', wraps=cache._handle_args_load) as mock_handle_args, \
-         patch.object(Cache, 'load_value', wraps=cache.load_value) as mock_load_value:
+    # Check that it's NOT yet loaded. We mock load_value to track calls.
+    with patch.object(Cache, 'load_value', wraps=cache.load_value) as mock_load_value:
 
         # Accessing arguments property returns a proxy, doesn't trigger load yet.
         args = lazy.arguments
         assert isinstance(args, LazyArguments)
-        assert mock_handle_args.call_count == 0
+        assert mock_load_value.call_count == 0
 
-        # Accessing an individual argument should trigger exactly one load for that argument.
+        # Accessing an individual argument should trigger exactly one load_value call.
         val_a = args["a"]
         assert val_a == 1
-        assert mock_handle_args.call_count == 1
-        mock_handle_args.assert_called_with(digest(1))
+        assert mock_load_value.call_count == 1
+        mock_load_value.assert_called_with(digest(1))
 
         # Accessing another argument triggers another load.
         val_b = args["b"]
         assert val_b == 2
-        assert mock_handle_args.call_count == 2
+        assert mock_load_value.call_count == 2
 
         # Accessing result should trigger its own load.
-        # Note: load_value might have been called by _handle_args_load if arguments were complex,
-        # but here they are simple ints.
-        load_value_count_before = mock_load_value.call_count
         res = lazy.result
         assert res == 3
-        assert mock_load_value.call_count == load_value_count_before + 1
+        assert mock_load_value.call_count == 3
         mock_load_value.assert_called_with(digest(3))
 
 
@@ -122,18 +118,21 @@ def test_lazy_call_frozen():
 
 def test_lazy_arguments_mapping():
     """Verify that LazyArguments implements the Mapping interface correctly."""
+    from fleche.digest import Digest
     cache = Mock()
-    cache._handle_args_load.side_effect = lambda x: f"loaded_{x}"
-    arg_digests = {"a": "dig_a", "b": "dig_b"}
+    cache.load_value.side_effect = lambda x: f"loaded_{x}"
+    dig_a = Digest("a" * 64)
+    dig_b = Digest("b" * 64)
+    arg_digests = {"a": dig_a, "b": dig_b}
     args = LazyArguments(cache, arg_digests)
 
     assert len(args) == 2
     assert set(args) == {"a", "b"}
-    assert args["a"] == "loaded_dig_a"
-    assert args["b"] == "loaded_dig_b"
+    assert args["a"] == f"loaded_{'a' * 64}"
+    assert args["b"] == f"loaded_{'b' * 64}"
     assert "a" in args
     assert "c" not in args
-    assert list(args.items()) == [("a", "loaded_dig_a"), ("b", "loaded_dig_b")]
+    assert list(args.items()) == [("a", f"loaded_{'a' * 64}"), ("b", f"loaded_{'b' * 64}")]
 
 
 def test_lazy_call_maintains_cache_reference():


### PR DESCRIPTION
LazyArguments.__getitem__ was calling self._cache._handle_args_load(), a private Cache method, from within call.py.  Since caches.py imports call.py, this created an implicit call.py -> caches.py backward dependency.

Inline the trivial _handle_args_load logic directly into LazyArguments.__getitem__ using the public BaseCache.load_value interface (already abstract on BaseCache), then remove the now-unused _handle_args_load from Cache.

Related to #335, closes #368 follow-up.