### PR TITLE
fix(typing): remove stale ty/type ignore directives

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -345,7 +345,7 @@ class Cache(BaseCache):
 
         This may take time depending on cache size."""
         for key in self.calls.list():
-            call = self.load(key).fetch()  # ty: ignore
+            call = self.load(key).fetch()
             if call.to_lookup_key() != key:
                 # instantiate values too
                 self.save(call)

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -247,7 +247,7 @@ def _asdict_init_only(obj) -> dict[str, Any]:
     appear in serialised config.
     """
     non_init = {f.name for f in dataclasses.fields(obj) if not f.init}
-    return {k: v for k, v in asdict(obj).items() if k not in non_init}  # type: ignore
+    return {k: v for k, v in asdict(obj).items() if k not in non_init}
 
 
 def storage_to_config(s: storage.ValueStorage | storage.CallStorage) -> dict[str, Any]:

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -219,7 +219,7 @@ def make_query(func, policy):
         call.metadata = metadata
         return state._CACHE.get().query(call)
 
-    wraps(func)(_query_func)  # ty: ignore
+    wraps(func)(_query_func)
     return _query_func
 
 


### PR DESCRIPTION
The underlying type errors these comments suppressed no longer fire under current ty, so ty was flagging them as `unused-ignore-comment` / `unused-type-ignore-comment` warnings.

https://claude.ai/code/session_019JezpzqdXw4K2NfAETuV6g