### PR TITLE
Unify _PicklableLock and _PicklableRLock via shared base class

### DIFF
--- a/src/fleche/storage/thread_safe.py
+++ b/src/fleche/storage/thread_safe.py
@@ -44,8 +44,10 @@ class _PicklableLock:
     independent lock that shares no state with locks in other processes.
     """
 
+    _factory = threading.Lock
+
     def __init__(self):
-        self._lock = threading.Lock()
+        self._lock = self._factory()
 
     def __reduce__(self):
         return (type(self), ())
@@ -57,24 +59,14 @@ class _PicklableLock:
         return self._lock.__exit__(*args)
 
 
-class _PicklableRLock:
+class _PicklableRLock(_PicklableLock):
     """A ``threading.RLock`` wrapper that survives pickle round-trips.
 
     Same in-process-only semantics as :class:`_PicklableLock`; reentrant so
     that nested acquisitions (e.g. ``expand`` inside ``load``) do not deadlock.
     """
 
-    def __init__(self):
-        self._lock = threading.RLock()
-
-    def __reduce__(self):
-        return (type(self), ())
-
-    def __enter__(self):
-        return self._lock.__enter__()
-
-    def __exit__(self, *args):
-        return self._lock.__exit__(*args)
+    _factory = threading.RLock
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Eliminate ~14 lines of byte-for-byte duplication by introducing a class-level `_factory` attribute on `_PicklableLock` (defaulting to `threading.Lock`) and making `_PicklableRLock` a subclass that overrides it with `threading.RLock`. `__reduce__` already uses `type(self)` so both classes continue to pickle-round-trip correctly. No behaviour change.

Closes #401

Generated with [Claude Code](https://claude.ai/code)