### PR TITLE
Refactor latest/oldest to share _timestop_extremum helper

### DIFF
--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -123,27 +123,32 @@ class QueryIterator(Iterable[call.LazyCall]):
             groups[k].append(c)
         return {k: QueryIterator(v) for k, v in groups.items()}
 
+    def _timestop_extremum(self, *, reverse: bool) -> call.LazyCall:
+        sentinel = float("-inf") if reverse else float("inf")
+        result = (builtins.max if reverse else builtins.min)(
+            self,
+            key=lambda c: c.metadata.get("runtime", {}).get("timestop", sentinel),
+            default=None,
+        )
+        if result is None:
+            raise IndexError("QueryIterator is empty")
+        return result
+
     def latest(self) -> call.LazyCall:
-        """Return the call with the most recent timestart (requires Runtime metadata).
+        """Return the call with the most recent timestop (requires Runtime metadata).
 
         Raises:
             IndexError: if there are no matching calls
         """
-        calls = builtins.list(self)
-        if not calls:
-            raise IndexError("QueryIterator is empty")
-        return builtins.max(calls, key=lambda c: c.metadata.get("runtime", {}).get("timestart", float("-inf")))
+        return self._timestop_extremum(reverse=True)
 
     def oldest(self) -> call.LazyCall:
-        """Return the call with the oldest timestart (requires Runtime metadata).
+        """Return the call with the oldest timestop (requires Runtime metadata).
 
         Raises:
             IndexError: if there are no matching calls
         """
-        calls = builtins.list(self)
-        if not calls:
-            raise IndexError("QueryIterator is empty")
-        return builtins.min(calls, key=lambda c: c.metadata.get("runtime", {}).get("timestart", float("inf")))
+        return self._timestop_extremum(reverse=False)
 
     def evict(self) -> None:
         """Remove all matched calls from the cache."""

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -567,23 +567,23 @@ def test_groupby_returns_query_iterators(test_cache):
 # ---------------------------------------------------------------------------
 
 def test_latest_returns_most_recent(test_cache):
-    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={"runtime": {"timestart": 100.0}}))
-    test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestart": 200.0}}))
-    test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestart": 50.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={"runtime": {"timestop": 100.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestop": 200.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestop": 50.0}}))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     all_calls = list(test_cache.query(tpl))
-    expected = max(all_calls, key=lambda c: c.metadata["runtime"]["timestart"])
+    expected = max(all_calls, key=lambda c: c.metadata["runtime"]["timestop"])
     result = test_cache.query(tpl).latest()
     assert result.to_lookup_key() == expected.to_lookup_key()
 
 
 def test_oldest_returns_earliest(test_cache):
-    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={"runtime": {"timestart": 100.0}}))
-    test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestart": 200.0}}))
-    test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestart": 50.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10, metadata={"runtime": {"timestop": 100.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20, metadata={"runtime": {"timestop": 200.0}}))
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30, metadata={"runtime": {"timestop": 50.0}}))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     all_calls = list(test_cache.query(tpl))
-    expected = min(all_calls, key=lambda c: c.metadata["runtime"]["timestart"])
+    expected = min(all_calls, key=lambda c: c.metadata["runtime"]["timestop"])
     result = test_cache.query(tpl).oldest()
     assert result.to_lookup_key() == expected.to_lookup_key()
 

--- a/tests/unit/storage/test_destructuring_dataclasses.py
+++ b/tests/unit/storage/test_destructuring_dataclasses.py
@@ -21,7 +21,7 @@ from tests.strategies import st_base_values, st_nested_values, dataclasses as st
 # ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
-class DestructuringMemory(ValueMixin, DestructuringMixin, MemoryBackend):
+class DestructuringMemory(DestructuringMixin, ValueMixin, MemoryBackend):
     pass
 
 


### PR DESCRIPTION
Extracts a shared _timestop_extremum helper for latest/oldest, switching from timestart to timestop and computing the extremum directly on the iterator (using max/min's default= param to detect empty).