### PR TITLE
Fix type error: super().put() → super().save() in DestructuringMixin

### DIFF
--- a/src/fleche/storage/destructuring.py
+++ b/src/fleche/storage/destructuring.py
@@ -220,10 +220,10 @@ class DestructuringMixin(base.ValueStorage):
 
             case _ if _dataclasses.is_dataclass(value) and not isinstance(value, type):
                 if not _dataclasses.fields(value):
-                    return super().put(value, key)
+                    return super().save(value, key)
                 value_or_digest, depth = self._intern_rec(value, key)
                 if depth < self.remaining_depth:
-                    return super().put(value_or_digest, key)
+                    return super().save(value_or_digest, key)
                 else:
                     return value_or_digest
 


### PR DESCRIPTION
## Summary

- `DestructuringMixin` inherits from `ValueStorage`, which declares `save()` but **not** `put()` — `put()` lives on `StorageBackend`.
- Lines 223 and 226 in `destructuring.py` called `super().put()` in the dataclass branch, which the `ty` type checker cannot resolve.
- Fixed by replacing `super().put(value, key)` → `super().save(value, key)`, consistent with all other branches of `save()` in the same method.
- Semantically correct: `save()` handles `key=None` properly (computes the digest if absent), while `put()` requires `key: Digest` — so the old code would have silently failed with `key=None`.

Closes #401 (type-check CI failure introduced in #410).

Related: #413 (will rebase on top of this fix)

🤖 Generated with [Claude Code](https://claude.ai/code)