### PR TITLE
fix(tests): correct MRO in DestructuringMemory fixture

### DIFF
--- a/tests/unit/storage/test_destructuring_dataclasses.py
+++ b/tests/unit/storage/test_destructuring_dataclasses.py
@@ -21,7 +21,7 @@ from tests.strategies import st_base_values, st_nested_values, dataclasses as st
 # ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
-class DestructuringMemory(ValueMixin, DestructuringMixin, MemoryBackend):
+class DestructuringMemory(DestructuringMixin, ValueMixin, MemoryBackend):
     pass
 
 


### PR DESCRIPTION
## Summary

- Fixes the MRO order in the `DestructuringMemory` test fixture in `tests/unit/storage/test_destructuring_dataclasses.py`
- `ValueMixin` was listed before `DestructuringMixin`, so Python's MRO dispatched `ValueMixin.save()` first — bypassing `DestructuringMixin.save()` entirely and causing 6 test failures where dataclasses were not wrapped in `DigestedDataclass`

Companion to #415 (which fixed the `super().put()` → `super().save()` type error in the same area).

## Test plan
- [x] All 38 tests in `test_destructuring_dataclasses.py` pass after the fix
- [x] `test_destructuring_storage.py` tests unaffected

Closes the remaining CI failures on PR #414.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)