### PR TITLE
Refactor: extract _default_memory_cache helper that interns

### DIFF
--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -110,7 +110,7 @@ from . import storage, metadata, caches
 
 logger = logging.getLogger("fleche.config")
 
-_live_caches: dict[str, caches.Cache] = {}
+_live_caches: dict[str | None, caches.Cache] = {}
 
 
 def _load_config(path: Path) -> dict[str, Any]:
@@ -396,6 +396,15 @@ def _create_cache(cache_config: dict[str, Any]) -> caches.Cache:
     return caches.Cache(values=values, calls=calls)
 
 
+def _default_memory_cache(name: str | None, reason: str | None = None) -> caches.Cache:
+    """Return (and intern) a fresh in-memory cache, optionally logging the fallback reason."""
+    if reason is not None:
+        logger.warning("Using default memory cache: %s", reason)
+    cache = caches.Cache(storage.ValueMemory({}), storage.CallMemory({}))
+    _live_caches[name] = cache
+    return cache
+
+
 def load_cache_config(name: str | None = None) -> caches.Cache:
     """
     Load a cache from the configuration file.
@@ -410,9 +419,7 @@ def load_cache_config(name: str | None = None) -> caches.Cache:
         return _live_caches[name]
 
     if name == "memory":
-        cache = caches.Cache(storage.ValueMemory({}), storage.CallMemory({}))
-        _live_caches[name] = cache
-        return cache
+        return _default_memory_cache("memory")
 
     if name == "void":
         cache = caches.Cache(storage.ValueVoid(), storage.CallVoid())
@@ -420,40 +427,23 @@ def load_cache_config(name: str | None = None) -> caches.Cache:
         return cache
 
     path = _get_config_path()
-    if path is None or not path.exists():
-        if name is not None:
-            logger.warning(
-                "No config file found. Using default memory cache for '%s'.", name
-            )
-        else:
-            logger.warning("No config file found. Using default memory cache.")
-        return caches.Cache(storage.ValueMemory({}), storage.CallMemory({}))
+    if path is None:
+        reason = f"no config file found (name={name!r})" if name is not None else "no config file found"
+        return _default_memory_cache(name, reason)
 
     config = _load_config(path)
 
-    cache_name = name
-    cache_config = None
-
-    if cache_name is None:
+    if name is None:
         if "default" not in config or "cache" not in config["default"]:
-            logger.warning("No default cache configured. Using default memory cache.")
-            return caches.Cache(storage.ValueMemory({}), storage.CallMemory({}))
-
+            return _default_memory_cache(None, "no default cache configured")
         default_cache = config["default"]["cache"]
         if isinstance(default_cache, str):
             return load_cache_config(default_cache)
-        else:
-            cache_name = "default"
-            cache_config = default_cache
-
-    if cache_config is None:
-        if cache_name not in config:
-            logger.warning(
-                "Cache '%s' not found in configuration. Using default memory cache.",
-                cache_name,
-            )
-            return caches.Cache(storage.ValueMemory({}), storage.CallMemory({}))
-        cache_config = config[cache_name]
+        cache_name, cache_config = "default", default_cache
+    else:
+        if name not in config:
+            return _default_memory_cache(name, f"cache {name!r} not found in configuration")
+        cache_name, cache_config = name, config[name]
 
     cache = _create_cache(cache_config)
     _live_caches[cache_name] = cache

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -5,7 +5,7 @@ import pytest
 from dataclasses import dataclass
 
 from fleche import storage, cache
-from fleche.config import load_cache_config, load_default_metadata
+from fleche.config import load_cache_config, load_default_metadata, _live_caches
 from fleche.caches import Cache, BaseCache
 from fleche.metadata import Runtime
 
@@ -86,6 +86,13 @@ def config_file_no_default():
         config_path = config_dir / "cache.toml"
         config_path.write_text(config)
         yield tmpdir
+
+
+@pytest.fixture(autouse=True)
+def _reset_live_caches():
+    _live_caches.clear()
+    yield
+    _live_caches.clear()
 
 
 @pytest.fixture
@@ -294,3 +301,33 @@ def test_load_default_metadata_with_syntax_error(tmp_path, monkeypatch):
     meta = load_default_metadata()
     assert len(meta) == 1
     assert isinstance(meta[0], Runtime)
+
+
+def test_fallback_no_config_file_is_singleton(monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/nonexistent")
+
+    default1 = load_cache_config()
+    default2 = load_cache_config()
+    assert default1 is default2
+
+    named1 = load_cache_config("missing")
+    named2 = load_cache_config("missing")
+    assert named1 is named2
+
+    assert default1 is not named1
+
+
+def test_fallback_no_default_in_config_is_singleton(monkeypatch, config_file_no_default):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file_no_default)
+
+    cache1 = load_cache_config()
+    cache2 = load_cache_config()
+    assert cache1 is cache2
+
+
+def test_fallback_named_cache_missing_is_singleton(monkeypatch, config_file_no_default):
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file_no_default)
+
+    cache1 = load_cache_config("nonexistent")
+    cache2 = load_cache_config("nonexistent")
+    assert cache1 is cache2


### PR DESCRIPTION
All four Memory-fallback sites in load_cache_config now go through a single _default_memory_cache(name, reason) helper that creates the cache, interns it in _live_caches under the requested name (including None for the default), and emits a consistent warning message.

Additional cleanup while in the area:
- _live_caches type widened to dict[str | None, …] (None is a valid key)
- Removed redundant `or not path.exists()` guard; _get_config_path() already only returns a path when the file exists
- Eliminated the cache_name/cache_config intermediate variables by splitting the name-is-None / name-is-not-None branches clearly

Tests: autouse _reset_live_caches fixture ensures test isolation; three new tests cover the singleton (interning) behaviour of the three fallback paths.