### PR TITLE
docs(agents): attribute bot commits to claude[bot]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,26 @@ issue or PR.
 # General Instructions
 
 When you cannot complete a task or question because you are missing depedencies fail early and report the errors.
+
+## Commit attribution
+
+When running inside a GitHub Action, the workflow may be authenticated with a
+user PAT (see `.github/workflows/claude.yaml`). Without intervention, any
+commits you create would be attributed to that user. Always attribute your
+commits to the bot identity instead:
+
+```
+git -c user.name="claude[bot]" \
+    -c user.email="claude[bot]@users.noreply.github.com" \
+    commit --author="claude[bot] <claude[bot]@users.noreply.github.com>" ...
+```
+
+Or set the identity once per session:
+
+```
+git config user.name "claude[bot]"
+git config user.email "claude[bot]@users.noreply.github.com"
+```
+
+and pass `--author="claude[bot] <claude[bot]@users.noreply.github.com>"` on
+every `git commit`. This applies to amends, rebases, and squash-merges too.


### PR DESCRIPTION
## Summary

- Adds a "Commit attribution" section to `AGENTS.md` instructing agents to set git author (and committer) to `claude[bot]` when running inside a GitHub Action.
- Motivation: `.github/workflows/claude.yaml` authenticates with a user PAT, so without intervention any commits Claude creates are attributed to that user instead of the bot.

## Test plan

- [ ] Verify this very PR's commit shows author = `claude[bot]` on GitHub (self-test — I used the instructed `--author` flag to make the commit).

https://claude.ai/code/session_014DQCmTw5c5ZtrpRKFxMyyR

---
_Generated by [Claude Code](https://claude.ai/code/session_014DQCmTw5c5ZtrpRKFxMyyR)_