### PR TITLE
feat: add Cache.gc() to evict values unreachable from any call

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -342,6 +342,53 @@ class Cache(BaseCache):
                 self.save(call)
                 self.calls.evict(key)
 
+    def gc(self) -> set[Digest]:
+        """Evict value entries not reachable from any stored call.
+
+        Brute-force mark-and-sweep: walks every call record to build the set
+        of directly-referenced value digests, then transitively follows
+        destructured sub-references (via :meth:`DestructuringMixin.sub_digests`
+        when available), and evicts every ``values`` key outside the reachable
+        set.  Call records are left untouched.
+
+        Returns:
+            The set of digests that were evicted from value storage.
+        """
+        reachable: set[Digest] = set()
+        for key in self.calls.list():
+            try:
+                dc = self.calls.load(key)
+            except KeyError:
+                continue
+            if isinstance(dc.result, Digest):
+                reachable.add(dc.result)
+            for v in dc.arguments.values():
+                if isinstance(v, Digest):
+                    reachable.add(v)
+
+        sub_digests = getattr(self.values, "sub_digests", None)
+        if sub_digests is not None:
+            frontier = set(reachable)
+            while frontier:
+                key = frontier.pop()
+                try:
+                    children = sub_digests(key)
+                except KeyError:
+                    continue
+                new = children - reachable
+                reachable |= new
+                frontier |= new
+
+        evicted: set[Digest] = set()
+        for key in list(self.values.list()):
+            if key not in reachable:
+                try:
+                    self.values.evict(key)
+                    evicted.add(key)
+                except KeyError:
+                    continue
+        return evicted
+
 
 @dataclass(frozen=True)
 class ReadOnlyCache(BaseCache):

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -10,6 +10,7 @@ import pandas as pd
 from . import digest as _digest
 from .digest import Digest  # type hint convenience
 from . import storage
+from .storage.destructuring import HasChildDigests
 from .call import Call, DigestedCall, LazyCall, QueryCall
 from . import call
 from . import query
@@ -347,8 +348,9 @@ class Cache(BaseCache):
 
         Brute-force mark-and-sweep: walks every call record to build the set
         of directly-referenced value digests, then transitively follows
-        destructured sub-references (via :meth:`DestructuringMixin.sub_digests`
-        when available), and evicts every ``values`` key outside the reachable
+        destructured sub-references (via :meth:`DestructuringMixin.child_digests`
+        on storages that satisfy :class:`HasChildDigests`), and evicts every
+        ``values`` key outside the reachable
         set.  Call records are left untouched.
 
         Returns:
@@ -366,13 +368,12 @@ class Cache(BaseCache):
                 if isinstance(v, Digest):
                     reachable.add(v)
 
-        sub_digests = getattr(self.values, "sub_digests", None)
-        if sub_digests is not None:
+        if isinstance(self.values, HasChildDigests):
             frontier = set(reachable)
             while frontier:
                 key = frontier.pop()
                 try:
-                    children = sub_digests(key)
+                    children = self.values.child_digests(key)
                 except KeyError:
                     continue
                 new = children - reachable

--- a/src/fleche/storage/destructuring.py
+++ b/src/fleche/storage/destructuring.py
@@ -270,6 +270,43 @@ class DestructuringMixin(base.ValueStorage):
             case _:
                 return value
 
+    def _raw_sub_digests(self, raw: Any) -> set[digest.Digest]:
+        """Direct digest children of a raw stored entry.
+
+        A *raw* entry is what ``super().load`` returns — i.e. what was written
+        to the underlying backend before :meth:`mend` rewires sub-digests back
+        into their parent container.  Only :class:`Digested` wrappers carry
+        child references; scalars and plain (non-destructured) containers
+        return an empty set.
+        """
+        match raw:
+            case DigestedIterable():
+                return {i for i in raw.items if isinstance(i, digest.Digest)}
+            case DigestedDict():
+                return {
+                    x
+                    for pair in raw.items.items()
+                    for x in pair
+                    if isinstance(x, digest.Digest)
+                }
+            case DigestedFields():
+                return {v for v in raw.fields.values() if isinstance(v, digest.Digest)}
+            case _:
+                return set()
+
+    def sub_digests(self, key: digest.Digest | str) -> set[digest.Digest]:
+        """Direct digest children of the raw entry stored at *key*.
+
+        Bypasses :meth:`mend`, so destructured sub-references are returned as
+        opaque :class:`~fleche.digest.Digest` keys rather than being followed.
+        Intended for reference-graph traversals (GC, debugging) where loading
+        the mended value would flatten the structure we need to inspect.
+
+        Raises:
+            KeyError: if *key* is not present in the underlying backend.
+        """
+        return self._raw_sub_digests(super().load(key))
+
     def count_reuses(self) -> Counter[digest.Digest]:
         """Return a counter of how many times each stored key is referenced as a sub-component.
 
@@ -295,20 +332,7 @@ class DestructuringMixin(base.ValueStorage):
         """
         counts: Counter[digest.Digest] = Counter({key: 0 for key in self.list()})
         for key in list(counts):
-            raw = super().load(key)
-            match raw:
-                case DigestedIterable():
-                    for item in raw.items:
-                        if isinstance(item, digest.Digest) and item in counts:
-                            counts[item] += 1
-                case DigestedDict():
-                    for k, v in raw.items.items():
-                        if isinstance(k, digest.Digest) and k in counts:
-                            counts[k] += 1
-                        if isinstance(v, digest.Digest) and v in counts:
-                            counts[v] += 1
-                case DigestedFields():
-                    for v in raw.fields.values():
-                        if isinstance(v, digest.Digest) and v in counts:
-                            counts[v] += 1
+            for sub in self._raw_sub_digests(super().load(key)):
+                if sub in counts:
+                    counts[sub] += 1
         return counts

--- a/src/fleche/storage/destructuring.py
+++ b/src/fleche/storage/destructuring.py
@@ -4,7 +4,7 @@ from collections import Counter
 import dataclasses as _dataclasses
 from dataclasses import dataclass
 from numbers import Number
-from typing import Any, Callable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 from . import base
 from .. import _attrs
@@ -155,6 +155,25 @@ class DigestedAttrs(DigestedFields):
         return _attrs.field_items(value)
 
 
+@runtime_checkable
+class HasChildDigests(Protocol):
+    """Structural protocol for value storages that expose a reference-graph edge query.
+
+    Any :class:`~fleche.storage.base.ValueStorage` that implements
+    :meth:`child_digests` satisfies this protocol automatically — no explicit
+    registration or inheritance required.  Use ``isinstance(storage, HasChildDigests)``
+    to check at runtime whether the storage supports transitive reachability walks.
+    """
+
+    def child_digests(self, key: digest.Digest) -> set[digest.Digest]:
+        """Return the set of digests directly referenced by the entry at *key*.
+
+        Raises:
+            KeyError: if *key* is not present in the storage.
+        """
+        ...
+
+
 @dataclass(frozen=True)
 class DestructuringMixin(base.ValueStorage):
     """Mixin that recursively destructures collections on save/load.
@@ -294,7 +313,7 @@ class DestructuringMixin(base.ValueStorage):
             case _:
                 return set()
 
-    def sub_digests(self, key: digest.Digest | str) -> set[digest.Digest]:
+    def child_digests(self, key: digest.Digest | str) -> set[digest.Digest]:
         """Direct digest children of the raw entry stored at *key*.
 
         Bypasses :meth:`mend`, so destructured sub-references are returned as

--- a/tests/unit/caches/test_gc.py
+++ b/tests/unit/caches/test_gc.py
@@ -6,177 +6,136 @@ import pytest
 
 from fleche.call import Call
 from fleche.caches import Cache
-from fleche.digest import Digest, digest
-from fleche.storage import ValueVoid, CallVoid
-from fleche.storage.memory import CallMemory, ValueMemory
+from fleche.digest import digest
+from fleche.storage.base import ValueMixin
+from fleche.storage.memory import CallMemory, MemoryBackend, ValueMemory
 
 
-def _make_cache() -> Cache:
-    return Cache(values=ValueMemory({}), calls=CallMemory({}))
+@dataclass(frozen=True)
+class FlatValueMemory(ValueMixin, MemoryBackend):
+    """Memory-backed value storage without destructuring.
+
+    Stores values opaquely — no ``DestructuringMixin``, so it does not satisfy
+    :class:`fleche.storage.destructuring.HasChildDigests`.  Used to exercise
+    the GC path that walks only direct call references.
+    """
 
 
-def test_gc_empty_cache_is_noop():
-    c = _make_cache()
-    assert c.gc() == set()
+@pytest.fixture(params=["destructuring", "flat"])
+def gc_cache(request):
+    """A fresh in-memory Cache, parametrised over destructuring vs flat values."""
+    if request.param == "destructuring":
+        return Cache(values=ValueMemory({}), calls=CallMemory({}))
+    return Cache(values=FlatValueMemory({}), calls=CallMemory({}))
 
 
-def test_gc_retains_values_referenced_by_calls():
-    c = _make_cache()
+def test_gc_empty_cache_is_noop(gc_cache):
+    assert gc_cache.gc() == set()
+
+
+def test_gc_retains_values_referenced_by_calls(gc_cache):
     call = Call(name="f", arguments={"x": 1}, result=2)
-    key = c.save(call)
+    key = gc_cache.save(call)
 
-    evicted = c.gc()
+    evicted = gc_cache.gc()
 
     assert evicted == set()
-    assert c.contains(key)
-    loaded = c.load(key)
+    assert gc_cache.contains(key)
+    loaded = gc_cache.load(key)
     assert loaded.arguments["x"] == 1
     assert loaded.result == 2
 
 
-def test_gc_evicts_orphan_value():
-    c = _make_cache()
-    orphan_key = c.values.save("nobody references me")
-    assert orphan_key in c.values.list()
+def test_gc_evicts_orphan_value(gc_cache):
+    orphan_key = gc_cache.values.save("nobody references me")
+    assert orphan_key in gc_cache.values.list()
 
-    evicted = c.gc()
+    evicted = gc_cache.gc()
 
     assert evicted == {orphan_key}
-    assert orphan_key not in c.values.list()
+    assert orphan_key not in gc_cache.values.list()
 
 
-def test_gc_keeps_destructured_subtree():
+def test_gc_preserves_call_records(gc_cache):
+    call_a = Call(name="a", arguments={"x": 1}, result=2)
+    call_b = Call(name="b", arguments={"y": [3, 4]}, result=5)
+    key_a = gc_cache.save(call_a)
+    key_b = gc_cache.save(call_b)
+    # Add an orphan value for good measure.
+    gc_cache.values.save("orphan")
+
+    gc_cache.gc()
+
+    assert gc_cache.contains(key_a)
+    assert gc_cache.contains(key_b)
+
+
+def test_gc_returns_evicted_keys(gc_cache):
+    gc_cache.save(Call(name="f", arguments={"x": 1}, result=None))
+
+    orphan_a = gc_cache.values.save("orphan-a")
+    orphan_b = gc_cache.values.save("orphan-b")
+
+    evicted = gc_cache.gc()
+
+    assert evicted == {orphan_a, orphan_b}
+
+
+# ---- Tests below exercise destructuring-specific reachability behaviour ----
+
+
+def test_gc_keeps_destructured_subtree(clean_cache):
     """A call referencing a nested list must keep every key in its subtree."""
-    c = _make_cache()
     call = Call(name="f", arguments={"xs": [1, [2, 3]]}, result=[4, 5])
-    c.save(call)
+    clean_cache.save(call)
 
-    keys_before = set(c.values.list())
-    evicted = c.gc()
+    keys_before = set(clean_cache.values.list())
+    evicted = clean_cache.gc()
 
     assert evicted == set(), (
         "GC should retain the root and every transitive destructured sub-key. "
         f"Evicted: {evicted}; before: {keys_before}"
     )
-    assert set(c.values.list()) == keys_before
+    assert set(clean_cache.values.list()) == keys_before
 
 
-def test_gc_keeps_shared_subtree_referenced_by_one_call():
+def test_gc_keeps_shared_subtree_referenced_by_one_call(clean_cache):
     """A leaf shared between two structures stays alive if any parent is reachable."""
-    c = _make_cache()
     shared = [2, 3]
     call = Call(name="f", arguments={"xs": [1, shared]}, result=None)
-    c.save(call)
+    clean_cache.save(call)
 
     # Save another structure directly referencing `shared`, then orphan it
     # (no call points to it).  The shared subtree is still referenced by the
     # live call, so GC must keep it.
-    other_key = c.values.save([4, shared])
-    assert other_key in c.values.list()
+    other_key = clean_cache.values.save([4, shared])
+    assert other_key in clean_cache.values.list()
 
-    evicted = c.gc()
+    evicted = clean_cache.gc()
 
     assert other_key in evicted, "Orphaned top-level container should be evicted"
     # The shared [2, 3] leaf and its scalar children must survive
     shared_key = digest([2, 3])
-    assert shared_key in c.values.list()
-    assert digest(2) in c.values.list()
-    assert digest(3) in c.values.list()
+    assert shared_key in clean_cache.values.list()
+    assert digest(2) in clean_cache.values.list()
+    assert digest(3) in clean_cache.values.list()
 
 
-def test_gc_evicts_deeply_unreachable_structure():
+def test_gc_evicts_deeply_unreachable_structure(clean_cache):
     """A whole orphan tree — root and every descendant — should be swept."""
-    c = _make_cache()
     # Seed a reachable call so the cache isn't entirely empty.
-    c.save(Call(name="live", arguments={"x": 42}, result=0))
-    reachable_before = set(c.values.list())
+    clean_cache.save(Call(name="live", arguments={"x": 42}, result=0))
+    reachable_before = set(clean_cache.values.list())
 
-    orphan_root = c.values.save([[10, 20], [30, 40]])
+    orphan_root = clean_cache.values.save([[10, 20], [30, 40]])
     orphan_leaf_only = digest(10)
-    assert orphan_root in c.values.list()
-    assert orphan_leaf_only in c.values.list()
+    assert orphan_root in clean_cache.values.list()
+    assert orphan_leaf_only in clean_cache.values.list()
 
-    evicted = c.gc()
+    evicted = clean_cache.gc()
 
     # Everything that was only reachable from `orphan_root` is gone.
     assert orphan_root in evicted
     assert orphan_leaf_only in evicted
     # Previously-live keys still present.
-    assert reachable_before.issubset(set(c.values.list()))
-
-
-def test_gc_preserves_call_records():
-    c = _make_cache()
-    call_a = Call(name="a", arguments={"x": 1}, result=2)
-    call_b = Call(name="b", arguments={"y": [3, 4]}, result=5)
-    key_a = c.save(call_a)
-    key_b = c.save(call_b)
-    # Add an orphan value for good measure.
-    c.values.save("orphan")
-
-    c.gc()
-
-    assert c.contains(key_a)
-    assert c.contains(key_b)
-
-
-def test_gc_on_non_destructuring_value_storage():
-    """Value storages without child_digests() (e.g. ValueVoid) are handled gracefully."""
-
-    @dataclass(frozen=True)
-    class _Stub:
-        """Minimal ValueStorage-ish stand-in: list + evict + no child_digests."""
-
-        _store: dict
-
-        def list(self):
-            return tuple(self._store.keys())
-
-        def save(self, value, key=None):
-            k = Digest(digest(value)) if key is None else key
-            self._store[k] = value
-            return k
-
-        def load(self, key):
-            return self._store[key]
-
-        def evict(self, key):
-            self._store.pop(Digest(key), None)
-
-        def contains(self, key):
-            return Digest(key) in self._store
-
-        def expand(self, key):
-            return Digest(key)
-
-        def shrink(self, key):
-            return Digest(key)
-
-    store = _Stub(_store={})
-    c = Cache(values=store, calls=CallMemory({}))
-
-    # Two directly-referenced values + one orphan.
-    ref_key = store.save("referenced")
-    orphan_key = store.save("orphan")
-    from fleche.call import DigestedCall
-
-    c.calls.save(
-        DigestedCall(name="f", arguments={"x": ref_key}, result=None)
-    )
-
-    evicted = c.gc()
-
-    assert evicted == {orphan_key}
-    assert ref_key in store.list()
-
-
-def test_gc_returns_evicted_keys():
-    c = _make_cache()
-    c.save(Call(name="f", arguments={"x": 1}, result=None))
-
-    orphan_a = c.values.save("orphan-a")
-    orphan_b = c.values.save("orphan-b")
-
-    evicted = c.gc()
-
-    assert evicted == {orphan_a, orphan_b}
+    assert reachable_before.issubset(set(clean_cache.values.list()))

--- a/tests/unit/caches/test_gc.py
+++ b/tests/unit/caches/test_gc.py
@@ -121,11 +121,11 @@ def test_gc_preserves_call_records():
 
 
 def test_gc_on_non_destructuring_value_storage():
-    """Value storages without sub_digests() (e.g. ValueVoid) are handled gracefully."""
+    """Value storages without child_digests() (e.g. ValueVoid) are handled gracefully."""
 
     @dataclass(frozen=True)
     class _Stub:
-        """Minimal ValueStorage-ish stand-in: list + evict + no sub_digests."""
+        """Minimal ValueStorage-ish stand-in: list + evict + no child_digests."""
 
         _store: dict
 

--- a/tests/unit/caches/test_gc.py
+++ b/tests/unit/caches/test_gc.py
@@ -1,0 +1,182 @@
+"""Tests for Cache.gc() — brute-force reachability-based value eviction."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from fleche.call import Call
+from fleche.caches import Cache
+from fleche.digest import Digest, digest
+from fleche.storage import ValueVoid, CallVoid
+from fleche.storage.memory import CallMemory, ValueMemory
+
+
+def _make_cache() -> Cache:
+    return Cache(values=ValueMemory({}), calls=CallMemory({}))
+
+
+def test_gc_empty_cache_is_noop():
+    c = _make_cache()
+    assert c.gc() == set()
+
+
+def test_gc_retains_values_referenced_by_calls():
+    c = _make_cache()
+    call = Call(name="f", arguments={"x": 1}, result=2)
+    key = c.save(call)
+
+    evicted = c.gc()
+
+    assert evicted == set()
+    assert c.contains(key)
+    loaded = c.load(key)
+    assert loaded.arguments["x"] == 1
+    assert loaded.result == 2
+
+
+def test_gc_evicts_orphan_value():
+    c = _make_cache()
+    orphan_key = c.values.save("nobody references me")
+    assert orphan_key in c.values.list()
+
+    evicted = c.gc()
+
+    assert evicted == {orphan_key}
+    assert orphan_key not in c.values.list()
+
+
+def test_gc_keeps_destructured_subtree():
+    """A call referencing a nested list must keep every key in its subtree."""
+    c = _make_cache()
+    call = Call(name="f", arguments={"xs": [1, [2, 3]]}, result=[4, 5])
+    c.save(call)
+
+    keys_before = set(c.values.list())
+    evicted = c.gc()
+
+    assert evicted == set(), (
+        "GC should retain the root and every transitive destructured sub-key. "
+        f"Evicted: {evicted}; before: {keys_before}"
+    )
+    assert set(c.values.list()) == keys_before
+
+
+def test_gc_keeps_shared_subtree_referenced_by_one_call():
+    """A leaf shared between two structures stays alive if any parent is reachable."""
+    c = _make_cache()
+    shared = [2, 3]
+    call = Call(name="f", arguments={"xs": [1, shared]}, result=None)
+    c.save(call)
+
+    # Save another structure directly referencing `shared`, then orphan it
+    # (no call points to it).  The shared subtree is still referenced by the
+    # live call, so GC must keep it.
+    other_key = c.values.save([4, shared])
+    assert other_key in c.values.list()
+
+    evicted = c.gc()
+
+    assert other_key in evicted, "Orphaned top-level container should be evicted"
+    # The shared [2, 3] leaf and its scalar children must survive
+    shared_key = digest([2, 3])
+    assert shared_key in c.values.list()
+    assert digest(2) in c.values.list()
+    assert digest(3) in c.values.list()
+
+
+def test_gc_evicts_deeply_unreachable_structure():
+    """A whole orphan tree — root and every descendant — should be swept."""
+    c = _make_cache()
+    # Seed a reachable call so the cache isn't entirely empty.
+    c.save(Call(name="live", arguments={"x": 42}, result=0))
+    reachable_before = set(c.values.list())
+
+    orphan_root = c.values.save([[10, 20], [30, 40]])
+    orphan_leaf_only = digest(10)
+    assert orphan_root in c.values.list()
+    assert orphan_leaf_only in c.values.list()
+
+    evicted = c.gc()
+
+    # Everything that was only reachable from `orphan_root` is gone.
+    assert orphan_root in evicted
+    assert orphan_leaf_only in evicted
+    # Previously-live keys still present.
+    assert reachable_before.issubset(set(c.values.list()))
+
+
+def test_gc_preserves_call_records():
+    c = _make_cache()
+    call_a = Call(name="a", arguments={"x": 1}, result=2)
+    call_b = Call(name="b", arguments={"y": [3, 4]}, result=5)
+    key_a = c.save(call_a)
+    key_b = c.save(call_b)
+    # Add an orphan value for good measure.
+    c.values.save("orphan")
+
+    c.gc()
+
+    assert c.contains(key_a)
+    assert c.contains(key_b)
+
+
+def test_gc_on_non_destructuring_value_storage():
+    """Value storages without sub_digests() (e.g. ValueVoid) are handled gracefully."""
+
+    @dataclass(frozen=True)
+    class _Stub:
+        """Minimal ValueStorage-ish stand-in: list + evict + no sub_digests."""
+
+        _store: dict
+
+        def list(self):
+            return tuple(self._store.keys())
+
+        def save(self, value, key=None):
+            k = Digest(digest(value)) if key is None else key
+            self._store[k] = value
+            return k
+
+        def load(self, key):
+            return self._store[key]
+
+        def evict(self, key):
+            self._store.pop(Digest(key), None)
+
+        def contains(self, key):
+            return Digest(key) in self._store
+
+        def expand(self, key):
+            return Digest(key)
+
+        def shrink(self, key):
+            return Digest(key)
+
+    store = _Stub(_store={})
+    c = Cache(values=store, calls=CallMemory({}))
+
+    # Two directly-referenced values + one orphan.
+    ref_key = store.save("referenced")
+    orphan_key = store.save("orphan")
+    from fleche.call import DigestedCall
+
+    c.calls.save(
+        DigestedCall(name="f", arguments={"x": ref_key}, result=None)
+    )
+
+    evicted = c.gc()
+
+    assert evicted == {orphan_key}
+    assert ref_key in store.list()
+
+
+def test_gc_returns_evicted_keys():
+    c = _make_cache()
+    c.save(Call(name="f", arguments={"x": 1}, result=None))
+
+    orphan_a = c.values.save("orphan-a")
+    orphan_b = c.values.save("orphan-b")
+
+    evicted = c.gc()
+
+    assert evicted == {orphan_a, orphan_b}


### PR DESCRIPTION
Baseline brute-force mark-and-sweep: scans every DigestedCall in call storage, collects the set of value digests referenced by arguments and result, then transitively follows destructured sub-references (DigestedIterable/DigestedDict/DigestedDataclass) until the frontier drains. Any value key not in the reachable set is evicted; call records are untouched.

To walk the reference graph without mending, factored the wrapper- matching logic out of DestructuringMixin.count_reuses into a new sub_digests(key) helper that returns the direct digest children of a raw entry. Value storages without this helper (e.g. ValueVoid) fall back to direct-reference reachability only.

https://claude.ai/code/session_01QJ4a61zNH95zyfJen4PzwB