### PR TITLE
docs(query): use QueryCall instead of Call in manual template example

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -42,12 +42,12 @@ Notes:
 - You can combine multiple metadata keys under a name (AND logic), e.g. ``{"tags": {"project": "alpha", "phase": "train"}}``.
 
 
-Querying with a Call template
------------------------------
-You can also construct a Call template manually and query against the active cache::
+Querying with a QueryCall template
+-----------------------------------
+You can also construct a ``QueryCall`` template manually and query against the active cache::
 
-    from fleche.call import Call
-    tpl = Call(
+    from fleche.call import QueryCall
+    tpl = QueryCall(
         name="add",             # or None for wildcard
         arguments={"a": None},  # key present wildcard for argument 'a'
         metadata={"tags": {"project": "alpha"}},


### PR DESCRIPTION
## Summary

`docs/query.rst` showed a "Querying with a Call template" example that used the `Call` class to construct a query template and passed it to `cache().query()`. This raises an `AttributeError` at runtime:

```
AttributeError: 'Call' object has no attribute 'matches'
```

`cache().query()` internally calls `template.matches()` on each stored call, which is only defined on `QueryCall`, not `Call`.

## What changed

- Replaced `from fleche.call import Call` with `from fleche.call import QueryCall`
- Replaced `Call(...)` with `QueryCall(...)` in the template construction
- Renamed the section heading from "Querying with a Call template" to "Querying with a QueryCall template" to make the type explicit

## Verification

```python
from fleche import fleche, cache, tags
from fleche.call import QueryCall

@fleche
def add(a, b):
    return a + b

with tags(project='alpha'):
    add(1, 2)

tpl = QueryCall(name="add", arguments={"a": None},
                metadata={"tags": {"project": "alpha"}},
                module=None, version=None, result=None)
for c in cache().query(tpl):
    print(c.name, dict(c.arguments))
# → add {'a': 1, 'b': 2}
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr887nE1wvfEEC2j7V932o)_