### PR TITLE
docs(helpers): fix decorated-method example to use a hashable class

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -64,16 +64,28 @@ Usage with Decorated Methods
    ``obj.method.query`` returns the same unbound helper as ``MyClass.method.query`` — Python's
    descriptor protocol does not propagate through attribute lookups on bound methods.
 
-   You must pass the instance explicitly as the first positional argument:
+   You must pass the instance explicitly as the first positional argument.
+
+   For ``fleche`` to cache calls that include ``self``, the class must be hashable —
+   i.e. it must implement a ``__digest__`` method (see :doc:`custom_digests`).
 
    .. code-block:: python
 
+      from fleche import fleche
+      from fleche.digest import digest, Digest
+
       class MyClass:
+          def __init__(self, id: int):
+              self.id = id
+
+          def __digest__(self) -> Digest:
+              return digest((type(self).__name__, self.id))
+
           @fleche
           def compute(self, x):
-              ...
+              return x ** 2
 
-      obj = MyClass()
+      obj = MyClass(id=1)
 
       # Correct — pass self explicitly
       obj.compute.query(obj, x=5)


### PR DESCRIPTION
## Summary

The "Usage with Decorated Methods" note in `docs/helpers.rst` contained a code example with a bare `MyClass` that had no `__digest__` method. Calling `obj.compute.digest(obj, x=5)` or `obj.compute.contains(obj, x=5)` therefore raised `fleche.digest.Unhashable` at runtime, because `fleche` cannot build a cache key containing an unhashable `self`.

Only `obj.compute.query(...)` happened to "work" (returning an empty list with a logged warning) because `Unhashable` is swallowed inside `_safe_iter`. The other two helpers fail loudly.

## Root cause

`obj.compute.digest(obj, x=5)` calls `_digest_func(obj, x=5)` → `get_call(obj, x=5).to_lookup_key()` → `digest.digest(Call(..., arguments={"self": obj, "x": 5}, ...))` → tries to digest `obj` → raises `Unhashable`.

## What changed

- Added `__init__` and `__digest__` to `MyClass` so the example class is hashable.
- Added a note that the instance class must implement `__digest__` for caching to work, with a cross-reference to `:doc:custom_digests`.
- Filled in a concrete method body (`return x ** 2`) so the example is self-contained.

## Verification

```python
from fleche import fleche
from fleche.digest import digest, Digest

class MyClass:
    def __init__(self, id: int):
        self.id = id
    def __digest__(self) -> Digest:
        return digest((type(self).__name__, self.id))
    @fleche
    def compute(self, x):
        return x ** 2

obj = MyClass(id=1)
obj.compute(x=5)                              # populate cache (self auto-bound)

print(obj.compute.digest(obj, x=5))          # ✓ returns cache key
print(obj.compute.contains(obj, x=5))        # ✓ True
print(list(obj.compute.query(obj, x=5)))     # ✓ [<LazyCall ...>]
print(list(obj.compute.query(self=obj, x=5)))# ✓ [<LazyCall ...>]
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr887nE1wvfEEC2j7V932o)_