### PR TITLE
docs(README): correct SQL storage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ def my_function(x):
 
 ### SQL Storage
 - Requires `sqlalchemy`
-- Stores metadata and results in database
-- Currently supports SQLite
-- Query capabilities for cached results
+- **Call storage only** — stores call records (function name, arguments, metadata) in a SQL database; a separate value backend (file or memory) is still required for results
+- SQLite is the primary tested backend; any SQLAlchemy-supported database should work
+- Enables efficient server-side filtering when querying cached calls
 
 ### In-Memory Storage
 - For testing or temporary caching


### PR DESCRIPTION
## Summary

The `README.md` SQL Storage section contained two factual errors:

1. **"Stores metadata and results in database"** — wrong on both counts.  The `Sql` backend is **call storage only**.  It stores call records (function name, arguments, metadata digests) but cannot store result values.  A separate value backend (file or memory) is always required alongside `Sql`.  This is clearly stated in `docs/configuration.rst` and enforced in `config.py`:
   ```python
   case "sql" if type == "call":
       return storage.Sql(**d)
   # "sql" with type == "value" falls through to ValueError
   ```

2. **"Currently supports SQLite"** — misleading.  The backend uses SQLAlchemy, so any SQLAlchemy-supported database should work.  SQLite is the only database shown in documentation examples and is the primary tested backend, but the code has no SQLite-only hard requirement.

## What changed

Replaced the three old bullet points with accurate ones:
- Clarify call-storage-only status and that a value backend is still needed.
- Note SQLite as primary tested backend while acknowledging SQLAlchemy generality.
- Replace "Query capabilities for cached results" with a note on server-side filtering, which is the actual SQL-specific advantage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr887nE1wvfEEC2j7V932o)_