### PR TITLE
Skip get_hooks() allocation when no hooks are registered

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -149,9 +149,13 @@ def _digest(value: Any) -> Digest:
     """
     m = hashlib.sha256()
 
-    for h in get_hooks():
-        if isinstance(value, h.type):
-            return h.digest(value)
+    # Fast-path: in the common case both hook lists are empty, so skip the
+    # ``get_hooks()`` call which would otherwise allocate a fresh combined list
+    # on every recursive ``_digest`` invocation (hot for large iterables).
+    if _HOOKS or _EP_HOOKS:
+        for h in get_hooks():
+            if isinstance(value, h.type):
+                return h.digest(value)
 
     m.update(type(value).__name__.encode())
     match value:


### PR DESCRIPTION
cProfile on the digest benchmark showed get_hooks() consuming ~6.5%
of total time digesting a list of 100 lists of 100+ ints, because every
recursive _digest() call allocates a fresh combined list even when both
hook lists are empty (the common case).

Gating the hook scan behind a truthy check on _HOOKS/_EP_HOOKS leaves
get_hooks() semantics unchanged (tests still mutate _HOOKS directly and
expect get_hooks() to reflect them) but avoids the allocation entirely
on the hot path.

Benchmark deltas (benchmark_digest.py, median of 3 repeats):

  Integer:                 150 us -> 126 us  (-16%)
  String (len<100):        142 us -> 118 us  (-17%)
  Float:                   264 us -> 217 us  (-18%)
  List (integers, len<100): 1.05 ms -> 0.90 ms (-14%)
  List (integers, len>100): 27.2 ms -> 22.5 ms (-17%)
  Dict (small):            1.66 ms -> 1.37 ms (-17%)
  Nested (Random):         1.99 ms -> 1.58 ms (-21%)

All 877 unit tests still pass.