### PR TITLE
Drop redundant contains/evict pre-check in Sql.save (-20% to -51%)

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -283,8 +283,13 @@ class Sql(PerKeyLockMixin, CallStorage):
         key = call.to_lookup_key()
         with self._operation_context(key):
             logger.debug("Saving call %s", key)
-            if self.contains(key):
-                self.evict(key)
+            # ``put`` already runs a SELECT for the existing row and handles
+            # the overwrite-vs-no-op decision in a single transaction, so the
+            # earlier ``contains`` / ``evict`` pre-check was a redundant SELECT
+            # plus an extra DELETE+COMMIT round-trip on collisions.  Per-key
+            # locking via ``PerKeyLockMixin`` keeps concurrent saves serialised,
+            # so the simplification preserves the regression-tested behaviour
+            # (see ``test_sql_concurrent_save.py``).
             return self.put(call, key)
 
     def load(self, key: Digest | str) -> DigestedCall:


### PR DESCRIPTION
## Summary

Implements the fix proposed in [#431 (comment)](https://github.com/pmrv/fleche/pull/431#issuecomment-4330315277).

`Sql.save` was running:

```python
if self.contains(key):     # SELECT
    self.evict(key)         # SELECT + DELETE + COMMIT (separate transaction)
return self.put(call, key)  # SELECT + INSERTs + COMMIT
```

`put()` already does its own `session.get(CallModel, key)` and handles
the overwrite-vs-no-op case in a single transaction, so the
`contains` / `evict` pre-check was at best one **redundant SELECT** (new-key
path) and at worst an entire **DELETE+COMMIT round-trip in a separate
transaction** (overwrite path).

Per-key locking via `PerKeyLockMixin` still serialises concurrent saves
of the same key, so `test_sql_concurrent_save.py`'s 8-thread race over
3 keys keeps passing without the pre-check.

## Microbench (`sqlite:///:memory:`, in-process)

| workload | before | after | Δ |
|---|---|---|---|
| new-key save (each call has unique key) | 1349 µs | 1073 µs | **−20 %** |
| overwrite save (same key, repeated) | 2738 µs | 1342 µs | **−51 %** |

The new-key path saves the redundant `contains` SELECT.  The overwrite
path additionally saves the separate DELETE + COMMIT round-trip
(`evict` had its own commit; now everything happens in `put`'s single
transaction).

## What did **not** make this PR

The original triage suggested also using `INSERT OR IGNORE` /
`ON CONFLICT DO NOTHING` to skip the `session.get` inside `put`.  That
turns out to be trickier than it looks:

- `put` currently compares the loaded existing row against the incoming
  call (`self.get(key) == call`) and only deletes-and-reinserts when
  they differ.  Since `to_lookup_key()` excludes `result` and
  `metadata`, two saves with the same key can legitimately differ on
  those fields, so we can't just trust `ON CONFLICT DO NOTHING` to
  preserve correctness — that would silently keep stale results.
- Doing it correctly would require either (a) a comparison query that
  fits in SQL, or (b) accepting that overwrite-with-different-result
  silently no-ops.  Both deserve a separate, deliberate change.

## Test plan

- [x] `pytest tests/unit/ tests/regression/` — 885 passed
- [x] `tests/regression/test_sql_concurrent_save.py` — passes (8 threads, 3 colliding keys, 24 saves)
- [x] `tests/regression/test_sql_table_uniqueness.py` — passes
- [x] `tests/integration/test_integration.py` — passes

## Risk

Low.  The pre-check was redundant by construction: `put`'s
SELECT-and-overwrite logic is the actual implementation.  Per-key
locking unchanged, so concurrency semantics unchanged.  The
microbenchmark improvements are entirely from removing duplicated work,
not from semantic shortcuts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvAnFkvRZvJRTrQbZk4aH1)_