### PR TITLE
Add cross-dialect SQL backend support for Postgres and MySQL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,3 +47,58 @@ jobs:
       shell: bash -l {0}
       run: |
         pytest
+
+  sql-backends:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: fleche
+          POSTGRES_PASSWORD: fleche
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U fleche"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: fleche
+          MARIADB_DATABASE: mysql
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      FLECHE_TEST_POSTGRES_URL: postgresql+psycopg2://fleche:fleche@localhost:5432/postgres
+      FLECHE_TEST_MYSQL_URL: mysql+pymysql://root:fleche@localhost:3306/mysql
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+        cache: pip
+    - name: Setup
+      shell: bash -l {0}
+      run: |
+        pip install -e .[tests]
+        # Drivers needed for the non-sqlite backends. Kept out of the project
+        # extras so they're a CI-only dependency.
+        pip install psycopg2-binary pymysql
+    - name: Run sqlalchemy backend tests
+      shell: bash -l {0}
+      run: |
+        # Run the cross-backend conformance tests plus every test that uses
+        # the parametrized call_storage fixture. The env vars cause the
+        # ``sql_postgres`` / ``sql_mysql`` parametrizations to activate.
+        pytest tests/regression/test_sql_non_sqlite_backends.py tests/unit/storage/ -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,12 @@ Only pickle-family backends are signed. Key rotation: first key in the list sign
 
 - `unit/` — one subdirectory per module under test (`caches/`, `call/`, `config/`, `digest/`, `fleche/`, `metadata/`, `storage/`); filenames mirror the feature being tested. Two top-level files: `test_cache_sticky.py` (sticky `cache()` context semantics) and `test_pickle.py` (pickling caches/wrappers).
 - `integration/` — `test_integration.py` (main), `test_notebooks.py` (exercises `notebooks/`), `test_parallel_execution.py`, `test_methods.py`, `test_wrapper_query_integration.py`, `test_hash_code_integration.py`.
-- `regression/` — `test_issue_{297,319,352}.py`, `test_sql_concurrent_save.py`, `test_sql_table_uniqueness.py`.
+- `regression/` — `test_issue_{297,319,352}.py`, `test_sql_concurrent_save.py`, `test_sql_table_uniqueness.py`, `test_sql_non_sqlite_backends.py`.
 
 Shared fixtures (in `fixtures.py`):
 - `call_storage` / `value_storage` / `storage_backend` — *parametrised* over every concrete backend (memory, pickle/cloudpickle/dill files, bagofholding h5, plus sql for calls only). The pickle-family fixtures use a fixed `secret_key` so signing is exercised by default. New backends should be added to these fixtures so they're swept by every consumer test.
+- `call_storage` additionally gains `sql_postgres` / `sql_mysql` parametrizations when `FLECHE_TEST_POSTGRES_URL` / `FLECHE_TEST_MYSQL_URL` are set; each yields an `Sql` backed by a freshly-created database that is dropped on teardown. CI populates these env vars from the `postgres` / `mariadb` service containers in `.github/workflows/tests.yml` (`sql-backends` job).
+- `postgres_sql` / `mysql_sql` — single-shot variants of the above (skip when the URL env var is unset). Use these in tests targeting dialect-specific concerns rather than a cross-backend sweep; the cross-backend `external_sql` fixture in `regression/test_sql_non_sqlite_backends.py` parametrizes over both lazily via `request.getfixturevalue` (declaring both as direct dependencies cascades the unconfigured-side skip onto every test).
 - `clean_cache` — yields a fresh in-memory `Cache(ValueMemory, CallMemory)` (does **not** install it as the active cache; use `with cache(clean_cache):` if you need that).
 - `file_cache` — disk-backed pickle `Cache` rooted at `tmp_path`.
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -1,0 +1,107 @@
+Developer Guide
+===============
+
+This page collects notes that aren't relevant to end users of ``fleche`` but
+are useful when hacking on the library itself.
+
+.. _testing-non-sqlite-backends:
+
+Testing the SQL backend on non-sqlite dialects
+----------------------------------------------
+
+The ``Sql`` :class:`~fleche.storage.sql.Sql` ``CallStorage`` is implemented on
+top of SQLAlchemy and is portable to any dialect SQLAlchemy supports. By
+default the test suite only exercises the sqlite path, because that is the
+only backend with no out-of-process dependencies. The cross-dialect tests are
+opt-in: they activate when a connection URL is supplied via environment
+variable, and skip silently otherwise.
+
+Two environment variables are recognised:
+
+============================== ====================================================
+Variable                       Example value
+============================== ====================================================
+``FLECHE_TEST_POSTGRES_URL``   ``postgresql+psycopg2://fleche:fleche@localhost:5432/postgres``
+``FLECHE_TEST_MYSQL_URL``      ``mysql+pymysql://fleche:fleche@localhost:3306/mysql``
+============================== ====================================================
+
+The URL must point at a server (the database part of the URL is the
+*administrative* database used to mint per-test databases — typically
+``postgres`` for PostgreSQL, ``mysql`` for MySQL/MariaDB). The connecting role
+needs ``CREATE DATABASE`` privilege.
+
+When set, the test session:
+
+1. Adds ``sql_postgres`` / ``sql_mysql`` parametrizations to the shared
+   ``call_storage`` fixture, so any test consuming that fixture (e.g. the
+   pickle round-trip suite) sweeps over the new backends as well.
+2. Activates the ``postgres_sql`` / ``mysql_sql`` single-shot fixtures and the
+   parametrized ``external_sql`` fixture used by
+   ``tests/regression/test_sql_non_sqlite_backends.py`` for backend-targeted
+   regression tests.
+
+Each test gets a freshly created, uniquely named database that is dropped on
+teardown — so concurrent tests don't share schema state and there's nothing
+to clean up after a test crash beyond the next ``DROP DATABASE`` attempt.
+
+Running locally
+~~~~~~~~~~~~~~~
+
+A typical local cycle against PostgreSQL looks like:
+
+.. code-block:: bash
+
+   # Once: create a role with CREATE DATABASE privilege.
+   sudo -u postgres psql -c \
+       "CREATE USER fleche WITH PASSWORD 'fleche' CREATEDB;"
+
+   # Per session: point the suite at the running server.
+   export FLECHE_TEST_POSTGRES_URL=postgresql+psycopg2://fleche:fleche@localhost:5432/postgres
+   pip install psycopg2-binary
+
+   pytest tests/regression/test_sql_non_sqlite_backends.py
+   # ... or sweep every consumer of call_storage:
+   pytest tests/
+
+For MariaDB / MySQL the workflow is symmetric:
+
+.. code-block:: bash
+
+   sudo mysql -e \
+       "CREATE USER 'fleche'@'localhost' IDENTIFIED BY 'fleche';
+        GRANT ALL PRIVILEGES ON *.* TO 'fleche'@'localhost' WITH GRANT OPTION;"
+
+   export FLECHE_TEST_MYSQL_URL=mysql+pymysql://fleche:fleche@localhost:3306/mysql
+   pip install pymysql
+
+   pytest tests/regression/test_sql_non_sqlite_backends.py
+
+Continuous integration
+~~~~~~~~~~~~~~~~~~~~~~
+
+The ``sql-backends`` job in ``.github/workflows/tests.yml`` provisions
+``postgres:16`` and ``mariadb:11`` service containers, exports the
+corresponding env vars, and installs the dialect drivers (``psycopg2-binary``,
+``pymysql``) before invoking ``pytest``. The drivers are kept out of the
+project's ``[tests]`` extra on purpose — they are only needed by maintainers
+running the cross-dialect suite, not by end users.
+
+Adding a new SQL dialect
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The fixture machinery in ``tests/fixtures.py`` is small enough to extend
+in-place:
+
+1. Pick a new env var name and a new param identifier.
+2. Add a branch to ``_admin_url`` if the dialect requires connecting to a
+   specific administrative database (Postgres needs ``postgres``).
+3. If the dialect's identifier quoting differs further from the
+   ``identifier_preparer`` defaults, special-case it; otherwise the existing
+   ``CREATE DATABASE``/``DROP DATABASE`` paths will work.
+4. Append the new param to ``_call_storage_params`` so existing
+   ``call_storage`` consumers sweep it automatically.
+
+The schema in :mod:`fleche.storage.sql` already uses ``String().with_variant``
+so dialect-specific length requirements (MySQL needs ``VARCHAR`` lengths) stay
+contained to the affected dialect — no other dialect should be perturbed when
+adding a new one.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Welcome to the **Fleche** library documentation.
    query
    parallel_execution
    security
+   developer
 
 .. toctree::
    :maxdepth: 1

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -93,13 +93,24 @@ with ImportAlarm(
 
 
 def _coerce_sqlite_url(path_or_url: str | None) -> str:
+    """Normalise the user-facing ``url=`` argument.
+
+    Accepts a filesystem path (treated as sqlite), a ``sqlite:`` URL
+    (passed through, parent dir auto-created), or any other SQLAlchemy URL
+    such as ``postgresql://`` / ``mysql+pymysql://`` (passed through
+    verbatim). Only sqlite paths get the parent-dir-create convenience.
+    """
     if path_or_url is None:
         return "sqlite:///:memory:"
 
-    if isinstance(path_or_url, str) and path_or_url.startswith("sqlite:"):
-        url = path_or_url
+    s = str(path_or_url)
+
+    # Already a SQLAlchemy URL of any dialect (driver scheme contains "://"
+    # or the short ``sqlite:foo`` form). Leave it alone.
+    if "://" in s or s.startswith("sqlite:"):
+        url = s
     else:
-        abs_path = Path(str(path_or_url)).absolute()
+        abs_path = Path(s).absolute()
         url = f"sqlite:///{abs_path}"
 
     if url.startswith("sqlite:///"):
@@ -115,6 +126,11 @@ SQLITE_FOREIGN_KEYS_ON = "PRAGMA foreign_keys=ON"
 
 
 def _enable_sqlite_foreign_keys(engine) -> None:
+    # PRAGMA is sqlite-only; running it on Postgres/MySQL connections would
+    # raise at connect time, so gate the listener on the dialect.
+    if engine.dialect.name != "sqlite":
+        return
+
     @event.listens_for(engine, "connect")
     def _set_sqlite_pragma(dbapi_connection, connection_record):
         cursor = dbapi_connection.cursor()
@@ -142,7 +158,10 @@ class Sql(PerKeyLockMixin, CallStorage):
         coerced_url = _coerce_sqlite_url(self.url)
         assert coerced_url is not None
         object.__setattr__(self, "url", coerced_url)
-        connect_args = {"check_same_thread": False} if coerced_url.startswith("sqlite:") else {}
+        # ``check_same_thread=False`` is a pysqlite-only flag; passing it to
+        # any other DBAPI driver raises ``TypeError`` at connect time.
+        is_sqlite = coerced_url.startswith("sqlite:")
+        connect_args = {"check_same_thread": False} if is_sqlite else {}
         engine = create_engine(coerced_url, echo=self.echo, future=True, connect_args=connect_args)
         _enable_sqlite_foreign_keys(engine)
         Base.metadata.create_all(engine)

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -41,12 +41,19 @@ with ImportAlarm(
 
     Base = declarative_base()
 
+    # MySQL/MariaDB reject ``VARCHAR`` columns without an explicit length, so
+    # every ``String`` here is sized. 255 is the conventional MySQL upper
+    # bound for indexable VARCHARs and comfortably fits Python qualified
+    # names, function/argument names, and the JSON-encoded scalar versions
+    # we actually store.
+    _NAME_LEN = 255
+
     class CallModel(Base):
         __tablename__ = "calls"
         key = mapped_column(String(DIGEST_LENGTH), primary_key=True)
-        name: Mapped[str] = mapped_column(String, nullable=False)
-        module: Mapped[str] = mapped_column(String, nullable=True)
-        version: Mapped[str] = mapped_column(String, nullable=True)
+        name: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=False)
+        module: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=True)
+        version: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=True)
         code_digest: Mapped[str] = mapped_column(String(DIGEST_LENGTH), nullable=True)
         result: Mapped[str] = mapped_column(String(DIGEST_LENGTH), nullable=True)
 
@@ -66,7 +73,7 @@ with ImportAlarm(
             nullable=False,
         )
         position = mapped_column(Integer, nullable=False)
-        name = mapped_column(String, nullable=False)
+        name = mapped_column(String(_NAME_LEN), nullable=False)
         value = mapped_column(String(DIGEST_LENGTH), nullable=False)
 
         __table_args__ = (
@@ -84,7 +91,7 @@ with ImportAlarm(
             nullable=False,
             index=True,
         )
-        name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+        name: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=False, index=True)
         data: Mapped[dict] = mapped_column(JSON, nullable=False)
 
         __table_args__ = (

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -41,19 +41,21 @@ with ImportAlarm(
 
     Base = declarative_base()
 
-    # MySQL/MariaDB reject ``VARCHAR`` columns without an explicit length, so
-    # every ``String`` here is sized. 255 is the conventional MySQL upper
-    # bound for indexable VARCHARs and comfortably fits Python qualified
-    # names, function/argument names, and the JSON-encoded scalar versions
-    # we actually store.
+    # MySQL/MariaDB reject ``VARCHAR`` columns without an explicit length; every
+    # other dialect we support (sqlite, Postgres) treats unbounded ``String`` as
+    # ``TEXT`` and is happy. Use ``with_variant`` so the length is applied only
+    # on the MySQL family — keep ``TEXT`` for everyone else. 255 is the MySQL
+    # convention for indexable VARCHARs and easily fits Python qualified names
+    # and JSON-encoded scalar versions.
     _NAME_LEN = 255
+    _Name = String().with_variant(String(_NAME_LEN), "mysql", "mariadb")
 
     class CallModel(Base):
         __tablename__ = "calls"
         key = mapped_column(String(DIGEST_LENGTH), primary_key=True)
-        name: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=False)
-        module: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=True)
-        version: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=True)
+        name: Mapped[str] = mapped_column(_Name, nullable=False)
+        module: Mapped[str] = mapped_column(_Name, nullable=True)
+        version: Mapped[str] = mapped_column(_Name, nullable=True)
         code_digest: Mapped[str] = mapped_column(String(DIGEST_LENGTH), nullable=True)
         result: Mapped[str] = mapped_column(String(DIGEST_LENGTH), nullable=True)
 
@@ -73,7 +75,7 @@ with ImportAlarm(
             nullable=False,
         )
         position = mapped_column(Integer, nullable=False)
-        name = mapped_column(String(_NAME_LEN), nullable=False)
+        name = mapped_column(_Name, nullable=False)
         value = mapped_column(String(DIGEST_LENGTH), nullable=False)
 
         __table_args__ = (
@@ -91,7 +93,7 @@ with ImportAlarm(
             nullable=False,
             index=True,
         )
-        name: Mapped[str] = mapped_column(String(_NAME_LEN), nullable=False, index=True)
+        name: Mapped[str] = mapped_column(_Name, nullable=False, index=True)
         data: Mapped[dict] = mapped_column(JSON, nullable=False)
 
         __table_args__ = (

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -61,9 +61,13 @@ def _ephemeral_database(base_url: str):
     admin_engine = create_engine(
         admin_url, isolation_level="AUTOCOMMIT", future=True
     )
+    # Use the dialect's own identifier preparer so MySQL/MariaDB get backticks
+    # and Postgres gets double quotes — bare double quotes are a syntax error
+    # on MariaDB unless ANSI_QUOTES is enabled.
+    quoted_db = admin_engine.dialect.identifier_preparer.quote(db_name)
     try:
         with admin_engine.connect() as conn:
-            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+            conn.execute(text(f"CREATE DATABASE {quoted_db}"))
     finally:
         admin_engine.dispose()
 
@@ -74,6 +78,7 @@ def _ephemeral_database(base_url: str):
         admin_engine = create_engine(
             admin_url, isolation_level="AUTOCOMMIT", future=True
         )
+        quoted_db = admin_engine.dialect.identifier_preparer.quote(db_name)
         try:
             with admin_engine.connect() as conn:
                 if backend == "postgresql":
@@ -87,7 +92,7 @@ def _ephemeral_database(base_url: str):
                         ),
                         {"db": db_name},
                     )
-                conn.execute(text(f'DROP DATABASE "{db_name}"'))
+                conn.execute(text(f"DROP DATABASE {quoted_db}"))
         finally:
             admin_engine.dispose()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,11 @@
+import os
+import uuid
+from contextlib import contextmanager
+
 import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine.url import make_url
+
 from fleche.storage import (
     ValueMemory,
     CallMemory,
@@ -15,22 +22,125 @@ from fleche.caches import Cache
 
 secret_key = [b"test_secret_key_32_bytes_long!!!!"]
 
-@pytest.fixture(params=["memory", "cloudpickle", "dill", "pickle", "h5", "sql"])
+
+# ---------------------------------------------------------------------------
+# Non-sqlite SQLAlchemy backend support
+#
+# We don't bundle any out-of-process database; instead, the corresponding
+# fixtures activate only when a connection URL is provided via environment
+# variable, and each test gets a freshly-created database for full isolation.
+# ---------------------------------------------------------------------------
+POSTGRES_URL_ENV = "FLECHE_TEST_POSTGRES_URL"
+MYSQL_URL_ENV = "FLECHE_TEST_MYSQL_URL"
+
+
+def _admin_url(url):
+    """Return a copy of ``url`` connected to the server's admin database.
+
+    Postgres requires connecting to *some* database to run ``CREATE DATABASE``;
+    we use the conventional ``postgres`` database. MySQL/MariaDB doesn't need a
+    selected database, so we drop the database name entirely.
+    """
+    backend = url.get_backend_name()
+    if backend == "postgresql":
+        return url.set(database="postgres")
+    return url.set(database=None)
+
+
+@contextmanager
+def _ephemeral_database(base_url: str):
+    """Create a uniquely-named database for one test, then drop it.
+
+    Yields the URL string a fleche ``Sql`` backend can be pointed at.
+    """
+    url = make_url(base_url)
+    backend = url.get_backend_name()
+    db_name = f"fleche_test_{uuid.uuid4().hex}"
+
+    admin_url = _admin_url(url)
+    admin_engine = create_engine(
+        admin_url, isolation_level="AUTOCOMMIT", future=True
+    )
+    try:
+        with admin_engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    finally:
+        admin_engine.dispose()
+
+    test_url = url.set(database=db_name).render_as_string(hide_password=False)
+    try:
+        yield test_url
+    finally:
+        admin_engine = create_engine(
+            admin_url, isolation_level="AUTOCOMMIT", future=True
+        )
+        try:
+            with admin_engine.connect() as conn:
+                if backend == "postgresql":
+                    # Force-disconnect any leftover sessions or DROP DATABASE
+                    # blocks until they idle out.
+                    conn.execute(
+                        text(
+                            "SELECT pg_terminate_backend(pid) "
+                            "FROM pg_stat_activity "
+                            "WHERE datname = :db AND pid <> pg_backend_pid()"
+                        ),
+                        {"db": db_name},
+                    )
+                conn.execute(text(f'DROP DATABASE "{db_name}"'))
+        finally:
+            admin_engine.dispose()
+
+
+def _make_external_sql(env_var: str):
+    """Yield a ``Sql`` backend pointed at a fresh DB, or skip."""
+    base = os.environ.get(env_var)
+    if not base:
+        pytest.skip(f"{env_var} not set; non-sqlite SQL backend test skipped")
+    with _ephemeral_database(base) as url:
+        sql = Sql(url)
+        try:
+            yield sql
+        finally:
+            sql.engine.dispose()
+
+
+def _call_storage_params():
+    """Build the parametrization list for ``call_storage``.
+
+    Always-on backends are listed first; non-sqlite SQL backends are only
+    appended when their URL env var is set, so local default runs stay quiet.
+    """
+    params = ["memory", "cloudpickle", "dill", "pickle", "h5", "sql"]
+    if os.environ.get(POSTGRES_URL_ENV):
+        params.append("sql_postgres")
+    if os.environ.get(MYSQL_URL_ENV):
+        params.append("sql_mysql")
+    return params
+
+
+@pytest.fixture(params=_call_storage_params())
 def call_storage(request, tmp_path):
     if request.param == "memory":
-        return CallMemory({})
+        yield CallMemory({})
     elif request.param == "cloudpickle":
-        return CallPickleFile.with_cloudpickle(
+        yield CallPickleFile.with_cloudpickle(
             tmp_path / "cloudpickle", secret_key=secret_key
         )
     elif request.param == "dill":
-        return CallPickleFile.with_dill(tmp_path / "dill", secret_key=secret_key)
+        yield CallPickleFile.with_dill(tmp_path / "dill", secret_key=secret_key)
     elif request.param == "pickle":
-        return CallPickleFile.with_pickle(tmp_path / "pickle", secret_key=secret_key)
+        yield CallPickleFile.with_pickle(tmp_path / "pickle", secret_key=secret_key)
     elif request.param == "h5":
-        return CallBagOfHoldingH5File(tmp_path / "h5")
+        yield CallBagOfHoldingH5File(tmp_path / "h5")
     elif request.param == "sql":
-        return Sql(tmp_path / "calls.db")
+        yield Sql(tmp_path / "calls.db")
+    elif request.param == "sql_postgres":
+        yield from _make_external_sql(POSTGRES_URL_ENV)
+    elif request.param == "sql_mysql":
+        yield from _make_external_sql(MYSQL_URL_ENV)
+    else:
+        raise ValueError(f"Unknown call_storage param: {request.param}")
 
 
 @pytest.fixture(params=["memory", "cloudpickle", "dill", "pickle", "h5"])
@@ -60,6 +170,28 @@ def storage_backend(request, tmp_path):
         return PickleFileBackend.with_pickle(tmp_path / "pickle")
     elif request.param == "h5":
         return BagOfHoldingH5FileBackend(tmp_path / "h5")
+
+
+@pytest.fixture
+def postgres_sql():
+    """A ``Sql`` storage pointed at a freshly-created Postgres database.
+
+    Skipped unless ``FLECHE_TEST_POSTGRES_URL`` is set (e.g.
+    ``postgresql+psycopg2://user:pw@localhost:5432/postgres``). The fixture
+    creates a unique per-test database and drops it on teardown.
+    """
+    yield from _make_external_sql(POSTGRES_URL_ENV)
+
+
+@pytest.fixture
+def mysql_sql():
+    """A ``Sql`` storage pointed at a freshly-created MySQL/MariaDB database.
+
+    Skipped unless ``FLECHE_TEST_MYSQL_URL`` is set (e.g.
+    ``mysql+pymysql://user:pw@localhost:3306/mysql``). The fixture creates
+    a unique per-test database and drops it on teardown.
+    """
+    yield from _make_external_sql(MYSQL_URL_ENV)
 
 
 @pytest.fixture

--- a/tests/regression/test_sql_non_sqlite_backends.py
+++ b/tests/regression/test_sql_non_sqlite_backends.py
@@ -1,0 +1,205 @@
+"""Cross-dialect smoke + regression tests for the SQLAlchemy ``Sql`` backend.
+
+The active-by-default suite already exercises the sqlite path. This file adds
+a parametrized fixture (`external_sql`) that yields a ``Sql`` storage pointed
+at a fresh database on every supported non-sqlite backend whose connection
+URL was provided via environment variable. Tests are silently skipped when
+no URL is configured, so the file is a no-op for default local runs but
+becomes the cross-backend conformance suite under CI / when a developer
+exports e.g. ``FLECHE_TEST_POSTGRES_URL``.
+
+Why these specific assertions:
+  * URL pass-through: regression for ``_coerce_sqlite_url`` rewriting any
+    non-``sqlite:`` URL into a sqlite file path.
+  * No PRAGMA on connect: regression for ``_enable_sqlite_foreign_keys``
+    being registered unconditionally and crashing Postgres on the first
+    connection.
+  * Save / load / list / contains / evict: covers the backend's CRUD path
+    against a real driver, which sqlite-only tests cannot do.
+  * Query with metadata pushdown: exercises the JSON-extract path against
+    each dialect's native JSON column type.
+"""
+
+import pytest
+
+from fleche.call import Call, QueryCall
+from fleche.digest import Digest
+from fleche.storage.sql import Sql, _coerce_sqlite_url
+
+
+# ---------------------------------------------------------------------------
+# Fixture: parametrized over every configured non-sqlite backend
+# ---------------------------------------------------------------------------
+def _external_backends():
+    """Return the list of param names whose URL env vars are set.
+
+    Mirrors the dispatch in ``tests/fixtures.py`` so the param names line up.
+    """
+    import os
+
+    backends = []
+    if os.environ.get("FLECHE_TEST_POSTGRES_URL"):
+        backends.append("postgres")
+    if os.environ.get("FLECHE_TEST_MYSQL_URL"):
+        backends.append("mysql")
+    return backends
+
+
+@pytest.fixture(params=_external_backends() or ["__skip__"])
+def external_sql(request):
+    """A fresh ``Sql`` backend on each configured non-sqlite database.
+
+    The underlying ``postgres_sql`` / ``mysql_sql`` fixtures are themselves
+    skip-when-unset, so we resolve only the one matching the current param
+    via ``request.getfixturevalue`` — declaring both as direct dependencies
+    would let the unconfigured one's skip cascade onto every test.
+    """
+    if request.param == "__skip__":
+        pytest.skip(
+            "No non-sqlite database URL configured "
+            "(set FLECHE_TEST_POSTGRES_URL or FLECHE_TEST_MYSQL_URL)"
+        )
+    if request.param == "postgres":
+        return request.getfixturevalue("postgres_sql")
+    if request.param == "mysql":
+        return request.getfixturevalue("mysql_sql")
+    raise ValueError(f"Unknown external_sql param: {request.param}")
+
+
+# ---------------------------------------------------------------------------
+# URL pass-through (no live DB needed; runs always)
+# ---------------------------------------------------------------------------
+def test_postgres_url_passthrough():
+    """A ``postgresql://`` URL must not be rewritten as a sqlite file path.
+
+    Regression: the previous coercion treated any non-``sqlite:``-prefixed
+    string as a filesystem path, so ``postgresql://host/db`` became
+    ``sqlite:///<cwd>/postgresql:/host/db``.
+    """
+    url = "postgresql://user:pw@localhost:5432/some_db"
+    assert _coerce_sqlite_url(url) == url
+
+
+def test_mysql_url_passthrough():
+    """A ``mysql+pymysql://`` URL must be returned verbatim."""
+    url = "mysql+pymysql://user:pw@localhost:3306/some_db"
+    assert _coerce_sqlite_url(url) == url
+
+
+def test_postgres_url_passthrough_with_driver():
+    """The dialect+driver form must also pass through unchanged."""
+    url = "postgresql+psycopg2://localhost/db"
+    assert _coerce_sqlite_url(url) == url
+
+
+# ---------------------------------------------------------------------------
+# Live, dialect-aware tests
+# ---------------------------------------------------------------------------
+def test_engine_dialect_is_not_sqlite(external_sql):
+    """Sanity: the fixture wired up the right driver, not a fallback sqlite."""
+    assert external_sql.engine.dialect.name in {"postgresql", "mysql", "mariadb"}
+
+
+def test_save_load_roundtrip(external_sql):
+    """Basic CRUD — argument digests, version, code_digest, result all
+    round-trip through the non-sqlite backend.
+    """
+    call = Call(
+        name="test_func",
+        arguments={"a": Digest("a" * 64), "b": Digest("b" * 64)},
+        metadata={"runtime": {"walltime": 1.5}},
+        module="m",
+        version=42,
+        code_digest=Digest("c" * 64),
+        result=Digest("r" * 64),
+    )
+    key = external_sql.save(call)
+
+    loaded = external_sql.load(key)
+    assert loaded.to_lookup_key() == call.to_lookup_key()
+    assert loaded.name == "test_func"
+    assert loaded.version == 42
+    assert loaded.metadata == {"runtime": {"walltime": 1.5}}
+    assert str(loaded.result) == "r" * 64
+
+
+def test_contains_and_list(external_sql):
+    """``contains`` and ``list`` must reflect what was just saved."""
+    call = Call(
+        name="f",
+        arguments={"x": Digest("a" * 64)},
+        metadata={},
+        result=Digest("r" * 64),
+    )
+    key = external_sql.save(call)
+    assert external_sql.contains(key)
+    assert key in list(external_sql.list())
+
+
+def test_evict_removes_call_and_arguments(external_sql):
+    """Evicting a call must cascade to its arguments / metadata rows."""
+    call = Call(
+        name="f",
+        arguments={"x": Digest("a" * 64)},
+        metadata={"tags": {"phase": "train"}},
+        result=Digest("r" * 64),
+    )
+    key = external_sql.save(call)
+    assert external_sql.contains(key)
+    external_sql.evict(key)
+    assert not external_sql.contains(key)
+    assert key not in list(external_sql.list())
+
+
+def test_query_metadata_pushdown(external_sql):
+    """JSON metadata filters must be pushed down through each dialect's
+    native JSON column type and return the right call.
+    """
+    c1 = Call(
+        name="f1",
+        arguments={"a": Digest("a" * 64)},
+        metadata={"flags": {"ok": True, "count": 3}},
+        result=Digest("r" * 64),
+    )
+    c2 = Call(
+        name="f2",
+        arguments={"b": Digest("b" * 64)},
+        metadata={"flags": {"ok": False, "count": 7}},
+        result=Digest("s" * 64),
+    )
+    external_sql.save(c1)
+    external_sql.save(c2)
+
+    tpl = QueryCall(metadata={"flags": {"ok": True}})
+    matched = list(external_sql.query(tpl))
+    assert {c.name for c in matched} == {"f1"}
+
+
+def test_query_argument_pushdown(external_sql):
+    """Argument filters compared via ``digest()`` must work on each dialect."""
+    c1 = Call(
+        name="f", arguments={"a": Digest("a" * 64)}, metadata={}, result=None
+    )
+    c2 = Call(
+        name="f", arguments={"a": Digest("b" * 64)}, metadata={}, result=None
+    )
+    external_sql.save(c1)
+    external_sql.save(c2)
+
+    tpl = QueryCall(arguments={"a": Digest("a" * 64)})
+    matched = list(external_sql.query(tpl))
+    assert {str(c.arguments["a"]) for c in matched} == {"a" * 64}
+
+
+def test_overwrite_same_key(external_sql):
+    """Saving twice with identical content must be a no-op (no duplicates)."""
+    call = Call(
+        name="f",
+        arguments={"a": Digest("a" * 64)},
+        metadata={},
+        result=Digest("r" * 64),
+    )
+    k1 = external_sql.save(call)
+    k2 = external_sql.save(call)
+    assert k1 == k2
+    assert sum(1 for _ in external_sql.list()) == 1

--- a/tests/regression/test_sql_non_sqlite_backends.py
+++ b/tests/regression/test_sql_non_sqlite_backends.py
@@ -8,6 +8,10 @@ no URL is configured, so the file is a no-op for default local runs but
 becomes the cross-backend conformance suite under CI / when a developer
 exports e.g. ``FLECHE_TEST_POSTGRES_URL``.
 
+End-user-facing documentation for the env-var contract and the maintainer
+workflow lives in ``docs/developer.rst`` (Developer Guide → "Testing the SQL
+backend on non-sqlite dialects").
+
 Why these specific assertions:
   * URL pass-through: regression for ``_coerce_sqlite_url`` rewriting any
     non-``sqlite:`` URL into a sqlite file path.


### PR DESCRIPTION
## Summary
This PR extends the `Sql` storage backend to support Postgres and MySQL/MariaDB databases in addition to SQLite, with comprehensive cross-dialect testing and CI integration.

## Key Changes

### Core Storage Backend (`src/fleche/storage/sql.py`)
- **Fixed URL handling in `_coerce_sqlite_url()`**: Previously treated any non-`sqlite:` URL as a filesystem path, causing `postgresql://host/db` to be rewritten as `sqlite:///<cwd>/postgresql:/host/db`. Now correctly detects SQLAlchemy URLs by checking for `://` or `sqlite:` prefix and passes them through verbatim.
- **Gated SQLite-specific PRAGMA**: Added dialect check to `_enable_sqlite_foreign_keys()` to prevent `PRAGMA foreign_keys` from being registered on non-SQLite connections, which would crash on first connect.
- **Conditional connect args**: Made `check_same_thread=False` conditional on SQLite dialect, as this pysqlite-only flag raises `TypeError` on other DBAPI drivers.

### Test Infrastructure (`tests/fixtures.py`)
- **Ephemeral database management**: Added `_ephemeral_database()` context manager that creates uniquely-named test databases and cleans them up, with dialect-specific handling for Postgres (admin database, session termination) and MySQL (no database selection needed).
- **External SQL fixtures**: Implemented `postgres_sql` and `mysql_sql` fixtures that skip gracefully when connection URLs aren't provided via environment variables.
- **Parametrized call_storage**: Extended the `call_storage` fixture to include `sql_postgres` and `sql_mysql` variants when their respective `FLECHE_TEST_*_URL` env vars are set, enabling existing tests to run against all backends.

### New Regression Test Suite (`tests/regression/test_sql_non_sqlite_backends.py`)
- **URL pass-through tests**: Verify that Postgres and MySQL URLs are not rewritten as SQLite paths.
- **Dialect detection**: Confirm the correct driver is loaded, not a fallback SQLite.
- **CRUD operations**: Test save/load/list/contains/evict against real database drivers.
- **Query pushdown**: Verify JSON metadata and argument filtering work correctly with each dialect's native JSON column type.
- **Idempotency**: Ensure duplicate saves don't create duplicates.

### CI Integration (`.github/workflows/tests.yml`)
- Added `sql-backends` job that spins up Postgres 16 and MariaDB 11 services.
- Installs dialect-specific drivers (`psycopg2-binary`, `pymysql`).
- Runs cross-backend conformance tests plus all storage unit tests with both external backends active.

## Implementation Details
- The fixture design uses `request.getfixturevalue()` to lazily resolve only the configured backend, preventing unconfigured backends' skip exceptions from cascading.
- Database creation uses `AUTOCOMMIT` isolation level to allow DDL operations.
- Postgres requires connecting to an admin database (`postgres`) to create new databases; MySQL doesn't.
- All external database fixtures are properly cleaned up via context managers and engine disposal.

https://claude.ai/code/session_01RfDKAL5NMMfMHMma9W9GPx