### PR TITLE
test(digest): cover Digest.expand / Digest.shrink helpers

### DIFF
--- a/tests/unit/digest/test_digest_methods.py
+++ b/tests/unit/digest/test_digest_methods.py
@@ -1,0 +1,68 @@
+"""Tests for ``Digest.expand`` and ``Digest.shrink`` instance helpers.
+
+These methods are thin convenience wrappers that delegate to the active (or
+explicitly supplied) cache.  They are part of the public ``Digest`` API and
+are documented as such, but were not directly exercised by any test.
+
+Coverage targets ``digest.py`` lines 35-38 (``Digest.expand``) and 49-52
+(``Digest.shrink``), including both branches of the ``if cache is None``
+gate in each method.
+"""
+
+import pytest
+
+from fleche import cache as active_cache
+from fleche.call import Call
+from fleche.caches import Cache
+from fleche.digest import Digest
+from fleche.storage import ValueMemory, CallMemory
+
+
+def _populated_cache() -> tuple[Cache, Digest]:
+    cache = Cache(ValueMemory({}), CallMemory({}))
+    call = Call(
+        name="f", arguments={"a": 1}, result="r",
+        module="m", version="1.0", metadata={},
+    )
+    return cache, cache.save(call)
+
+
+def test_digest_expand_with_explicit_cache_forwards_to_cache():
+    cache, full = _populated_cache()
+    short = Digest(full[:6])
+
+    assert short.expand(cache=cache) == full
+
+
+def test_digest_expand_without_cache_uses_active_cache():
+    cache, full = _populated_cache()
+    short = Digest(full[:6])
+
+    with active_cache(cache):
+        assert short.expand() == full
+
+
+def test_digest_shrink_with_explicit_cache_forwards_to_cache():
+    cache, full = _populated_cache()
+
+    shortened = full.shrink(cache=cache)
+
+    assert isinstance(shortened, Digest)
+    assert cache.expand(shortened) == full
+
+
+def test_digest_shrink_without_cache_uses_active_cache():
+    cache, full = _populated_cache()
+
+    with active_cache(cache):
+        shortened = full.shrink()
+
+    assert isinstance(shortened, Digest)
+    assert cache.expand(shortened) == full
+
+
+def test_digest_expand_unknown_key_propagates_keyerror():
+    cache = Cache(ValueMemory({}), CallMemory({}))
+
+    with pytest.raises(KeyError):
+        Digest("deadbeef").expand(cache=cache)


### PR DESCRIPTION
## Summary

Coverage sweep showed `src/fleche/digest.py` at **85 %** — the lowest among non-trivial modules. The biggest single gap was the pair of convenience methods on `Digest` itself:

```text
src/fleche/digest.py     35-38, 49-52   # Digest.expand, Digest.shrink
```

Both are public API (documented in their respective docstrings as the `Digest`-side of the cache `expand`/`shrink` flow), but no test ever instantiated a `Digest` and called these methods directly — every existing call went through `cache.expand` / `cache.shrink`.

This PR adds **5 focused tests** in `tests/unit/digest/test_digest_methods.py` covering both methods, both branches (`cache=None` → active cache; `cache=<explicit>` → forwarded), and the KeyError pass-through.

### Coverage delta

| Metric | Before | After |
|---|---|---|
| `src/fleche/digest.py` | **85 %** (18 missed, 11 partial branches) | **90 %** (10 missed, 11 partial branches) |
| **Total** | **94 %** (100 missed) | **95 %** (92 missed) |

(8 lines newly covered; both `if cache is None` branches in each method now hit either side.)

<details><summary>Full coverage table — after</summary>

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__init__.py                       13      3      2      1    73%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        277     28     70      5    90%
src/fleche/call.py                          187      6     50      3    96%
src/fleche/config.py                        164      6     76      5    95%
src/fleche/digest.py                        140     10     78     11    90%
src/fleche/executor.py                       35      2     10      0    96%
src/fleche/metadata.py                       33      1      0      0    97%
src/fleche/query.py                         108      0     40      1    99%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/state.py                          52      1     10      1    97%
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py      40      1      8      1    96%
src/fleche/storage/base.py                  114      1     32      1    99%
src/fleche/storage/destructuring.py         171      4     72      7    95%
src/fleche/storage/file.py                   69      2      8      0    97%
src/fleche/storage/memory.py                 24      0      4      0   100%
src/fleche/storage/pickle_file.py            82      4     16      0    96%
src/fleche/storage/sql.py                   242     16     86      7    92%
src/fleche/storage/thread_safe.py            48      0      4      1    98%
src/fleche/storage/void.py                   20      1      4      0    96%
src/fleche/wrapper.py                       222      1     50      1    99%
---------------------------------------------------------------------------
TOTAL                                      2131     92    646     47    95%
941 passed, 11 skipped
```
</details>

## Test plan

- [x] `pytest tests/unit/digest/test_digest_methods.py -v` → 5/5 pass
- [x] Full suite still green: 941 passed / 11 skipped (vs. 936 / 11 before)
- [x] Both branches of `if cache is None` exercised (line + branch coverage on the file confirmed via `--cov-branch`)

A follow-up PR will look at the inverse direction — knocking out tests that don't move coverage — per the same task.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LB9rcKuW6k3h5JYaYhKRqX)_