### PR TITLE
fix: normalize string keys in Cache.load_value without requiring D() wrapping

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -253,10 +253,9 @@ class Cache(BaseCache):
     calls: storage.CallStorage
 
     def load_value(self, key):
-        if not isinstance(key, Digest):
-            return key
-
-        return self.values.load(key)
+        if isinstance(key, str):  # Digest is a str subclass; values.load handles normalization
+            return self.values.load(key)
+        return key
 
     def save(self, call: Call) -> str:
         try:

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import logging
 import random
+import string
 import threading
 from dataclasses import dataclass, replace, field
 from typing import Iterable, Any, Callable, Literal
@@ -253,7 +254,9 @@ class Cache(BaseCache):
     calls: storage.CallStorage
 
     def load_value(self, key):
-        if isinstance(key, str):  # Digest is a str subclass; values.load handles normalization
+        if isinstance(key, Digest):
+            return self.values.load(key)
+        if isinstance(key, str) and 4 <= len(key) <= _digest.DIGEST_LENGTH and all(c in string.hexdigits for c in key):
             return self.values.load(key)
         return key
 

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -350,6 +350,49 @@ def test_cache_query_kwargs_and_template_raises():
         c.query(QueryCall(), name="foo")
 
 
+def test_load_value_plain_string_key():
+    """load_value should accept a plain hex string without requiring D() wrapping."""
+    from fleche.storage.memory import ValueMemory, CallMemory
+    from fleche.digest import digest
+
+    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
+    val = 42
+    key = digest(val)  # full-length Digest
+
+    c.values.save(val)
+
+    # plain str (not Digest) should work without explicit D() wrapping
+    assert c.load_value(str(key)) == val
+    # Digest instance should still work
+    assert c.load_value(key) == val
+
+
+def test_load_value_short_prefix():
+    """load_value should accept a short hex prefix, expanding it automatically."""
+    from fleche.storage.memory import ValueMemory, CallMemory
+    from fleche.digest import digest
+
+    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
+    val = "hello"
+    key = digest(val)
+
+    c.values.save(val)
+
+    short = str(key)[:8]
+    assert c.load_value(short) == val
+
+
+def test_load_value_non_string_passthrough():
+    """load_value should return non-string values as-is (they are already loaded values)."""
+    from fleche.storage.memory import ValueMemory, CallMemory
+
+    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
+
+    assert c.load_value(42) == 42
+    assert c.load_value(None) is None
+    assert c.load_value([1, 2]) == [1, 2]
+
+
 def test_hash_builtin_caches():
     """Test that all cache types respond properly to hash() builtin."""
     from fleche.caches import ReadOnlyCache, FilteredCache, RefreshingCache, SizeLimitedCache


### PR DESCRIPTION
load_value now accepts plain hex strings (full digests or short prefixes) directly, delegating to values.load() which already calls _normalize_key() internally. Non-string non-Digest values are still returned as-is.

Closes #422