### PR TITLE
Update notebooks to use `.fleche` accessor for helper methods

### DIFF
--- a/notebooks/CacheStack.ipynb
+++ b/notebooks/CacheStack.ipynb
@@ -26,7 +26,7 @@
     }
    },
    "outputs": [],
-   "source": "import tempfile\nimport os\nfrom fleche import fleche, cache\nfrom fleche.caches import Cache, CacheStack\nfrom fleche.storage import ValueMemory, CallMemory, ValuePickleFile, CallPickleFile\nfrom fleche.storage.sql import Sql\n\n# 1. Setup a 'remote' persistent cache\ntmp_dir = tempfile.TemporaryDirectory()\n# Use PickleFile for values and Sql for calls to simulate a robust remote storage\nremote_storage_values = ValuePickleFile.with_cloudpickle(tmp_dir.name)\nremote_storage_calls = Sql(f\"sqlite:///{os.path.join(tmp_dir.name, 'cache.db')}\")\nremote_cache = Cache(remote_storage_values, remote_storage_calls)\n\n# 2. Setup a 'local' fast memory cache\nlocal_cache = Cache(ValueMemory({}), CallMemory({}))\n\n@fleche\ndef expensive_computation(x):\n    print(f\"Computing {x}...\")\n    return x * 10\n\n# Pre-populate the remote cache\nwith cache(remote_cache):\n    expensive_computation(42)\n\nprint(\"Remote cache contains 42:\", remote_cache.contains(expensive_computation.digest(42)))\nprint(\"Local cache contains 42: \", local_cache.contains(expensive_computation.digest(42)))"
+   "source": "import tempfile\nimport os\nfrom fleche import fleche, cache\nfrom fleche.caches import Cache, CacheStack\nfrom fleche.storage import ValueMemory, CallMemory, ValuePickleFile, CallPickleFile\nfrom fleche.storage.sql import Sql\n\n# 1. Setup a 'remote' persistent cache\ntmp_dir = tempfile.TemporaryDirectory()\n# Use PickleFile for values and Sql for calls to simulate a robust remote storage\nremote_storage_values = ValuePickleFile.with_cloudpickle(tmp_dir.name)\nremote_storage_calls = Sql(f\"sqlite:///{os.path.join(tmp_dir.name, 'cache.db')}\")\nremote_cache = Cache(remote_storage_values, remote_storage_calls)\n\n# 2. Setup a 'local' fast memory cache\nlocal_cache = Cache(ValueMemory({}), CallMemory({}))\n\n@fleche\ndef expensive_computation(x):\n    print(f\"Computing {x}...\")\n    return x * 10\n\n# Pre-populate the remote cache\nwith cache(remote_cache):\n    expensive_computation(42)\n\nprint(\"Remote cache contains 42:\", remote_cache.contains(expensive_computation.fleche.digest(42)))\nprint(\"Local cache contains 42: \", local_cache.contains(expensive_computation.fleche.digest(42)))"
   },
   {
    "cell_type": "markdown",
@@ -67,7 +67,7 @@
     "    result = expensive_computation(42)\n",
     "    print(f\"Result: {result}\")\n",
     "\n",
-    "print(\"Local cache now contains 42:\", local_cache.contains(expensive_computation.digest(42)))\n",
+    "print(\"Local cache now contains 42:\", local_cache.contains(expensive_computation.fleche.digest(42)))\n",
     "\n",
     "# Cleanup\n",
     "tmp_dir.cleanup()"

--- a/notebooks/Caches.ipynb
+++ b/notebooks/Caches.ipynb
@@ -78,10 +78,11 @@
     "# Run and store inside cache_A\n",
     "with cache(cache_A):\n",
     "    compute_value(5)\n",
-    "    print(\"Is 5 in cache_A?\", compute_value.contains(5))\n",
+    "    print(\"Is 5 in cache_A?\", compute_value.fleche.contains(5))\n",
     "\n",
     "with cache(cache_B):\n",
-    "    print(\"Is 5 in cache_B?\", compute_value.contains(5))\n"
+    "    print(\"Is 5 in cache_B?\", compute_value.fleche.contains(5))\n",
+    ""
    ]
   },
   {
@@ -121,10 +122,11 @@
     "\n",
     "print(\"After transferring with pop=True:\")\n",
     "with cache(cache_A):\n",
-    "    print(\"Is 5 in cache_A?\", compute_value.contains(5))\n",
+    "    print(\"Is 5 in cache_A?\", compute_value.fleche.contains(5))\n",
     "\n",
     "with cache(cache_B):\n",
-    "    print(\"Is 5 in cache_B?\", compute_value.contains(5))\n"
+    "    print(\"Is 5 in cache_B?\", compute_value.fleche.contains(5))\n",
+    ""
    ]
   }
  ],

--- a/notebooks/ConcurrentExecution.ipynb
+++ b/notebooks/ConcurrentExecution.ipynb
@@ -44,9 +44,9 @@
    "id": "5d911614",
    "metadata": {},
    "source": [
-    "## 1. `BoundWrapper.bind` \u2014 explicit state capture\n",
+    "## 1. `BoundWrapper.bind` — explicit state capture\n",
     "\n",
-    "`BoundWrapper.bind(func)` captures the active cache and metadata at bind time and restores them on every call, including inside worker threads and processes.  The returned object is a regular picklable callable \u2014 you can pass it to any executor, store it in a dict, or hand it to another module."
+    "`BoundWrapper.bind(func)` captures the active cache and metadata at bind time and restores them on every call, including inside worker threads and processes.  The returned object is a regular picklable callable — you can pass it to any executor, store it in a dict, or hand it to another module."
    ]
   },
   {
@@ -77,7 +77,7 @@
     "        results = [f.result() for f in futures]\n",
     "\n",
     "print(\"Results:\", results)                                    # [1, 3, 5, 7]\n",
-    "print(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))   # True"
+    "print(\"In my_cache:\", my_cache.contains(add.fleche.digest(0, 1)))   # True"
    ]
   },
   {
@@ -102,13 +102,13 @@
     "with cache(my_cache):\n",
     "    bound_add = BoundWrapper.bind(add)   # bind once, reuse anywhere\n",
     "\n",
-    "# bound_add carries my_cache \u2014 the cache context manager is no longer needed at the call site\n",
+    "# bound_add carries my_cache — the cache context manager is no longer needed at the call site\n",
     "with ThreadPoolExecutor(max_workers=2) as pool:\n",
     "    futures = [pool.submit(bound_add, x, x + 1) for x in range(4)]\n",
     "    results = [f.result() for f in futures]\n",
     "\n",
     "print(\"Results:\", results)                                    # [1, 3, 5, 7]\n",
-    "print(\"In my_cache:\", my_cache.contains(add.digest(0, 1)))   # True"
+    "print(\"In my_cache:\", my_cache.contains(add.fleche.digest(0, 1)))   # True"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "source": [
     "### 1c. ProcessPoolExecutor\n",
     "\n",
-    "Worker processes run in separate Python interpreters \u2014 an in-memory cache set in the parent is **not visible** inside workers.  Use a **file-** or **SQL-backed** backend so that results written by workers are visible to the parent process."
+    "Worker processes run in separate Python interpreters — an in-memory cache set in the parent is **not visible** inside workers.  Use a **file-** or **SQL-backed** backend so that results written by workers are visible to the parent process."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "            results = list(pool.map(BoundWrapper.bind(expensive), range(5)))\n",
     "\n",
     "    print(\"Results:\", results)                                      # [0, 1, 8, 27, 64]\n",
-    "    print(\"Cached:\", shared_cache.contains(expensive.digest(3)))    # True"
+    "    print(\"Cached:\", shared_cache.contains(expensive.fleche.digest(3)))    # True"
    ]
   },
   {
@@ -185,7 +185,7 @@
     "                results = [f.result() for f in futures]\n",
     "\n",
     "        print(\"Results:\", results)                                              # [0, 1, 8, 27, 64]\n",
-    "        print(\"In shared_cache:\", shared_cache.contains(cube_sne.digest(3)))    # True\n",
+    "        print(\"In shared_cache:\", shared_cache.contains(cube_sne.fleche.digest(3)))    # True\n",
     "except ImportError:\n",
     "    print(\"executorlib not installed; skipping SingleNodeExecutor example.\")"
    ]
@@ -196,7 +196,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 2. Future pass-through \u2014 cache async-style return values\n",
+    "## 2. Future pass-through — cache async-style return values\n",
     "\n",
     "A fleche-decorated function can return a `concurrent.futures.Future` directly.  Fleche detects this, passes the future through to the caller unchanged, and **caches the result once the future completes** via a done-callback.\n",
     "\n",
@@ -225,7 +225,7 @@
     "    fut = square_async(4)\n",
     "    print(\"First call returns a Future:\", isinstance(fut, Future))     # True\n",
     "    print(\"Result:\", fut.result())                                      # 16\n",
-    "    print(\"Cached:\", my_cache.contains(square_async.digest(4)))         # True\n",
+    "    print(\"Cached:\", my_cache.contains(square_async.fleche.digest(4)))         # True\n",
     "\n",
     "    # Second call: no executor submission, cached value returned directly.\n",
     "    result = square_async(4)\n",
@@ -237,7 +237,7 @@
    "id": "64942686",
    "metadata": {},
    "source": [
-    "When a cached value already exists, the decorated function is **not** invoked and **no** Future is created \u2014 you simply get the cached result back.  If you need the result to always behave like a Future at the call site, wrap it with an already-completed Future at that point, or use `wrap_executor` below instead."
+    "When a cached value already exists, the decorated function is **not** invoked and **no** Future is created — you simply get the cached result back.  If you need the result to always behave like a Future at the call site, wrap it with an already-completed Future at that point, or use `wrap_executor` below instead."
    ]
   },
   {
@@ -246,15 +246,15 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## 3. `wrap_executor` \u2014 transparent submit interception\n",
+    "## 3. `wrap_executor` — transparent submit interception\n",
     "\n",
     "`fleche.wrap_executor(executor)` monkey-patches `executor.submit` on an existing instance so that fleche-decorated functions are handled automatically.  It does three things per `submit`:\n",
     "\n",
     "1. **Non-fleche callables** pass straight through to the original `submit`.\n",
-    "2. **Cache hits** return an already-completed `Future` \u2014 the executor is never touched, saving submit/serialise overhead.\n",
+    "2. **Cache hits** return an already-completed `Future` — the executor is never touched, saving submit/serialise overhead.\n",
     "3. **Cache misses** are bound via `BoundWrapper.bind(...)` so the parent's cache and metadata travel with the call into the worker.\n",
     "\n",
-    "No subclassing, no proxy \u2014 it replaces the `submit` attribute on the instance and returns the same instance."
+    "No subclassing, no proxy — it replaces the `submit` attribute on the instance and returns the same instance."
    ]
   },
   {
@@ -328,7 +328,7 @@
     "            results = [f.result() for f in futures]\n",
     "\n",
     "    print(\"Results:\", results)                                         # [0, 1, 8, 27, 64]\n",
-    "    print(\"Cached:\", shared_cache.contains(expensive.digest(3)))       # True"
+    "    print(\"Cached:\", shared_cache.contains(expensive.fleche.digest(3)))       # True"
    ]
   },
   {
@@ -363,27 +363,27 @@
     "## Summary\n",
     "\n",
     "```\n",
-    "BoundWrapper.bind(func)                    \u2705 explicit; pass bound callable anywhere\n",
+    "BoundWrapper.bind(func)                    ✅ explicit; pass bound callable anywhere\n",
     "    with cache(...): pool.submit(BoundWrapper.bind(func), ...)\n",
     "\n",
-    "Future pass-through                        \u2705 cache async-style return values\n",
+    "Future pass-through                        ✅ cache async-style return values\n",
     "    @fleche\n",
     "    def f(x): return pool.submit(...)\n",
     "\n",
-    "wrap_executor(pool)                        \u2705 transparent; cache hits never submit\n",
+    "wrap_executor(pool)                        ✅ transparent; cache hits never submit\n",
     "    with cache(...):\n",
     "        wrap_executor(pool)\n",
-    "        pool.submit(f, x)                   \u2190 ordinary submit\n",
+    "        pool.submit(f, x)                   ← ordinary submit\n",
     "```\n",
     "\n",
     "**Storage reference**\n",
     "\n",
     "| Backend | Cross-process sharing |\n",
     "|---|---|\n",
-    "| `Memory` | \u274c Ephemeral \u2014 process-local only |\n",
-    "| `PickleFile` | \u2705 Persistent \u2014 shared via filesystem |\n",
-    "| `Sql` | \u2705 Persistent \u2014 shared via database |\n",
-    "| `BagOfHolding` | \u2705 Persistent \u2014 shared via HDF5 file |"
+    "| `Memory` | ❌ Ephemeral — process-local only |\n",
+    "| `PickleFile` | ✅ Persistent — shared via filesystem |\n",
+    "| `Sql` | ✅ Persistent — shared via database |\n",
+    "| `BagOfHolding` | ✅ Persistent — shared via HDF5 file |"
    ]
   }
  ],

--- a/notebooks/ExtraMethods.ipynb
+++ b/notebooks/ExtraMethods.ipynb
@@ -65,7 +65,7 @@
     }
    ],
    "source": [
-    "call_info = slow_add.call(10, b=20)\n",
+    "call_info = slow_add.fleche.call(10, b=20)\n",
     "print(f\"Function Name: {call_info.name}\")\n",
     "print(f\"Arguments: {call_info.arguments}\")\n",
     "print(f\"Call Object: {call_info}\")"
@@ -94,7 +94,7 @@
     }
    ],
    "source": [
-    "key = slow_add.digest(10, b=20)\n",
+    "key = slow_add.fleche.digest(10, b=20)\n",
     "print(f\"Cache Key: {key}\")"
    ]
   },
@@ -122,12 +122,12 @@
     }
    ],
    "source": [
-    "print(f\"Is (10, 20) in cache? {slow_add.contains(10, b=20)}\")\n",
+    "print(f\"Is (10, 20) in cache? {slow_add.fleche.contains(10, b=20)}\")\n",
     "\n",
     "# Now we run it to populate the cache\n",
     "slow_add(10, b=20)\n",
     "\n",
-    "print(f\"Is (10, 20) in cache now? {slow_add.contains(10, b=20)}\")"
+    "print(f\"Is (10, 20) in cache now? {slow_add.fleche.contains(10, b=20)}\")"
    ]
   },
   {
@@ -154,11 +154,11 @@
     }
    ],
    "source": [
-    "result = slow_add.load(10, b=20)\n",
+    "result = slow_add.fleche.load(10, b=20)\n",
     "print(f\"Loaded result: {result}\")\n",
     "\n",
     "try:\n",
-    "    slow_add.load(1, 2)\n",
+    "    slow_add.fleche.load(1, 2)\n",
     "except KeyError:\n",
     "    print(\"Result for (1, 2) not in cache.\")"
    ]
@@ -188,7 +188,7 @@
    ],
    "source": [
     "start = time.time()\n",
-    "res = slow_add.rerun(10, b=20)\n",
+    "res = slow_add.fleche.rerun(10, b=20)\n",
     "end = time.time()\n",
     "print(f\"Rerun Result: {res} (took {end - start:.2f} seconds forcing execution)\")\n",
     "\n",
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "source": "## Gotcha: Using Helpers with Decorated Methods\n\nWhen `@fleche` is applied to a class method, the helper methods do **not** automatically bind\n`self` the way a normal method call would. `obj.method.query` is the same unbound function as\n`MyClass.method.query` — no partial application of `self=obj` happens.\n\nYou must pass the instance explicitly as the first positional argument (or as `self=`):\n\n```python\nclass MyClass:\n    def __init__(self, val):\n        self.val = val\n\n    def __digest__(self):\n        from fleche.digest import Digest\n        return Digest(str(self.val))\n\n    @fleche\n    def compute(self, x):\n        return self.val + x\n\nobj = MyClass(10)\nobj.compute(5)  # populates cache\n\n# Correct — pass self explicitly\nobj.compute.contains(obj, x=5)  # True\nobj.compute.digest(obj, x=5)    # cache key string\nobj.compute.query(self=obj, x=5)  # also works as keyword\n\n# Incorrect — raises TypeError: missing argument 'self'\n# obj.compute.contains(x=5)\n```",
+   "source": "## Gotcha: Using Helpers with Decorated Methods\n\nWhen `@fleche` is applied to a class method, the helper methods do **not** automatically bind\n`self` the way a normal method call would. `obj.method.fleche.query` is the same unbound function as\n`MyClass.method.fleche.query` — no partial application of `self=obj` happens.\n\nYou must pass the instance explicitly as the first positional argument (or as `self=`):\n\n```python\nclass MyClass:\n    def __init__(self, val):\n        self.val = val\n\n    def __digest__(self):\n        from fleche.digest import Digest\n        return Digest(str(self.val))\n\n    @fleche\n    def compute(self, x):\n        return self.val + x\n\nobj = MyClass(10)\nobj.compute(5)  # populates cache\n\n# Correct — pass self explicitly\nobj.compute.fleche.contains(obj, x=5)  # True\nobj.compute.fleche.digest(obj, x=5)    # cache key string\nobj.compute.fleche.query(self=obj, x=5)  # also works as keyword\n\n# Incorrect — raises TypeError: missing argument 'self'\n# obj.compute.fleche.contains(x=5)\n```",
    "metadata": {}
   }
  ],

--- a/notebooks/GettingStarted.ipynb
+++ b/notebooks/GettingStarted.ipynb
@@ -336,7 +336,7 @@
     }
    ],
    "source": [
-    "long_running_calculation.query().table()"
+    "long_running_calculation.fleche.query().table()"
    ]
   },
   {
@@ -442,7 +442,7 @@
     }
    ],
    "source": [
-    "long_running_calculation.query().table(arguments=['x'])"
+    "long_running_calculation.fleche.query().table(arguments=['x'])"
    ]
   },
   {
@@ -543,7 +543,7 @@
     }
    ],
    "source": [
-    "long_running_calculation.query().table(arguments=['x'], results=True)"
+    "long_running_calculation.fleche.query().table(arguments=['x'], results=True)"
    ]
   },
   {
@@ -922,15 +922,16 @@
    ],
    "source": [
     "# Query by metadata presence (tags) and a specific key-value filter\n",
-    "for call in another_calculation.query(1, 2, metadata={\"tags\": {}}):\n",
+    "for call in another_calculation.fleche.query(1, 2, metadata={\"tags\": {}}):\n",
     "    # presence-only: any call with 'tags'\n",
     "    print(call.name, call.arguments, call.metadata.get(\"tags\"))\n",
     "\n",
-    "for call in another_calculation.query(3, 4, metadata={\"tags\": {\"project\": \"my_project\"}}):\n",
+    "for call in another_calculation.fleche.query(3, 4, metadata={\"tags\": {\"project\": \"my_project\"}}):\n",
     "    # equality filter on metadata\n",
     "    assert call.metadata[\"tags\"][\"project\"] == \"my_project\"\n",
     "    # arguments and result are decoded if they were stored as digests\n",
-    "    print(call.arguments, call.result)\n"
+    "    print(call.arguments, call.result)\n",
+    ""
    ]
   },
   {
@@ -1783,15 +1784,16 @@
    ],
    "source": [
     "# Query by metadata presence (tags) and a specific key-value filter\n",
-    "for call in another_calculation.query(1, 2, metadata={\"tags\": {}}):\n",
+    "for call in another_calculation.fleche.query(1, 2, metadata={\"tags\": {}}):\n",
     "    # presence-only: any call with 'tags'\n",
     "    print(call.name, call.arguments, call.metadata.get(\"tags\"))\n",
     "\n",
-    "for call in another_calculation.query(3, 4, metadata={\"tags\": {\"project\": \"my_project\"}}):\n",
+    "for call in another_calculation.fleche.query(3, 4, metadata={\"tags\": {\"project\": \"my_project\"}}):\n",
     "    # equality filter on metadata\n",
     "    assert call.metadata[\"tags\"][\"project\"] == \"my_project\"\n",
     "    # arguments and result are decoded if they were stored as digests\n",
-    "    print(call.arguments, call.result)\n"
+    "    print(call.arguments, call.result)\n",
+    ""
    ]
   },
   {
@@ -1820,12 +1822,13 @@
    ],
    "source": [
     "# Default load: returns a LazyCall — no deserialization yet\n",
-    "key = fib.digest(20)\n",
+    "key = fib.fleche.digest(20)\n",
     "lazy_call = cache().load(key)\n",
     "print(f\"Got a {type(lazy_call).__name__} for {lazy_call.name}(20)\")\n",
     "\n",
     "# Accessing .result triggers the actual load from storage\n",
-    "print(f\"Result: {lazy_call.result}\")\n"
+    "print(f\"Result: {lazy_call.result}\")\n",
+    ""
    ]
   },
   {

--- a/notebooks/TransferWorkflow.ipynb
+++ b/notebooks/TransferWorkflow.ipynb
@@ -868,7 +868,7 @@
     }
    ],
    "source": [
-    "simulations_only = local_cache.filter(simulate.call(param=None))\n",
+    "simulations_only = local_cache.filter(simulate.fleche.call(param=None))\n",
     "simulations_only.table()"
    ]
   },


### PR DESCRIPTION
## Summary
This PR updates all notebook examples to use the `.fleche` accessor when calling helper methods like `digest()`, `query()`, `contains()`, `load()`, `call()`, and `rerun()` on fleche-decorated functions. This reflects a change in the API where these methods are now accessed through a `.fleche` attribute rather than directly on the decorated function.

## Key Changes
- **ConcurrentExecution.ipynb**: Updated all `add.digest()`, `expensive.digest()`, `cube_sne.digest()`, and `square_async.digest()` calls to use `.fleche.digest()`
- **GettingStarted.ipynb**: Updated `long_running_calculation.query()` calls to `long_running_calculation.fleche.query()` and `fib.digest()` to `fib.fleche.digest()`
- **ExtraMethods.ipynb**: Updated all helper method calls (`call()`, `digest()`, `contains()`, `load()`, `rerun()`) to use the `.fleche` accessor; also updated the "Gotcha" section documentation to reflect the new accessor pattern
- **Caches.ipynb**: Updated `compute_value.contains()` calls to `compute_value.fleche.contains()`
- **CacheStack.ipynb**: Updated `expensive_computation.digest()` calls to `expensive_computation.fleche.digest()`
- **TransferWorkflow.ipynb**: Updated `simulate.call()` to `simulate.fleche.call()`
- **Unicode normalization**: Replaced em-dashes (–) with proper em-dashes (—) and updated checkmark/cross symbols to use proper Unicode characters (✅, ❌, ←) in summary tables

## Notable Details
- The `.fleche` accessor provides a consistent interface for accessing cache introspection and metadata methods
- All notebook examples now demonstrate the correct API usage pattern
- Documentation in the "Gotcha" section was updated to show the new accessor pattern for class methods

https://claude.ai/code/session_01QjVZpj6D8QXJZeyamSJUzC