### PR TITLE
fix(caches): only call values.load for Digest or hex strings in load_value

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import logging
 import random
+import string
 import threading
 from dataclasses import dataclass, replace, field
 from typing import Iterable, Any, Callable, Literal
@@ -253,7 +254,9 @@ class Cache(BaseCache):
     calls: storage.CallStorage
 
     def load_value(self, key):
-        if isinstance(key, str):  # Digest is a str subclass; values.load handles normalization
+        if isinstance(key, Digest):
+            return self.values.load(key)
+        if isinstance(key, str) and 4 <= len(key) <= _digest.DIGEST_LENGTH and all(c in string.hexdigits for c in key):
             return self.values.load(key)
         return key
 


### PR DESCRIPTION
## Summary

- The previous `load_value` in `Cache` called `self.values.load(key)` for all strings (including non-hex inline values), which caused spurious storage lookups.
- Fix checks `isinstance(key, Digest)` first (always load from storage), then for plain `str` validates it is a non-empty all-hex string before loading, otherwise returns the key as-is.

## Test plan

- [ ] Verify `Digest` instances still resolve through `values.load`
- [ ] Verify plain lowercase hex strings (e.g. `"deadbeef"`) still resolve through `values.load`
- [ ] Verify non-hex inline strings (e.g. `"hello world"`, `"not-hex!"`) are returned as-is without touching storage
- [ ] Run full test suite: `pytest tests/`

https://claude.ai/code/session_012ttgcjUfWdJDdDdX63art2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ttgcjUfWdJDdDdX63art2)_