### PR TITLE
refactor: extract _longest_common_prefix_length helper

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -11,6 +11,7 @@ import pandas as pd
 from . import digest as _digest
 from .digest import Digest  # type hint convenience
 from . import storage
+from .storage.base import _longest_common_prefix_length
 from .storage.destructuring import HasChildDigests
 from .call import Call, DigestedCall, LazyCall, QueryCall
 from . import call
@@ -225,14 +226,9 @@ def _combine_expand(key: "Digest | str", results: "Iterable[Digest]") -> "Digest
         raise KeyError(key)
     if len(unique) == 1:
         return unique[0]
-    m1, m2 = unique[0], unique[1]
-    for i, (c1, c2) in enumerate(zip(m1, m2)):
-        if c1 != c2:
-            break
-    else:
-        i = min(len(m1), len(m2))
+    lcp = _longest_common_prefix_length(unique[0], unique[1])
     raise storage.AmbiguousDigestError(
-        f"Short digest {key} is ambiguous; expands to: {unique}; need at least {i + 1} characters."
+        f"Short digest {key} is ambiguous; expands to: {unique}; need at least {lcp + 1} characters."
     )
 
 

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -18,6 +18,13 @@ class AmbiguousDigestError(ValueError):
     pass
 
 
+def _longest_common_prefix_length(s1: str, s2: str) -> int:
+    for i, (c1, c2) in enumerate(zip(s1, s2)):
+        if c1 != c2:
+            return i
+    return min(len(s1), len(s2))
+
+
 def _resolve_prefix(key: str, candidates: list[Digest]) -> Digest:
     """Return the unique Digest for *key* prefix, or raise KeyError / AmbiguousDigestError.
 
@@ -29,14 +36,9 @@ def _resolve_prefix(key: str, candidates: list[Digest]) -> Digest:
         raise KeyError(key)
     if len(candidates) == 1:
         return candidates[0]
-    m1, m2 = candidates[0], candidates[1]
-    for i, (c1, c2) in enumerate(zip(m1, m2)):
-        if c1 != c2:
-            break
-    else:
-        i = min(len(m1), len(m2))
+    lcp = _longest_common_prefix_length(candidates[0], candidates[1])
     raise AmbiguousDigestError(
-        f"Short digest {key} is ambiguous; need at least {i+1} characters."
+        f"Short digest {key} is ambiguous; need at least {lcp+1} characters."
     )
 
 

--- a/tests/unit/storage/test_short_digest.py
+++ b/tests/unit/storage/test_short_digest.py
@@ -1,5 +1,6 @@
 import pytest
 from fleche.storage import AmbiguousDigestError, ValueMemory
+from fleche.storage.base import _longest_common_prefix_length
 from fleche.digest import DIGEST_LENGTH
 
 
@@ -57,3 +58,23 @@ def test_missing_digest():
 
     with pytest.raises(KeyError):
         store.expand("ffff")
+
+
+class TestLongestCommonPrefixLength:
+    def test_identical_strings(self):
+        assert _longest_common_prefix_length("abcd", "abcd") == 4
+
+    def test_no_common_prefix(self):
+        assert _longest_common_prefix_length("abc", "xyz") == 0
+
+    def test_partial_common_prefix(self):
+        assert _longest_common_prefix_length("abcX", "abcY") == 3
+
+    def test_one_is_prefix_of_other(self):
+        assert _longest_common_prefix_length("abc", "abcdef") == 3
+
+    def test_empty_strings(self):
+        assert _longest_common_prefix_length("", "") == 0
+
+    def test_one_empty(self):
+        assert _longest_common_prefix_length("", "abc") == 0


### PR DESCRIPTION
Extract the duplicated longest-common-prefix loop from `_resolve_prefix` (`storage/base.py`) and `_combine_expand` (`caches.py`) into a single named helper in `storage/base.py`, imported by `caches.py`.

Also adds 6 focused unit tests for the new helper in `tests/unit/storage/test_short_digest.py`.

Closes #407

Generated with [Claude Code](https://claude.ai/code)