### PR TITLE
refactor: drop non-key passthrough in Cache.load_value

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 import logging
 import random
-import string
 import threading
 from dataclasses import dataclass, replace, field
 from typing import Iterable, Any, Callable, Literal
@@ -254,11 +253,7 @@ class Cache(BaseCache):
     calls: storage.CallStorage
 
     def load_value(self, key):
-        if isinstance(key, Digest):
-            return self.values.load(key)
-        if isinstance(key, str) and 4 <= len(key) <= _digest.DIGEST_LENGTH and all(c in string.hexdigits for c in key):
-            return self.values.load(key)
-        return key
+        return self.values.load(key)
 
     def save(self, call: Call) -> str:
         try:

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -308,6 +308,8 @@ class LazyCall:
 
     @property
     def result(self):
+        if self._result is None:
+            return None
         return self._cache.load_value(self._result)
 
     def to_lookup_key(self) -> str:

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -382,17 +382,6 @@ def test_load_value_short_prefix():
     assert c.load_value(short) == val
 
 
-def test_load_value_non_string_passthrough():
-    """load_value should return non-string values as-is (they are already loaded values)."""
-    from fleche.storage.memory import ValueMemory, CallMemory
-
-    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
-
-    assert c.load_value(42) == 42
-    assert c.load_value(None) is None
-    assert c.load_value([1, 2]) == [1, 2]
-
-
 def test_hash_builtin_caches():
     """Test that all cache types respond properly to hash() builtin."""
     from fleche.caches import ReadOnlyCache, FilteredCache, RefreshingCache, SizeLimitedCache

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -118,6 +118,9 @@ class TestDigestedCallFetch:
         lazy = dc.fetch(cache)
         assert isinstance(lazy, LazyCall)
         assert lazy._result is None
+        # Accessing .result on a LazyCall with _result=None returns None
+        # without consulting the value store.
+        assert lazy.result is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #446.

`Cache.load_value` now dispatches cleanly to `values.load`. The historical "return non-key values unmodified" branch is gone.

## Why

The `if not isinstance(key, Digest): return key` guard was introduced in 1dc628b when `_recursive_value_load` was renamed to `load_value` — back then the helper walked destructured containers recursively and encountered inline (non-Digest) leaf values mid-walk. After 580a200 (Feb 2026) extracted that recursion into a dedicated `DestructuringStorage` wrapper, the recursion was removed but the guard remained as defensive code. Since then it has had no functional purpose; #446 then preserved it (and extended it to cover plain hex strings) when adding string-key support.

## Audit of all call sites

| Site | Guard before reaching `load_value` |
|------|------|
| `wrapper.py:263` (positional args) | `isinstance(arg, Digest)` |
| `wrapper.py:267` (kwargs) | `isinstance(v, Digest)` |
| `call.py:LazyArguments.__getitem__` | `isinstance(value, Digest)` |
| `call.py:LazyCall.result` | **none** — `_result` can be `None` for a `DigestedCall` constructed without a result |

Only the last site needed the passthrough, and only for the `None` case (e.g. SQL loads of records stored with `result=None`, exercised by `test_fetch_none_result`). Handling that explicitly at `LazyCall.result` is clearer than a magic global passthrough on `load_value`.

The string-key behaviour from #446 still works because `Digest` is a `str` subclass and `ValueStorage.load` already calls `_normalize_key`, so plain hex strings (full or short prefix) flow through unchanged.

## Changes

- `Cache.load_value` → `return self.values.load(key)`
- `LazyCall.result` → guard `_result is None` at the call site
- Drop `test_load_value_non_string_passthrough` (now unsupported)
- `test_fetch_none_result` gains an assertion that `LazyCall.result` returns `None` without touching the value store

## Test plan
- [x] `pytest tests/` — 848 passed, 11 skipped (the 11 skips are pre-existing dialect-conditional SQL tests)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nrv5HWvCdWNruphiS4juUp)_