### PR TITLE
feat: replace custom file locking with py-filelock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     'numpy',
     'pandas >= 2.2, <4',
     'pyiron-snippets',
+    'filelock',
 ]
 
 [project.optional-dependencies]

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -22,9 +22,7 @@ following **lowercase** identifiers:
     :class:`~fleche.storage.CallPickleFile`).
     Required: ``root`` (path to storage directory).
     Optional: ``compress`` (bool, default ``False``) — gzip-compress files.
-    Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
-    Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
-    interval for exponential backoff (s).
+    Optional: ``lock_timeout`` (float, default ``1.0``) — file-lock acquisition timeout (s).
     Optional: ``secret_key`` (list of hex strings) — HMAC-SHA256 signing keys;
     each element is a hex-encoded byte string (same format as ``FLECHE_SECRET_KEY``).
     If omitted, falls back to the ``FLECHE_SECRET_KEY`` environment variable.
@@ -35,9 +33,7 @@ following **lowercase** identifiers:
     complex Python objects than ``pickle``.
     Required: ``root``.
     Optional: ``compress`` (bool, default ``False``) — gzip-compress files.
-    Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
-    Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
-    interval for exponential backoff (s).
+    Optional: ``lock_timeout`` (float, default ``1.0``) — file-lock acquisition timeout (s).
     Optional: ``secret_key`` (list of hex strings) — same as ``"pickle"``.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 
@@ -45,9 +41,7 @@ following **lowercase** identifiers:
     Filesystem backend serialised with ``dill``.
     Required: ``root``.
     Optional: ``compress`` (bool, default ``False``) — gzip-compress files.
-    Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
-    Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
-    interval for exponential backoff (s).
+    Optional: ``lock_timeout`` (float, default ``1.0``) — file-lock acquisition timeout (s).
     Optional: ``secret_key`` (list of hex strings) — same as ``"pickle"``.
     Optional (value backend): ``remaining_depth`` (int, default ``0``).
 
@@ -56,9 +50,7 @@ following **lowercase** identifiers:
     (:class:`~fleche.storage.ValueBagOfHoldingH5File` /
     :class:`~fleche.storage.CallBagOfHoldingH5File`).
     Required: ``root``.
-    Optional: ``lock_timeout`` (float, default ``1.0``) — write-lock wait timeout (s).
-    Optional: ``lock_wait_start`` (float, default ``0.001``) — initial lock-poll
-    interval for exponential backoff (s).
+    Optional: ``lock_timeout`` (float, default ``1.0``) — file-lock acquisition timeout (s).
     Optional: ``version_validator`` (str, default omitted) — version validation
     strategy passed to :meth:`bagofholding:bagofholding.h5.bag.H5Bag.load`.  One of ``"exact"``, ``"semantic-minor"``,
     ``"semantic-major"``, ``"none"``.  When omitted, bagofholding's default applies.
@@ -237,14 +229,14 @@ def storage_from_config(d: dict[str, Any], type: Literal["call", "value"]) -> st
     * ``{"type": "memory"}``
     * ``{"type": "void"}``
     * ``{"type": "pickle", "root": "<path>"}``
-      — optional: ``compress``, ``lock_timeout``, ``lock_wait_start``,
+      — optional: ``compress``, ``lock_timeout``,
       ``secret_key`` (list of hex strings), ``remaining_depth`` (value only)
     * ``{"type": "cloudpickle", "root": "<path>"}``
       — same optional keys as ``"pickle"``
     * ``{"type": "dill", "root": "<path>"}``
       — same optional keys as ``"pickle"``
     * ``{"type": "bagofholding_hdf", "root": "<path>"}``
-      — optional: ``lock_timeout``, ``lock_wait_start``,
+      — optional: ``lock_timeout``,
       ``version_validator``, ``remaining_depth`` (value only)
     * ``{"type": "sql", "url": "<sqlalchemy-url>"}``  *(call storage only)*
       — optional: ``echo``

--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -1,7 +1,5 @@
 import logging
-import os
-import socket
-import time
+import filelock
 from abc import abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,47 +13,20 @@ logger = logging.getLogger("fleche.storage")
 
 
 @contextmanager
-def file_write_lock(lock_path: Path) -> Generator[None, None, None]:
-    """Context manager for acquiring a write lock on a file.
-
-    Creates a lock file with hostname, PID, and timestamp.
-    """
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.write_text(f"{socket.gethostname()}\n{os.getpid()}\n{time.time()}")
-    try:
-        yield
-    finally:
-        lock_path.unlink(missing_ok=True)
-
-
-@contextmanager
-def file_read_lock(
-    lock_path: Path, timeout: float, wait_start: float, key: str
+def _file_read_lock_with_fallback(
+    lock_path: Path, timeout: float, key: str
 ) -> Generator[None, None, None]:
-    """Context manager for acquiring a read lock on a file.
-
-    Waits for a lock file to be removed with exponential backoff.
-    """
+    lock = filelock.FileLock(lock_path, timeout=timeout)
     tried_anyway = False
-    if lock_path.exists():
-        start_time = time.perf_counter()
-        wait_time = wait_start
-        while lock_path.exists() and (time.perf_counter() - start_time) < timeout:
-            time.sleep(wait_time)
-            wait_time *= 2
-
-        if lock_path.exists():
-            try:
-                lock_info = lock_path.read_text().replace("\n", " ")
-            except Exception:
-                lock_info = "unknown"
-            logger.warning(
-                "Lock still held for %s after %s seconds (info: %s), trying to read anyway.",
-                key,
-                timeout,
-                lock_info,
-            )
-            tried_anyway = True
+    try:
+        lock.acquire()
+    except filelock.Timeout:
+        logger.warning(
+            "Lock still held for %s after %s seconds, trying to read anyway.",
+            key,
+            timeout,
+        )
+        tried_anyway = True
     try:
         yield
     except Exception as e:
@@ -67,6 +38,9 @@ def file_read_lock(
             )
             raise KeyError(key) from None
         raise
+    finally:
+        if not tried_anyway:
+            lock.release()
 
 
 @dataclass(frozen=True)
@@ -78,7 +52,6 @@ class FileStorage(StorageBackend):
 
     root: Path
     lock_timeout: float = 1.0
-    lock_wait_start: float = 0.001
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "root", Path(self.root).expanduser().absolute().resolve())
@@ -103,15 +76,13 @@ class FileStorage(StorageBackend):
 
     def put(self, value: Any, key: Digest) -> Digest:
         lock_path = self._path(f"{key}.lock")
-        with file_write_lock(lock_path):
+        with filelock.FileLock(lock_path, timeout=self.lock_timeout):
             self._to_file(value, self._path(key))
         return key
 
     def get(self, key: Digest) -> Any:
         lock_path = self._path(f"{key}.lock")
-        with file_read_lock(
-            lock_path, self.lock_timeout, self.lock_wait_start, str(key)
-        ):
+        with _file_read_lock_with_fallback(lock_path, self.lock_timeout, str(key)):
             return self._from_file(self._path(key))
 
     @abstractmethod

--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
-from .file import FileStorage, file_write_lock
+import filelock
+
+from .file import FileStorage
 from .base import ValueMixin, CallMixin
 from .thread_safe import PerKeyLockMixin
 from .destructuring import DestructuringMixin
@@ -88,7 +90,7 @@ class PickleFileBackend(FileStorage):
         for key in list(self.list()):
             path = self._path(key)
             lock_path = self._path(f"{key}.lock")
-            with file_write_lock(lock_path):
+            with filelock.FileLock(lock_path, timeout=self.lock_timeout):
                 try:
                     content = path.read_bytes()
                 except FileNotFoundError:
@@ -101,7 +103,7 @@ class PickleFileBackend(FileStorage):
         for key in list(self.list()):
             path = self._path(key)
             lock_path = self._path(f"{key}.lock")
-            with file_write_lock(lock_path):
+            with filelock.FileLock(lock_path, timeout=self.lock_timeout):
                 try:
                     content = path.read_bytes()
                 except FileNotFoundError:

--- a/tests/unit/storage/test_file_storage.py
+++ b/tests/unit/storage/test_file_storage.py
@@ -1,7 +1,7 @@
 import time
 import threading
 import tempfile
-import socket
+import filelock
 from pathlib import Path
 import pytest
 from fleche.storage import ValuePickleFile as PickleFile
@@ -58,20 +58,21 @@ def test_file_storage_list_filtering(tmp_path):
 
 def test_load_waits_for_lock():
     with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir)
+        storage = PickleFile.with_pickle(tmpdir, lock_timeout=2.0)
         key = digest("test")
         data = "content"
         storage.save(data, key=key)
 
         lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.write_text("dummy")
+        holder = filelock.FileLock(lock_path)
+        holder.acquire()
 
-        def remove_lock_later():
+        def release_lock_later():
             time.sleep(0.2)
-            lock_path.unlink()
+            holder.release()
 
         start = time.perf_counter()
-        threading.Thread(target=remove_lock_later).start()
+        threading.Thread(target=release_lock_later).start()
 
         loaded = storage.load(key)
         end = time.perf_counter()
@@ -89,15 +90,19 @@ def test_load_timeouts_and_reads_anyway(caplog):
         storage.save(data, key=key)
 
         lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.write_text("dummy")
+        holder = filelock.FileLock(lock_path)
+        holder.acquire()
 
-        start = time.perf_counter()
-        loaded = storage.load(key)
-        end = time.perf_counter()
+        try:
+            start = time.perf_counter()
+            loaded = storage.load(key)
+            end = time.perf_counter()
 
-        assert loaded == data
-        assert (end - start) >= 0.1
-        assert "trying to read anyway" in caplog.text
+            assert loaded == data
+            assert (end - start) >= 0.1
+            assert "trying to read anyway" in caplog.text
+        finally:
+            holder.release()
 
 
 def test_load_fails_after_timeout_raises_keyerror(caplog):
@@ -107,12 +112,16 @@ def test_load_fails_after_timeout_raises_keyerror(caplog):
         # Do NOT save data, so load will fail
 
         lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.write_text("dummy")
+        holder = filelock.FileLock(lock_path)
+        holder.acquire()
 
-        with pytest.raises(KeyError):
-            storage.load(key)
+        try:
+            with pytest.raises(KeyError):
+                storage.load(key)
 
-        assert "Failed to read" in caplog.text
+            assert "Failed to read" in caplog.text
+        finally:
+            holder.release()
 
 
 def test_save_creates_and_removes_lock(monkeypatch):
@@ -128,15 +137,16 @@ def test_save_creates_and_removes_lock(monkeypatch):
             nonlocal write_called
             if self == data_path:
                 assert lock_path.exists()
-                content = lock_path.read_text().splitlines()
-                assert content[0] == socket.gethostname()
                 write_called = True
             return len(data)
 
         monkeypatch.setattr(Path, "write_bytes", mocked_write_bytes)
         storage.save("data", key=key)
         assert write_called
-        assert not lock_path.exists()
+        # verify the lock is released after save (can re-acquire immediately)
+        verifier = filelock.FileLock(lock_path, timeout=0.1)
+        verifier.acquire()
+        verifier.release()
 
 
 def test_list_excludes_locks():
@@ -146,7 +156,7 @@ def test_list_excludes_locks():
         storage.save("data", key=key)
 
         lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.write_text("dummy")
+        lock_path.touch()
 
         keys = list(storage.list())
         assert key in keys
@@ -162,7 +172,7 @@ def test_evict_removes_lock():
         storage.save("data", key=key)
 
         lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.write_text("dummy")
+        lock_path.touch()
 
         storage.evict(key)
         assert not lock_path.exists()

--- a/tests/unit/storage/test_file_storage.py
+++ b/tests/unit/storage/test_file_storage.py
@@ -1,6 +1,5 @@
 import time
 import threading
-import tempfile
 import filelock
 from pathlib import Path
 import pytest
@@ -23,156 +22,93 @@ class ConcreteFileStorage(FileStorage):
 def test_file_storage_list_filtering(tmp_path):
     storage = ConcreteFileStorage(root=tmp_path)
 
-    # Create valid files (simulating digests)
     valid_digest1 = "a" * 64
     valid_digest2 = "b" * 64
 
     (tmp_path / valid_digest1).touch()
     (tmp_path / valid_digest2).touch()
-
-    # Create lock files
     (tmp_path / f"{valid_digest1}.lock").touch()
     (tmp_path / "other.lock").touch()
-
-    # Create a directory (edge case)
     (tmp_path / "subdir").mkdir()
-
-    # Create a hidden file (edge case)
     (tmp_path / ".hidden").touch()
-
-    # Create a hidden directory (edge case)
     (tmp_path / ".hidden_dir").mkdir()
 
     items = list(storage.list())
 
+    assert len(items) == 2
     assert Digest(valid_digest1) in items
     assert Digest(valid_digest2) in items
-    assert Digest(f"{valid_digest1}.lock") not in items
-    assert Digest("other.lock") not in items
-    assert Digest("subdir") not in items
-    assert Digest(".hidden") not in items
-    assert Digest(".hidden_dir") not in items
-
-    assert len(items) == 2
 
 
-def test_load_waits_for_lock():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir, lock_timeout=2.0)
-        key = digest("test")
-        data = "content"
-        storage.save(data, key=key)
+def test_load_waits_for_lock(tmp_path):
+    storage = PickleFile.with_pickle(tmp_path, lock_timeout=2.0)
+    key = digest("test")
+    storage.save("content", key=key)
 
-        lock_path = Path(tmpdir) / f"{key}.lock"
-        holder = filelock.FileLock(lock_path)
-        holder.acquire()
+    lock_path = tmp_path / f"{key}.lock"
+    holder = filelock.FileLock(lock_path)
+    holder.acquire()
 
-        def release_lock_later():
-            time.sleep(0.2)
-            holder.release()
+    def release_lock_later():
+        time.sleep(0.2)
+        holder.release()
 
-        start = time.perf_counter()
-        threading.Thread(target=release_lock_later).start()
+    threading.Thread(target=release_lock_later).start()
+    start = time.perf_counter()
+    loaded = storage.load(key)
+    assert loaded == "content"
+    assert time.perf_counter() - start >= 0.2
 
+
+def test_load_timeouts_and_reads_anyway(tmp_path, caplog):
+    storage = PickleFile.with_pickle(tmp_path, lock_timeout=0.1)
+    key = digest("test")
+    storage.save("content", key=key)
+
+    lock_path = tmp_path / f"{key}.lock"
+    holder = filelock.FileLock(lock_path)
+    holder.acquire()
+    try:
         loaded = storage.load(key)
-        end = time.perf_counter()
-
-        assert loaded == data
-        assert (end - start) >= 0.2
-        print(f"Waited for {(end - start):.3f}s")
-
-
-def test_load_timeouts_and_reads_anyway(caplog):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir, lock_timeout=0.1)
-        key = digest("test")
-        data = "content"
-        storage.save(data, key=key)
-
-        lock_path = Path(tmpdir) / f"{key}.lock"
-        holder = filelock.FileLock(lock_path)
-        holder.acquire()
-
-        try:
-            start = time.perf_counter()
-            loaded = storage.load(key)
-            end = time.perf_counter()
-
-            assert loaded == data
-            assert (end - start) >= 0.1
-            assert "trying to read anyway" in caplog.text
-        finally:
-            holder.release()
+        assert loaded == "content"
+        assert "trying to read anyway" in caplog.text
+    finally:
+        holder.release()
 
 
-def test_load_fails_after_timeout_raises_keyerror(caplog):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir, lock_timeout=0.1)
-        key = digest("test")
-        # Do NOT save data, so load will fail
+def test_load_fails_after_timeout_raises_keyerror(tmp_path, caplog):
+    storage = PickleFile.with_pickle(tmp_path, lock_timeout=0.1)
+    key = digest("test")
 
-        lock_path = Path(tmpdir) / f"{key}.lock"
-        holder = filelock.FileLock(lock_path)
-        holder.acquire()
-
-        try:
-            with pytest.raises(KeyError):
-                storage.load(key)
-
-            assert "Failed to read" in caplog.text
-        finally:
-            holder.release()
+    lock_path = tmp_path / f"{key}.lock"
+    holder = filelock.FileLock(lock_path)
+    holder.acquire()
+    try:
+        with pytest.raises(KeyError):
+            storage.load(key)
+        assert "Failed to read" in caplog.text
+    finally:
+        holder.release()
 
 
-def test_save_creates_and_removes_lock(monkeypatch):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir)
-        key = digest("test")
-        lock_path = storage._path(f"{key}.lock")
-        data_path = storage._path(key)
+def test_save_releases_lock(tmp_path):
+    storage = PickleFile.with_pickle(tmp_path)
+    key = digest("test")
+    storage.save("data", key=key)
 
-        write_called = False
-
-        def mocked_write_bytes(self, data):
-            nonlocal write_called
-            if self == data_path:
-                assert lock_path.exists()
-                write_called = True
-            return len(data)
-
-        monkeypatch.setattr(Path, "write_bytes", mocked_write_bytes)
-        storage.save("data", key=key)
-        assert write_called
-        # verify the lock is released after save (can re-acquire immediately)
-        verifier = filelock.FileLock(lock_path, timeout=0.1)
-        verifier.acquire()
-        verifier.release()
+    lock_path = tmp_path / f"{key}.lock"
+    verifier = filelock.FileLock(lock_path, timeout=0.1)
+    verifier.acquire()
+    verifier.release()
 
 
-def test_list_excludes_locks():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir)
-        key = digest("test")
-        storage.save("data", key=key)
+def test_evict_removes_lock(tmp_path):
+    storage = PickleFile.with_pickle(tmp_path)
+    key = digest("test")
+    storage.save("data", key=key)
 
-        lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.touch()
+    lock_path = tmp_path / f"{key}.lock"
+    lock_path.touch()
 
-        keys = list(storage.list())
-        assert key in keys
-        assert len(keys) == 1
-        for k in keys:
-            assert not k.endswith(".lock")
-
-
-def test_evict_removes_lock():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = PickleFile.with_pickle(tmpdir)
-        key = digest("test")
-        storage.save("data", key=key)
-
-        lock_path = Path(tmpdir) / f"{key}.lock"
-        lock_path.touch()
-
-        storage.evict(key)
-        assert not lock_path.exists()
+    storage.evict(key)
+    assert not lock_path.exists()


### PR DESCRIPTION
Swaps the hand-rolled TOCTOU-racy write lock and polling read lock in storage/file.py for filelock.FileLock (OS-level fcntl/msvcrt, atomic). Retains "read anyway after timeout" semantics: on Timeout the read proceeds with a warning; if it then fails, raises KeyError.

Removes lock_wait_start (was only the initial exponential-backoff interval; filelock has its own configurable poll interval).

Closes #221