### PR TITLE
docs(configuration): remove nonexistent lock_wait_start parameter

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -120,7 +120,7 @@ Available storage types
      - Filesystem backend, standard ``pickle``
        (:class:`~fleche.storage.ValuePickleFile` / :class:`~fleche.storage.CallPickleFile`)
      - ``root``
-     - ``compress``, ``lock_timeout``, ``lock_wait_start``,
+     - ``compress``, ``lock_timeout``,
        ``secret_key``, ``remaining_depth`` *(value only)*
    * - ``"cloudpickle"``
      - Filesystem backend, ``cloudpickle``; handles lambdas, closures, etc.
@@ -137,7 +137,7 @@ Available storage types
        (:class:`~fleche.storage.ValueBagOfHoldingH5File` /
        :class:`~fleche.storage.CallBagOfHoldingH5File`)
      - ``root``
-     - ``lock_timeout``, ``lock_wait_start``,
+     - ``lock_timeout``,
        ``version_validator``, ``remaining_depth`` *(value only)*
    * - ``"sql"``
      - SQL via SQLAlchemy (:class:`~fleche.storage.Sql`).
@@ -157,10 +157,6 @@ Key descriptions
 ``lock_timeout``
     (float, default ``1.0``) — maximum seconds to wait for a concurrent write lock
     before attempting a read anyway.
-
-``lock_wait_start``
-    (float, default ``0.001``) — initial poll interval (seconds) for exponential
-    backoff while waiting for the write lock.
 
 ``secret_key``
     (list of hex strings) — HMAC-SHA256 signing keys for tamper detection;


### PR DESCRIPTION
## Summary

- `lock_wait_start` appeared in the storage configuration table (for `"pickle"`, `"cloudpickle"`, `"dill"`, and `"bagofholding_hdf"` backends) and in the Key Descriptions section, but this parameter **does not exist anywhere in the source code**.

## Why it wouldn't work

`FileStorage` (the base for all disk-backed backends) only accepts `root` and `lock_timeout`. Passing `lock_wait_start` to any concrete storage constructor — e.g. `ValuePickleFile.with_pickle(root=..., lock_wait_start=0.001)` — raises:

```
TypeError: ValuePickleFile.__init__() got an unexpected keyword argument 'lock_wait_start'
```

The `filelock` library manages internal polling/backoff on its own; there is no exposed knob for the initial poll interval in fleche's storage layer.

## Changes

- Removed `lock_wait_start` from the optional-parameters column for `"pickle"` (and its `"cloudpickle"` / `"dill"` variants that say "same as pickle") and `"bagofholding_hdf"`.
- Removed the `lock_wait_start` key-description entry.

## Test plan

- [ ] Verify no `lock_wait_start` remains in `docs/storage/configuration.rst`
- [ ] Grep confirms `lock_wait_start` is absent from `src/` (was already absent before this PR)
- [ ] Existing tests continue to pass (`pytest tests/`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WziTVYgCsQZcxiS8p44MVR)_