### PR TITLE
docs(helpers): fix hash_code default and descriptor protocol explanation

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -61,7 +61,7 @@ To keep the cache-hit hot path fast, ``@fleche`` memoises three pure-of-``func``
 quantities the first time it sees a given function:
 
 - ``inspect.signature(func)``
-- the digest of ``func.__code__`` (when ``hash_code=True``, the default)
+- the digest of ``func.__code__`` (included in cache keys only when ``hash_code=True``; the default is ``False``)
 - ``(qualname, module, version)`` extracted via
   :class:`pyiron_snippets.versions.VersionInfo`
 
@@ -113,11 +113,11 @@ Usage with Decorated Methods
 .. note::
 
    When ``@fleche`` is applied to a method, the helper methods (`.call`, `.digest`, `.query`,
-   `.load`, `.contains`, `.rerun`) do **not** automatically bind ``self``. Accessing
-   ``obj.method.query`` returns the same unbound helper as ``MyClass.method.query`` — Python's
-   descriptor protocol does not propagate through attribute lookups on bound methods.
-
-   You must pass the instance explicitly as the first positional argument.
+   `.load`, `.contains`, `.rerun`) do **not** automatically bind ``self``. Python's bound method
+   objects delegate custom attribute lookups to the underlying function, so
+   ``obj.method.query`` and ``MyClass.method.query`` return the same helper function.
+   However, this helper is a plain function — not a bound method — so ``obj`` is not
+   pre-applied; you must pass the instance explicitly as the first positional argument.
 
    For ``fleche`` to cache calls that include ``self``, the class must be hashable —
    i.e. it must implement a ``__digest__`` method (see :doc:`/dev/custom_digests`).


### PR DESCRIPTION
## Summary

Two factual errors in `docs/usage/helpers.rst`:

1. **Wrong default for `hash_code`** — the Per-Function Static Caching section said the code digest is computed "when `hash_code=True`, the default". The actual default is `hash_code=False`. The fleche decorator signature confirms: `hash_code: bool = False`.

2. **Incorrect descriptor-protocol claim** — the decorated-methods note stated "Python's descriptor protocol does not propagate through attribute lookups on bound methods", implying `obj.method.query` would raise `AttributeError`. This is wrong. Python bound method objects *do* delegate custom attribute lookups to `__func__`, so `obj.method.query` works and returns the same function as `MyClass.method.query`. The real reason `self` must be passed explicitly is that the helper is a plain function, not a bound method — `obj` is never pre-applied.

## Why the examples still work

The code examples in the note were correct all along: you do need to write `obj.compute.query(obj, x=5)`. The *explanation* of why was wrong — not the usage guidance.

## Verification

```python
from fleche.wrapper import fleche
import inspect
sig = inspect.signature(fleche)
print(sig.parameters['hash_code'].default)  # False

from fleche import fleche as fl
from fleche.digest import digest, Digest

class MyClass:
    def __init__(self, id):
        self.id = id
    def __digest__(self):
        return digest((type(self).__name__, self.id))
    @fl
    def compute(self, x):
        return x ** 2

obj = MyClass(1)
# attribute access works; same object in both cases
assert obj.compute.query is MyClass.compute.query  # True
```

## Test plan

- [ ] `pytest tests/` passes
- [ ] `hash_code=False` is the correct default (confirmed above)
- [ ] `obj.method.query` attribute access is accessible (confirmed above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WziTVYgCsQZcxiS8p44MVR)_