### PR TITLE
feat(storage): add rebag convenience method to BagOfHoldingH5FileBackend

### DIFF
--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -3,8 +3,6 @@ from pathlib import Path
 from typing import Any, Literal
 import logging
 
-import filelock
-
 from .file import FileStorage
 from .base import SaveError, ValueMixin, CallMixin
 from .thread_safe import PerKeyLockMixin
@@ -51,7 +49,7 @@ class BagOfHoldingH5FileBackend(FileStorage):
             logger.error(f"Corrupt file present in cache at path {path}: {e}")
             raise KeyError(path) from e
 
-    def resave_all(self, version_validator: VersionValidator = "none") -> None:
+    def rebag(self, version_validator: VersionValidator = "none") -> None:
         """Re-open and re-save all bags using the given version validator.
 
         Useful when bags were created with an older library version and
@@ -59,13 +57,12 @@ class BagOfHoldingH5FileBackend(FileStorage):
         """
         for key in list(self.list()):
             path = self._path(key)
-            lock_path = self._path(f"{key}.lock")
-            with filelock.FileLock(lock_path, timeout=self.lock_timeout):
+            with self._operation_context(key):
                 try:
                     value = H5Bag(path).load(version_validator=version_validator)
                     H5Bag.save(value, path)
-                except OSError:
-                    continue
+                except OSError as e:
+                    logger.warning("Failed to rebag %s: %s", key, e)
 
 
 @dataclass(frozen=True)

--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Any, Literal
 import logging
 
+import filelock
+
 from .file import FileStorage
 from .base import SaveError, ValueMixin, CallMixin
 from .thread_safe import PerKeyLockMixin
@@ -48,6 +50,22 @@ class BagOfHoldingH5FileBackend(FileStorage):
         except OSError as e:
             logger.error(f"Corrupt file present in cache at path {path}: {e}")
             raise KeyError(path) from e
+
+    def resave_all(self, version_validator: VersionValidator = "none") -> None:
+        """Re-open and re-save all bags using the given version validator.
+
+        Useful when bags were created with an older library version and
+        would otherwise fail strict version checking on load.
+        """
+        for key in list(self.list()):
+            path = self._path(key)
+            lock_path = self._path(f"{key}.lock")
+            with filelock.FileLock(lock_path, timeout=self.lock_timeout):
+                try:
+                    value = H5Bag(path).load(version_validator=version_validator)
+                    H5Bag.save(value, path)
+                except OSError:
+                    continue
 
 
 @dataclass(frozen=True)

--- a/tests/unit/storage/test_bagofholding_file.py
+++ b/tests/unit/storage/test_bagofholding_file.py
@@ -1,4 +1,6 @@
 import logging
+from unittest.mock import MagicMock
+
 import pytest
 
 from fleche.digest import Digest
@@ -38,21 +40,9 @@ def test_version_validator_passed_to_load(tmp_path, monkeypatch):
     pytest.importorskip("bagofholding")
     import fleche.storage.bagofholding_file as boh_mod
 
-    captured = {}
-
-    class FakeH5Bag:
-        def __init__(self, path):
-            self.path = path
-
-        def load(self, **kwargs):
-            captured.update(kwargs)
-            return 42
-
-        @staticmethod
-        def save(value, path):
-            pass
-
-    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.return_value = 42
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
 
     s = BagOfHoldingH5FileBackend(tmp_path, version_validator="semantic-minor")
     key = Digest("test_key")
@@ -60,123 +50,74 @@ def test_version_validator_passed_to_load(tmp_path, monkeypatch):
     result = s.get(key)
 
     assert result == 42
-    assert captured.get("version_validator") == "semantic-minor"
+    mock_h5bag.return_value.load.assert_called_with(version_validator="semantic-minor")
 
 
 def test_version_validator_none_not_passed_to_load(tmp_path, monkeypatch):
     pytest.importorskip("bagofholding")
     import fleche.storage.bagofholding_file as boh_mod
 
-    captured = {"called": False}
-
-    class FakeH5Bag:
-        def __init__(self, path):
-            self.path = path
-
-        def load(self, **kwargs):
-            captured["kwargs"] = kwargs
-            captured["called"] = True
-            return 42
-
-        @staticmethod
-        def save(value, path):
-            pass
-
-    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.return_value = 42
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
 
     s = BagOfHoldingH5FileBackend(tmp_path)
     key = Digest("test_key2")
     s.put(42, key)
     s.get(key)
 
-    assert captured["called"]
-    assert "version_validator" not in captured["kwargs"]
+    _, kwargs = mock_h5bag.return_value.load.call_args
+    assert "version_validator" not in kwargs
 
 
-def test_resave_all_calls_load_and_save(tmp_path, monkeypatch):
+def test_rebag_calls_load_and_save(tmp_path, monkeypatch):
     pytest.importorskip("bagofholding")
     import fleche.storage.bagofholding_file as boh_mod
 
-    load_calls = []
-    save_calls = []
-
-    class FakeH5Bag:
-        def __init__(self, path):
-            self.path = path
-
-        def load(self, **kwargs):
-            load_calls.append(kwargs)
-            return 99
-
-        @staticmethod
-        def save(value, path):
-            save_calls.append((value, path))
-
-    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.return_value = 99
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
 
     s = BagOfHoldingH5FileBackend(tmp_path)
     key = Digest("resave_key")
-    # Create a file on disk directly so list() sees it
     s._path(key).write_bytes(b"dummy")
 
-    s.resave_all(version_validator="none")
+    s.rebag(version_validator="none")
 
-    assert len(load_calls) == 1
-    assert load_calls[0]["version_validator"] == "none"
-    assert len(save_calls) == 1
-    assert save_calls[0][0] == 99
+    mock_h5bag.return_value.load.assert_called_once_with(version_validator="none")
+    mock_h5bag.save.assert_called_once_with(99, s._path(key))
 
 
-def test_resave_all_skips_oserror(tmp_path, monkeypatch):
+def test_rebag_skips_oserror(tmp_path, monkeypatch, caplog):
     pytest.importorskip("bagofholding")
     import fleche.storage.bagofholding_file as boh_mod
 
-    class FakeH5Bag:
-        def __init__(self, path):
-            self.path = path
-
-        def load(self, **kwargs):
-            raise OSError("broken bag")
-
-        @staticmethod
-        def save(value, path):
-            pass
-
-    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.side_effect = OSError("broken bag")
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
 
     s = BagOfHoldingH5FileBackend(tmp_path)
     key = Digest("broken_key")
-    # Create a file on disk directly so list() sees it
     s._path(key).write_bytes(b"dummy")
 
-    s.resave_all(version_validator="none")  # should not raise
+    with caplog.at_level(logging.WARNING, logger="fleche.storage.bagofholding_file"):
+        s.rebag(version_validator="none")  # should not raise
+
+    assert "Failed to rebag" in caplog.text
 
 
-def test_resave_all_default_validator_is_none(tmp_path, monkeypatch):
+def test_rebag_default_validator_is_none(tmp_path, monkeypatch):
     pytest.importorskip("bagofholding")
     import fleche.storage.bagofholding_file as boh_mod
 
-    load_calls = []
-
-    class FakeH5Bag:
-        def __init__(self, path):
-            self.path = path
-
-        def load(self, **kwargs):
-            load_calls.append(kwargs)
-            return 1
-
-        @staticmethod
-        def save(value, path):
-            pass
-
-    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.return_value = 1
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
 
     s = BagOfHoldingH5FileBackend(tmp_path)
     key = Digest("default_key")
-    # Create a file on disk directly so list() sees it
     s._path(key).write_bytes(b"dummy")
 
-    s.resave_all()
+    s.rebag()
 
-    assert load_calls[0]["version_validator"] == "none"
+    mock_h5bag.return_value.load.assert_called_once_with(version_validator="none")

--- a/tests/unit/storage/test_bagofholding_file.py
+++ b/tests/unit/storage/test_bagofholding_file.py
@@ -91,3 +91,92 @@ def test_version_validator_none_not_passed_to_load(tmp_path, monkeypatch):
 
     assert captured["called"]
     assert "version_validator" not in captured["kwargs"]
+
+
+def test_resave_all_calls_load_and_save(tmp_path, monkeypatch):
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    load_calls = []
+    save_calls = []
+
+    class FakeH5Bag:
+        def __init__(self, path):
+            self.path = path
+
+        def load(self, **kwargs):
+            load_calls.append(kwargs)
+            return 99
+
+        @staticmethod
+        def save(value, path):
+            save_calls.append((value, path))
+
+    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    key = Digest("resave_key")
+    # Create a file on disk directly so list() sees it
+    s._path(key).write_bytes(b"dummy")
+
+    s.resave_all(version_validator="none")
+
+    assert len(load_calls) == 1
+    assert load_calls[0]["version_validator"] == "none"
+    assert len(save_calls) == 1
+    assert save_calls[0][0] == 99
+
+
+def test_resave_all_skips_oserror(tmp_path, monkeypatch):
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    class FakeH5Bag:
+        def __init__(self, path):
+            self.path = path
+
+        def load(self, **kwargs):
+            raise OSError("broken bag")
+
+        @staticmethod
+        def save(value, path):
+            pass
+
+    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    key = Digest("broken_key")
+    # Create a file on disk directly so list() sees it
+    s._path(key).write_bytes(b"dummy")
+
+    s.resave_all(version_validator="none")  # should not raise
+
+
+def test_resave_all_default_validator_is_none(tmp_path, monkeypatch):
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    load_calls = []
+
+    class FakeH5Bag:
+        def __init__(self, path):
+            self.path = path
+
+        def load(self, **kwargs):
+            load_calls.append(kwargs)
+            return 1
+
+        @staticmethod
+        def save(value, path):
+            pass
+
+    monkeypatch.setattr(boh_mod, "H5Bag", FakeH5Bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    key = Digest("default_key")
+    # Create a file on disk directly so list() sees it
+    s._path(key).write_bytes(b"dummy")
+
+    s.resave_all()
+
+    assert load_calls[0]["version_validator"] == "none"


### PR DESCRIPTION
Adds `rebag(version_validator: VersionValidator = "none")` to `BagOfHoldingH5FileBackend`, wrapping the bag migration pattern from #353 into a single method call. Uses the storage's `_operation_context` for locking so thread-safety is handled by whichever mixin is present in the MRO.

Closes #353

Generated with [Claude Code](https://claude.ai/code)