### PR TITLE
feat: add digest support for stdlib datetime types

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -1,4 +1,5 @@
 import cmath
+import datetime
 import hashlib
 import logging
 import dataclasses
@@ -256,6 +257,16 @@ def _digest(value: Any) -> Digest:
             if hasattr(value, "co_exceptiontable"):
                 props.append(value.co_exceptiontable)
             m.update(digest(tuple(props)).encode())
+        case datetime.timezone():
+            m.update(digest(value.utcoffset(None)).encode())
+        case datetime.timedelta():
+            m.update(digest(value.total_seconds()).encode())
+        case datetime.datetime():  # datetime subclasses date; must precede date case
+            m.update(value.isoformat().encode())
+        case datetime.date():
+            m.update(value.isoformat().encode())
+        case datetime.time():
+            m.update(value.isoformat().encode())
         case _ if dataclasses.is_dataclass(value):
             # cannot use asdict because it recursively converts values which destroys digests
             # instead (flat-) convert to dictionaries, salt with type name, then fallback to dictionary case.

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -1,4 +1,5 @@
 import cmath
+import datetime
 import struct
 
 import pytest
@@ -410,3 +411,95 @@ def test_local_function_digests_same_as_module_level():
         return x + 1
 
     assert digest(local_add_one) == digest(_module_level_add_one)
+
+
+# --- Tests for datetime type digests ---
+
+
+def test_datetime_date_is_digestible():
+    assert digest(datetime.date(2024, 1, 15)) is not None
+
+
+def test_datetime_datetime_is_digestible():
+    assert digest(datetime.datetime(2024, 1, 15, 12, 0, 0)) is not None
+
+
+def test_datetime_time_is_digestible():
+    assert digest(datetime.time(12, 30, 45)) is not None
+
+
+def test_datetime_timedelta_is_digestible():
+    assert digest(datetime.timedelta(days=3, seconds=7200)) is not None
+
+
+def test_datetime_timezone_is_digestible():
+    assert digest(datetime.timezone.utc) is not None
+    assert digest(datetime.timezone(datetime.timedelta(hours=5))) is not None
+
+
+def test_different_dates_have_different_digests():
+    assert digest(datetime.date(2024, 1, 1)) != digest(datetime.date(2024, 1, 2))
+    assert digest(datetime.date(2024, 1, 1)) != digest(datetime.date(2025, 1, 1))
+
+
+def test_different_datetimes_have_different_digests():
+    assert digest(datetime.datetime(2024, 1, 1, 0, 0)) != digest(datetime.datetime(2024, 1, 1, 0, 1))
+    assert digest(datetime.datetime(2024, 1, 1, 0, 0)) != digest(datetime.datetime(2024, 1, 2, 0, 0))
+
+
+def test_different_times_have_different_digests():
+    assert digest(datetime.time(12, 0, 0)) != digest(datetime.time(12, 0, 1))
+    assert digest(datetime.time(12, 0, 0)) != digest(datetime.time(13, 0, 0))
+
+
+def test_different_timedeltas_have_different_digests():
+    assert digest(datetime.timedelta(days=1)) != digest(datetime.timedelta(days=2))
+    assert digest(datetime.timedelta(seconds=1)) != digest(datetime.timedelta(seconds=2))
+
+
+def test_different_timezones_have_different_digests():
+    tz_utc = datetime.timezone.utc
+    tz_plus5 = datetime.timezone(datetime.timedelta(hours=5))
+    tz_minus3 = datetime.timezone(datetime.timedelta(hours=-3))
+    assert digest(tz_utc) != digest(tz_plus5)
+    assert digest(tz_plus5) != digest(tz_minus3)
+
+
+def test_datetime_subclass_matches_before_date():
+    """datetime.datetime is a subclass of datetime.date; they must produce different digests."""
+    d = datetime.date(2024, 6, 15)
+    dt = datetime.datetime(2024, 6, 15, 0, 0, 0)
+    assert digest(d) != digest(dt)
+
+
+def test_datetime_same_value_same_digest():
+    assert digest(datetime.date(2024, 3, 10)) == digest(datetime.date(2024, 3, 10))
+    assert digest(datetime.datetime(2024, 3, 10, 8, 0)) == digest(datetime.datetime(2024, 3, 10, 8, 0))
+    assert digest(datetime.time(8, 30)) == digest(datetime.time(8, 30))
+    assert digest(datetime.timedelta(hours=2)) == digest(datetime.timedelta(hours=2))
+    assert digest(datetime.timezone.utc) == digest(datetime.timezone.utc)
+
+
+def test_datetime_timezone_aware_differs_from_naive():
+    """A timezone-aware datetime digests differently from a naive one with the same wall-clock values."""
+    naive = datetime.datetime(2024, 1, 1, 12, 0)
+    aware = datetime.datetime(2024, 1, 1, 12, 0, tzinfo=datetime.timezone.utc)
+    assert digest(naive) != digest(aware)
+
+
+def test_datetime_stdlib_class_constants_digestible():
+    """Motivating use case: stdlib class-level datetime constants (e.g. date.min) must be digestible.
+
+    This is needed so that digest(dict(datetime.date.__dict__)) can eventually work.
+    """
+    assert digest(datetime.date.min) is not None
+    assert digest(datetime.date.max) is not None
+    assert digest(datetime.date.resolution) is not None
+    assert digest(datetime.datetime.min) is not None
+    assert digest(datetime.datetime.max) is not None
+    assert digest(datetime.time.min) is not None
+    assert digest(datetime.time.max) is not None
+    assert digest(datetime.timedelta.min) is not None
+    assert digest(datetime.timedelta.max) is not None
+    assert digest(datetime.timedelta.resolution) is not None
+    assert digest(datetime.timezone.utc) is not None


### PR DESCRIPTION
Fixes part of the stdlib type-digest survey from #475.

## Summary

- Adds `match` cases for `datetime.timezone`, `datetime.timedelta`, `datetime.datetime`, `datetime.date`, and `datetime.time` in `_digest()`
- `datetime.datetime` case precedes `datetime.date` to respect the subclass relationship
- Digests are stable and location-independent: `isoformat()` for date/datetime/time, `total_seconds()` for timedelta, `utcoffset(None)` (delegates to timedelta) for timezone
- Motivating use case: stdlib class-level constants (`datetime.date.min`, `datetime.date.max`, `datetime.timedelta.resolution`, etc.) are now digestible — this is required for eventual strict `digest(T) == digest(dict(T.__dict__))` equivalence for types with datetime class attributes

## Test plan

- [ ] `test_datetime_date_is_digestible` / `datetime_is_digestible` / `time_is_digestible` / `timedelta_is_digestible` / `timezone_is_digestible` — basic smoke tests
- [ ] `test_different_dates/datetimes/times/timedeltas/timezones_have_different_digests` — distinctness
- [ ] `test_datetime_same_value_same_digest` — stability
- [ ] `test_datetime_subclass_matches_before_date` — datetime ≠ date for same wall-clock
- [ ] `test_datetime_timezone_aware_differs_from_naive` — tz-aware vs naive
- [ ] `test_datetime_stdlib_class_constants_digestible` — regression for the Group 3 motivating use case

All 870 tests pass, 11 skipped.

This is Group 3 from the survey in #475 discussion, broken out per request.

🤖 Generated with [Claude Code](https://claude.ai/code)