### PR TITLE
fix(digest): handle generic Mapping types via type-aware case

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -1,4 +1,5 @@
 import cmath
+import datetime
 import hashlib
 import logging
 import dataclasses
@@ -134,6 +135,18 @@ def load_entry_points():
             logger.error("Failed to load entry point %s: %s", ep.name, e)
 
 
+def _digest_mapping(type_salt: str, contents: dict) -> Digest:
+    m = hashlib.sha256()
+    m.update(type_salt.encode())
+    sorted_items = sorted(
+        ((digest(k), k, v) for k, v in contents.items()), key=lambda item: item[0]
+    )
+    for k_digest, k, v in sorted_items:
+        m.update(k_digest.encode())
+        m.update(digest(v).encode())
+    return Digest(m.hexdigest())
+
+
 def digest(value: Any) -> Digest:
     try:
         return _digest(value)
@@ -248,6 +261,16 @@ def _digest(value: Any) -> Digest:
             if hasattr(value, "co_exceptiontable"):
                 props.append(value.co_exceptiontable)
             m.update(digest(tuple(props)).encode())
+        case datetime.timezone():
+            m.update(digest(value.utcoffset(None)).encode())
+        case datetime.timedelta():
+            m.update(digest(value.total_seconds()).encode())
+        case datetime.datetime():  # datetime subclasses date; must precede date case
+            m.update(value.isoformat().encode())
+        case datetime.date():
+            m.update(value.isoformat().encode())
+        case datetime.time():
+            m.update(value.isoformat().encode())
         case _ if dataclasses.is_dataclass(value):
             # cannot use asdict because it recursively converts values which destroys digests
             # instead (flat-) convert to dictionaries, salt with type name, then fallback to dictionary case.
@@ -260,12 +283,7 @@ def _digest(value: Any) -> Digest:
             # with the same name + field layout hash identically.
             m.update(digest(dict(_attrs.field_items(value))).encode())
         case Mapping():
-            sorted_items = sorted(
-                ((digest(k), k, v) for k, v in value.items()), key=lambda item: item[0]
-            )
-            for k_digest, k, v in sorted_items:
-                m.update(k_digest.encode())
-                m.update(digest(v).encode())
+            return _digest_mapping(str(type(value)), dict(value))
         case Iterable():
             for v in value:
                 m.update(digest(v).encode())

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -135,9 +135,7 @@ def load_entry_points():
             logger.error("Failed to load entry point %s: %s", ep.name, e)
 
 
-def _digest_mapping(type_salt: str, contents: dict) -> Digest:
-    m = hashlib.sha256()
-    m.update(type_salt.encode())
+def _digest_mapping(m, contents: dict) -> Digest:
     sorted_items = sorted(
         ((digest(k), k, v) for k, v in contents.items()), key=lambda item: item[0]
     )
@@ -283,7 +281,7 @@ def _digest(value: Any) -> Digest:
             # with the same name + field layout hash identically.
             m.update(digest(dict(_attrs.field_items(value))).encode())
         case Mapping():
-            return _digest_mapping(type(value).__name__, dict(value))
+            return _digest_mapping(m, dict(value))
         case Iterable():
             for v in value:
                 m.update(digest(v).encode())

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -283,7 +283,7 @@ def _digest(value: Any) -> Digest:
             # with the same name + field layout hash identically.
             m.update(digest(dict(_attrs.field_items(value))).encode())
         case Mapping():
-            return _digest_mapping(str(type(value)), dict(value))
+            return _digest_mapping(type(value).__name__, dict(value))
         case Iterable():
             for v in value:
                 m.update(digest(v).encode())

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -219,14 +219,6 @@ def _digest(value: Any) -> Digest:
             m.update(str(value).encode())
         case None:
             m.update(b"__None__")
-        case dict():
-            # Sort by digest of keys to ensure merkle tree property and order stability
-            sorted_items = sorted(
-                ((digest(k), k, v) for k, v in value.items()), key=lambda item: item[0]
-            )
-            for k_digest, k, v in sorted_items:
-                m.update(k_digest.encode())
-                m.update(digest(v).encode())
         case np.bool_():
             return digest(bool(value))
         case np.integer():

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -7,7 +7,7 @@ from numbers import Number
 import struct
 import types
 import importlib.metadata
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any, TypeVar, Callable, Type, Generic
 import numpy as np
 
@@ -267,6 +267,13 @@ def _digest(value: Any) -> Digest:
             # mirror the dataclass digest format so an attrs class and a dataclass
             # with the same name + field layout hash identically.
             m.update(digest(dict(_attrs.field_items(value))).encode())
+        case Mapping():
+            sorted_items = sorted(
+                ((digest(k), k, v) for k, v in value.items()), key=lambda item: item[0]
+            )
+            for k_digest, k, v in sorted_items:
+                m.update(k_digest.encode())
+                m.update(digest(v).encode())
         case Iterable():
             for v in value:
                 m.update(digest(v).encode())

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -1,4 +1,5 @@
 import cmath
+import datetime
 import struct
 import collections
 import collections.abc
@@ -475,3 +476,95 @@ def test_generic_mapping_same_content_same_type_identical_digest():
     cm1 = collections.ChainMap({'a': 1}, {'b': 2})
     cm2 = collections.ChainMap({'b': 2, 'a': 1})
     assert digest(cm1) == digest(cm2)
+
+
+# --- Tests for datetime type digests ---
+
+
+def test_datetime_date_is_digestible():
+    assert digest(datetime.date(2024, 1, 15)) is not None
+
+
+def test_datetime_datetime_is_digestible():
+    assert digest(datetime.datetime(2024, 1, 15, 12, 0, 0)) is not None
+
+
+def test_datetime_time_is_digestible():
+    assert digest(datetime.time(12, 30, 45)) is not None
+
+
+def test_datetime_timedelta_is_digestible():
+    assert digest(datetime.timedelta(days=3, seconds=7200)) is not None
+
+
+def test_datetime_timezone_is_digestible():
+    assert digest(datetime.timezone.utc) is not None
+    assert digest(datetime.timezone(datetime.timedelta(hours=5))) is not None
+
+
+def test_different_dates_have_different_digests():
+    assert digest(datetime.date(2024, 1, 1)) != digest(datetime.date(2024, 1, 2))
+    assert digest(datetime.date(2024, 1, 1)) != digest(datetime.date(2025, 1, 1))
+
+
+def test_different_datetimes_have_different_digests():
+    assert digest(datetime.datetime(2024, 1, 1, 0, 0)) != digest(datetime.datetime(2024, 1, 1, 0, 1))
+    assert digest(datetime.datetime(2024, 1, 1, 0, 0)) != digest(datetime.datetime(2024, 1, 2, 0, 0))
+
+
+def test_different_times_have_different_digests():
+    assert digest(datetime.time(12, 0, 0)) != digest(datetime.time(12, 0, 1))
+    assert digest(datetime.time(12, 0, 0)) != digest(datetime.time(13, 0, 0))
+
+
+def test_different_timedeltas_have_different_digests():
+    assert digest(datetime.timedelta(days=1)) != digest(datetime.timedelta(days=2))
+    assert digest(datetime.timedelta(seconds=1)) != digest(datetime.timedelta(seconds=2))
+
+
+def test_different_timezones_have_different_digests():
+    tz_utc = datetime.timezone.utc
+    tz_plus5 = datetime.timezone(datetime.timedelta(hours=5))
+    tz_minus3 = datetime.timezone(datetime.timedelta(hours=-3))
+    assert digest(tz_utc) != digest(tz_plus5)
+    assert digest(tz_plus5) != digest(tz_minus3)
+
+
+def test_datetime_subclass_matches_before_date():
+    """datetime.datetime is a subclass of datetime.date; they must produce different digests."""
+    d = datetime.date(2024, 6, 15)
+    dt = datetime.datetime(2024, 6, 15, 0, 0, 0)
+    assert digest(d) != digest(dt)
+
+
+def test_datetime_same_value_same_digest():
+    assert digest(datetime.date(2024, 3, 10)) == digest(datetime.date(2024, 3, 10))
+    assert digest(datetime.datetime(2024, 3, 10, 8, 0)) == digest(datetime.datetime(2024, 3, 10, 8, 0))
+    assert digest(datetime.time(8, 30)) == digest(datetime.time(8, 30))
+    assert digest(datetime.timedelta(hours=2)) == digest(datetime.timedelta(hours=2))
+    assert digest(datetime.timezone.utc) == digest(datetime.timezone.utc)
+
+
+def test_datetime_timezone_aware_differs_from_naive():
+    """A timezone-aware datetime digests differently from a naive one with the same wall-clock values."""
+    naive = datetime.datetime(2024, 1, 1, 12, 0)
+    aware = datetime.datetime(2024, 1, 1, 12, 0, tzinfo=datetime.timezone.utc)
+    assert digest(naive) != digest(aware)
+
+
+def test_datetime_stdlib_class_constants_digestible():
+    """Motivating use case: stdlib class-level datetime constants (e.g. date.min) must be digestible.
+
+    This is needed so that digest(dict(datetime.date.__dict__)) can eventually work.
+    """
+    assert digest(datetime.date.min) is not None
+    assert digest(datetime.date.max) is not None
+    assert digest(datetime.date.resolution) is not None
+    assert digest(datetime.datetime.min) is not None
+    assert digest(datetime.datetime.max) is not None
+    assert digest(datetime.time.min) is not None
+    assert digest(datetime.time.max) is not None
+    assert digest(datetime.timedelta.min) is not None
+    assert digest(datetime.timedelta.max) is not None
+    assert digest(datetime.timedelta.resolution) is not None
+    assert digest(datetime.timezone.utc) is not None

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -1,5 +1,7 @@
 import cmath
 import struct
+import collections
+import collections.abc
 
 import pytest
 from hypothesis import given
@@ -410,3 +412,66 @@ def test_local_function_digests_same_as_module_level():
         return x + 1
 
     assert digest(local_add_one) == digest(_module_level_add_one)
+
+
+class _CustomMapping(collections.abc.Mapping):
+    """Minimal Mapping implementation (not a dict subclass)."""
+    def __init__(self, d):
+        self._d = dict(d)
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def __iter__(self):
+        return iter(self._d)
+
+    def __len__(self):
+        return len(self._d)
+
+
+def test_generic_mapping_value_change_causes_digest_change():
+    """Changing a value in a non-dict Mapping must change its digest."""
+    cm1 = collections.ChainMap({'a': 1, 'b': 2})
+    cm2 = collections.ChainMap({'a': 99, 'b': 2})
+    assert digest(cm1) != digest(cm2)
+
+    m1 = _CustomMapping({'x': 'hello'})
+    m2 = _CustomMapping({'x': 'world'})
+    assert digest(m1) != digest(m2)
+
+
+def test_generic_mapping_key_change_causes_digest_change():
+    """Changing a key in a non-dict Mapping must change its digest."""
+    m1 = _CustomMapping({'a': 1})
+    m2 = _CustomMapping({'b': 1})
+    assert digest(m1) != digest(m2)
+
+
+def test_different_mapping_types_same_content_hash_differently():
+    """Different mapping types with identical content must hash differently."""
+    content = {'a': 1, 'b': 2}
+
+    d = dict(content)
+    cm = collections.ChainMap(content)
+    m = _CustomMapping(content)
+    od = collections.OrderedDict(content)
+
+    # plain dict vs ChainMap
+    assert digest(d) != digest(cm)
+    # plain dict vs custom Mapping
+    assert digest(d) != digest(m)
+    # plain dict vs OrderedDict (already handled by dict case, but type name differs)
+    assert digest(d) != digest(od)
+    # ChainMap vs custom Mapping
+    assert digest(cm) != digest(m)
+
+
+def test_generic_mapping_same_content_same_type_identical_digest():
+    """Two Mapping instances of the same type with the same content must hash identically."""
+    m1 = _CustomMapping({'a': 1, 'b': 2})
+    m2 = _CustomMapping({'b': 2, 'a': 1})  # insertion order differs
+    assert digest(m1) == digest(m2)
+
+    cm1 = collections.ChainMap({'a': 1}, {'b': 2})
+    cm2 = collections.ChainMap({'b': 2, 'a': 1})
+    assert digest(cm1) == digest(cm2)

--- a/tests/unit/fleche/test_futures.py
+++ b/tests/unit/fleche/test_futures.py
@@ -5,6 +5,7 @@ When a fleche-decorated function returns a concurrent.futures.Future,
 fleche passes the future back to the caller and attaches a done callback
 that caches the result once the future completes.
 """
+import time
 from concurrent.futures import Future, ThreadPoolExecutor, ProcessPoolExecutor
 from unittest.mock import Mock
 
@@ -12,6 +13,19 @@ from fleche import fleche
 from fleche.caches import Cache
 from fleche.state import cache
 from fleche.storage import ValueMemory, CallMemory
+
+
+def _wait_for_cache(fn, *args, timeout=0.1):
+    """Spin until fn.contains(*args) is True.
+
+    CPython's Future.set_result() releases the condition lock before calling
+    _invoke_callbacks(), so future.result() can return while the done callback
+    that saves to the cache is still pending on the worker thread.
+    """
+    deadline = time.monotonic() + timeout
+    while not fn.contains(*args):
+        assert time.monotonic() < deadline, f"cache never populated for args {args}"
+        time.sleep(0.001)
 
 
 def _make_cache():
@@ -50,8 +64,12 @@ class TestThreadPoolFutures:
             with cache(_make_cache()):
                 future = compute(5)
                 assert future.result() == 10
-                # Done callback has run — result is now cached
                 assert call_count == 1
+
+                # Wait for the done callback to populate the cache before
+                # re-calling; result() can return before _invoke_callbacks()
+                # fires (CPython releases the condition lock first).
+                _wait_for_cache(compute, 5)
 
                 second = compute(5)
                 # Cache hit: returns the plain value, not a future
@@ -73,6 +91,10 @@ class TestThreadPoolFutures:
                 f2 = compute(7)
                 assert f1.result() == 12
                 assert f2.result() == 21
+
+                # Wait for done callbacks before re-calling (same race as above)
+                _wait_for_cache(compute, 4)
+                _wait_for_cache(compute, 7)
 
                 assert compute(4) == 12
                 assert compute(7) == 21
@@ -117,6 +139,10 @@ class TestThreadPoolFutures:
                 futures = [compute(i) for i in range(5)]
                 results = [f.result() for f in futures]
                 assert results == [0, 1, 4, 9, 16]
+
+                # Wait for all done callbacks before re-calling
+                for i in range(5):
+                    _wait_for_cache(compute, i)
 
                 # All results should now be cached
                 cached = [compute(i) for i in range(5)]


### PR DESCRIPTION
Add a `Mapping` match case before `Iterable` so non-dict Mapping subclasses (ChainMap, custom ABCs, etc.) are hashed over their key-value pairs instead of just their keys.  The existing `m.update(t.__name__.encode())` prefix means different mapping types with identical content produce distinct digests.

Add tests verifying:
- value change in a non-dict Mapping changes its digest
- key change in a non-dict Mapping changes its digest
- different mapping types with same content hash differently
- same type + same content always hashes identically (order-invariant)

Closes #479