### PR TITLE
test(caches): cover RefreshingCache always-miss contract

### DIFF
--- a/tests/unit/caches/test_refreshing_cache.py
+++ b/tests/unit/caches/test_refreshing_cache.py
@@ -1,0 +1,37 @@
+from fleche.call import Call
+from fleche.caches import Cache, RefreshingCache
+from fleche.storage import ValueMemory, CallMemory
+
+
+def test_refreshing_cache_always_misses_even_when_underlying_contains_key():
+    """A RefreshingCache must always miss on ``load`` and ``contains``.
+
+    Intent: The whole point of :class:`RefreshingCache` is to force re-execution
+    by hiding existing entries. Both the ``load`` and ``contains`` overrides
+    must return as if the key were absent, regardless of what the wrapped cache
+    holds. Saves and value loads must still be forwarded so newly-computed
+    results can be stored.
+    """
+    inner = Cache(ValueMemory({}), CallMemory({}))
+    stored = Call(name="f", arguments={"x": 1}, result=2)
+    key = inner.save(stored)
+    assert inner.contains(key)
+
+    refreshing = RefreshingCache(inner)
+
+    assert refreshing.contains(key) is False, (
+        "RefreshingCache.contains must report a miss even when the wrapped "
+        "cache holds the key — otherwise nested @fleche calls would short-circuit "
+        "during a rerun."
+    )
+
+    try:
+        refreshing.load(key)
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("RefreshingCache.load must raise KeyError on every key")
+
+    fresh = Call(name="f", arguments={"x": 2}, result=3)
+    fresh_key = refreshing.save(fresh)
+    assert inner.contains(fresh_key), "save must forward to the wrapped cache"


### PR DESCRIPTION
## Summary

Targets the lowest-hanging coverage gap surfaced by `pytest --cov=src/fleche --cov-branch` on `main`.

`RefreshingCache` (caches.py:461) is the wrapper that powers `@fleche().rerun()` — its design contract is "every lookup misses, regardless of what the wrapped cache holds." Both `load` and `contains` were only exercised *indirectly* via `tests/unit/fleche/test_rerun.py`, and `contains` (caches.py:476) was outright uncovered. No `tests/unit/caches/test_refreshing*.py` existed at all.

This PR adds **one** focused test (`test_refreshing_cache_always_misses_even_when_underlying_contains_key`) that pre-populates a `Cache`, wraps it in `RefreshingCache`, and asserts the three contract invariants in the same scenario:

- `contains(key)` returns `False` even though the inner cache has the key
- `load(key)` raises `KeyError`
- `save` still forwards through to the wrapped cache (so freshly-computed results during a rerun do get persisted)

The test is intentionally singly focused: one feature (RefreshingCache), one scenario (populated inner + wrapper), one contract (always-miss + write-through).

## Coverage report

Run command:

```bash
pytest --cov=src/fleche --cov-branch --cov-report=term-missing
```

### Before this PR (`main` @ da9e3f9)

```
Name                                      Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------
src/fleche/__init__.py                       13      3      2      1    73%   5-6, 44
src/fleche/_attrs.py                         12      2      0      0    83%   14-15
src/fleche/caches.py                        301     29     80      6    91%   ..., 476, ...
src/fleche/call.py                          236      8     62      5    96%
src/fleche/config.py                        164      6     76      5    95%
src/fleche/digest.py                        151     10     88     11    91%
src/fleche/executor.py                       35      2     10      0    96%
src/fleche/metadata.py                       33      1      0      0    97%
src/fleche/query.py                         108      0     40      1    99%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/state.py                          52      1     10      1    97%
src/fleche/storage/base.py                  115      1     32      1    99%
src/fleche/storage/destructuring.py         173      4     62      4    97%
src/fleche/storage/pickle_file.py            83      4     16      0    96%
src/fleche/storage/sql.py                   242     16     86      7    92%
src/fleche/storage/thread_safe.py            48      0      4      1    98%
src/fleche/storage/void.py                   20      1      4      0    96%
src/fleche/wrapper.py                       181      1     44      1    99%
src/fleche/storage/bagofholding_file.py      49      1     10      1    97%
... (other 100% modules elided)
-------------------------------------------------------------------------------------
TOTAL                                      2172     93    660     47    95%
```

870 passed, 11 skipped.

### After this PR

```
src/fleche/caches.py                        301     28     80      6    91%
TOTAL                                      2172     92    660     47    95%
```

871 passed, 11 skipped. `caches.py` line 476 (`RefreshingCache.contains` returning `False`) is now covered. Total stays at 95% (1-line absolute gain, below per-module rounding).

## Why this gap and not a bigger one

The other low-coverage hot spots are either:

- **Defensive `KeyError` swallows in `Cache.gc` / `CacheStack.evict`** — only triggered by mid-iteration races or cache corruption, hard to exercise without mocking, and not really a design contract.
- **`__init__.py:44` (`D()` for non-hex strings)** — a one-line helper-fallback, but doesn't represent a load-bearing feature.
- **`_attrs.py:14-15`** — the `attrs` import-failure fallback, only reachable when the optional dep is missing.
- **NumPy scalar branches in `digest.py`** — would need numpy-version-sensitive setup.

The `RefreshingCache` gap is the cleanest match for the brief: a real feature with a clear, documented contract that the suite happened to skip.

## Test plan

- [x] `pytest tests/unit/caches/test_refreshing_cache.py -v` — passes
- [x] Full suite still green: 871 passed, 11 skipped
- [x] Confirmed line 476 covered via `pytest --cov`

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8iwRy3RivzJ5mc5RskJSx)_