### PR TITLE
perf: avoid redundant dict() copy in _digest_mapping

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -135,7 +135,7 @@ def load_entry_points():
             logger.error("Failed to load entry point %s: %s", ep.name, e)
 
 
-def _digest_mapping(m, contents: dict) -> None:
+def _digest_mapping(m, contents: Mapping) -> None:
     sorted_items = sorted(
         ((digest(k), k, v) for k, v in contents.items()), key=lambda item: item[0]
     )
@@ -285,7 +285,7 @@ def _digest(value: Any) -> Digest:
                 names = dir(value)
             _digest_mapping(m, {name: getattr(value, name) for name in names})
         case Mapping():
-            _digest_mapping(m, dict(value))
+            _digest_mapping(m, value)
         case Iterable():
             for v in value:
                 m.update(digest(v).encode())


### PR DESCRIPTION
Fixes hot-spot 2 from #491: for the common case where `value` is already a `dict`, `dict(value)` performed an O(n) shallow copy that served no purpose — `_digest_mapping` only calls `.items()` and never mutates its argument. Broaden the type hint to `Mapping` and pass `value` directly.

Closes #491

Generated with [Claude Code](https://claude.ai/code)