### PR TITLE
docs(helpers): add missing .bind helper documentation

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -40,6 +40,34 @@ See :doc:`query` for a detailed guide on querying cached calls.
 
 Forces the function to re-execute, even if its result is already present in the cache, and saves the newly computed result to the cache. This forces reevaluation recursively for any nested `@fleche` calls as well.
 
+``.bind(*args, **kwargs)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns a :class:`~fleche.state.BoundWrapper` that captures the currently active cache and metadata at the moment of the call. The bound wrapper is a plain callable — it does not carry the ``fleche`` helper namespace.
+
+Optionally pre-applies ``*args`` and ``**kwargs`` via :func:`functools.partial`. This is useful when work needs to be submitted to a process pool where the cache context must travel with the callable.
+
+.. code-block:: python
+
+   from fleche import fleche, cache
+
+   @fleche
+   def add(a, b):
+       return a + b
+
+   with cache("memory"):
+       bound = add.bind()      # freezes the active "memory" cache
+       result = bound(1, 2)    # runs under that cache regardless of current context
+       assert result == 3
+
+   # Pre-apply arguments
+   with cache("memory"):
+       bound_partial = add.bind(1, 2)
+       result = bound_partial()   # equivalent to add(1, 2) in the frozen context
+       assert result == 3
+
+See :class:`~fleche.state.BoundWrapper` for the full API, including pickling support.
+
 Accessing the Original Function
 -------------------------------
 


### PR DESCRIPTION
## Problem

``.bind(*args, **kwargs)`` is implemented in ``wrapper.py`` and attached to every ``@fleche``-decorated function alongside ``.call``, ``.digest``, ``.load``, ``.contains``, ``.query``, and ``.rerun``. It is listed in the ``fleche()`` docstring but was absent from ``docs/usage/helpers.rst``.

## Changes

- Added a ``.bind`` section to the Helper Methods list in ``docs/usage/helpers.rst``.
- Describes what it returns (a ``BoundWrapper`` that freezes the active cache/metadata) and why it is useful (passing fleche-decorated work to process pools).
- Includes a short runnable example covering both the no-arg and partial-application forms — both were manually verified to pass.

## Verification

```python
from fleche import fleche, cache

@fleche
def add(a, b):
    return a + b

with cache("memory"):
    bound = add.bind()
    assert bound(1, 2) == 3

with cache("memory"):
    bound_partial = add.bind(1, 2)
    assert bound_partial() == 3
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNKmavMCzD63AWAJCyCNQr)_