### PR TITLE
docs(query): clarify LazyArguments proxy in wrapper query example

### DIFF
--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -13,7 +13,7 @@ When querying, any field in the template set to ``None`` acts as a wildcard. For
 
 Querying from a wrapper
 -----------------------
-The wrapper-based API builds the correct Call template for you and decodes values on return.
+The wrapper-based API builds the correct Call template for you.
 
 Example::
 
@@ -34,8 +34,11 @@ Example::
     for call in add.query(1, 2, metadata={"tags": {"project": "alpha"}}):
         assert call.name == "add"
         assert call.metadata["tags"]["project"] == "alpha"
-        # arguments and result are decoded from the value storage
-        print(call.arguments, call.result)
+        # call.result is decoded immediately on access
+        print(call.result)                # e.g. 3
+        # call.arguments is a lazy proxy — individual keys are decoded on access
+        print(call.arguments["a"])        # e.g. 1
+        print(dict(call.arguments))       # decode all arguments at once
 
 Notes:
 - ``metadata={"tags": {}}`` matches any call with a "tags" metadata entry (presence check).


### PR DESCRIPTION
## Problem

The "Querying from a wrapper" example in `docs/usage/query.rst` had a misleading comment and `print` call:

```python
# arguments and result are decoded from the value storage
print(call.arguments, call.result)
```

`call.result` is indeed decoded on property access and prints the Python value.  
`call.arguments`, however, returns a `LazyArguments` **proxy** — printing it gives digest strings like `LazyArguments({'a': 'da217d...', 'b': '92a9b2...'})`, not the actual Python objects.

The introductory sentence also claimed the wrapper API "decodes values on return", which incorrectly implied arguments were already a plain dict.

## Why it matters

A reader following this example would see confusing hex-digest output and not know how to retrieve actual argument values.

## Changes

- Replace the single `print(call.arguments, call.result)` with three lines showing the real access patterns:
  - `call.result` — decoded immediately on access (correct as before)
  - `call.arguments["a"]` — decoded per-key on access  
  - `dict(call.arguments)` — decode all arguments at once
- Remove the inaccurate "decodes values on return" phrase from the section intro.

## Verification

```python
from fleche import fleche, tags

@fleche
def add(a, b):
    return a + b

with tags(project="alpha"):
    add(1, 2)

for call in add.query(1, 2, metadata={"tags": {"project": "alpha"}}):
    print(call.result)            # 3
    print(call.arguments["a"])    # 1
    print(dict(call.arguments))   # {'a': 1, 'b': 2}
```

All three lines produce the expected Python values, not digest strings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNKmavMCzD63AWAJCyCNQr)_