### PR TITLE
fix(query): make QueryIterator re-iterable

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -156,7 +156,7 @@ class BaseCache(ABC):
                 yield from self._query(template)
             except _digest.Unhashable as e:
                 logger.warning("No hash for query argument: %s", e.args[0])
-        return query.QueryIterator(_safe_iter())
+        return query.QueryIterator(_safe_iter)
 
     def table(self, arguments: Iterable[str] | str | Literal[True] = (), results=False) -> pd.DataFrame:
         """Return a pandas DataFrame summarizing cached calls via query().

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -24,11 +24,11 @@ def _resolve_key(key: "str | Callable[[call.LazyCall], Any]") -> "Callable[[call
 class QueryIterator(Iterable[call.LazyCall]):
     """Re-iterable view over a lazy query result.
 
-    ``calls`` must be a zero-argument callable that returns a fresh iterable
-    each time it is invoked.  This makes ``QueryIterator`` itself re-iterable:
-    every ``for`` loop, ``list()``, or consuming method starts a new traversal
-    of the underlying source rather than silently seeing an empty sequence on
-    the second call.
+    ``calls`` is a zero-argument callable that returns a fresh iterable each
+    time it is invoked.  Every ``for`` loop, ``list()``, or consuming method
+    therefore starts a new traversal of the underlying source, so the same
+    ``QueryIterator`` can be used multiple times and will reflect the current
+    state of the cache on each pass.
 
     Args:
         calls: factory returning an iterable of :class:`~fleche.call.LazyCall`

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -22,15 +22,22 @@ def _resolve_key(key: "str | Callable[[call.LazyCall], Any]") -> "Callable[[call
 
 @dataclass(frozen=True)
 class QueryIterator(Iterable[call.LazyCall]):
-    """Iterator that adds some convenience to plain iterators over calls of query result.
+    """Re-iterable view over a lazy query result.
+
+    ``calls`` must be a zero-argument callable that returns a fresh iterable
+    each time it is invoked.  This makes ``QueryIterator`` itself re-iterable:
+    every ``for`` loop, ``list()``, or consuming method starts a new traversal
+    of the underlying source rather than silently seeing an empty sequence on
+    the second call.
 
     Args:
-        calls: (iterable of call.LazyCall): underlying results of the query"""
+        calls: factory returning an iterable of :class:`~fleche.call.LazyCall`
+    """
 
-    calls: Iterable[call.LazyCall]
+    calls: Callable[[], Iterable[call.LazyCall]]
 
     def __iter__(self) -> Iterator[call.LazyCall]:
-        yield from self.calls
+        yield from self.calls()
 
     def only(self) -> call.LazyCall:
         """Return the single matching call.
@@ -71,15 +78,15 @@ class QueryIterator(Iterable[call.LazyCall]):
 
     def take(self, n: int) -> "QueryIterator":
         """Return first n results as a new QueryIterator (lazy)."""
-        return QueryIterator(itertools.islice(iter(self), n))
+        return QueryIterator(lambda: itertools.islice(iter(self), n))
 
     def skip(self, n: int) -> "QueryIterator":
         """Skip first n results and return the rest as a new QueryIterator (lazy)."""
-        return QueryIterator(itertools.islice(iter(self), n, None))
+        return QueryIterator(lambda: itertools.islice(iter(self), n, None))
 
     def filter(self, predicate: Callable[[call.LazyCall], bool]) -> "QueryIterator":
         """Return a new QueryIterator keeping only calls where predicate(call) is truthy (lazy)."""
-        return QueryIterator(c for c in self.calls if predicate(c))
+        return QueryIterator(lambda: (c for c in self if predicate(c)))
 
     def sorted(
         self,
@@ -93,7 +100,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             reverse: if True, sort in descending order
         """
         key = _resolve_key(key) if key is not None else None
-        return QueryIterator(builtins.sorted(self, key=key, reverse=reverse))
+        return QueryIterator(lambda: builtins.sorted(self, key=key, reverse=reverse))
 
     def unique(self, key: "str | Callable[[call.LazyCall], Any]") -> "QueryIterator":
         """Return a new QueryIterator with duplicates removed, keeping the first per group (lazy).
@@ -111,7 +118,7 @@ class QueryIterator(Iterable[call.LazyCall]):
                     seen.add(v)
                     yield c
 
-        return QueryIterator(_unique(self.calls, key))
+        return QueryIterator(lambda: _unique(self, key))
 
     def groupby(self, key: "str | Callable[[call.LazyCall], Any]") -> "dict[Any, QueryIterator]":
         """Partition calls into a dict of QueryIterators keyed by group value.
@@ -126,7 +133,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             if k not in groups:
                 groups[k] = []
             groups[k].append(c)
-        return {k: QueryIterator(v) for k, v in groups.items()}
+        return {k: QueryIterator(lambda v=v: v) for k, v in groups.items()}
 
     def _timestop_extremum(self, *, reverse: bool) -> call.LazyCall:
         sentinel = float("-inf") if reverse else float("inf")
@@ -197,7 +204,7 @@ class QueryIterator(Iterable[call.LazyCall]):
             arguments = tuple(arguments)
 
         rows: dict[str, dict[str, Any]] = {}
-        for c in self.calls:
+        for c in self:
             row = {
                     prop: getattr(c, prop) for prop in ("name", "module", "metadata")
             }
@@ -227,5 +234,5 @@ class QueryIterator(Iterable[call.LazyCall]):
 
     def results(self) -> Iterator[Any]:
         """Returns an iterator over the results of queried calls."""
-        for c in self.calls:
+        for c in self:
             yield c.result

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -35,8 +35,19 @@ def test_query_iterator_is_iterable(test_cache):
 
 def test_query_iterator_empty():
     """QueryIterator over an empty iterable yields nothing."""
-    it = QueryIterator([])
+    it = QueryIterator(lambda: [])
     assert list(it) == []
+
+
+def test_query_iterator_is_re_iterable(test_cache):
+    """Iterating a QueryIterator twice yields the same results both times."""
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    qi = test_cache.query(tpl)
+    first = sorted(c.arguments["x"] for c in qi)
+    second = sorted(c.arguments["x"] for c in qi)
+    assert first == second == [1, 2]
 
 
 def test_query_iterator_can_be_iterated_from_wrapper(test_cache):
@@ -70,7 +81,7 @@ def test_query_iterator_results(test_cache):
 
 def test_query_iterator_results_empty():
     """results() on an empty QueryIterator yields nothing."""
-    assert list(QueryIterator([]).results()) == []
+    assert list(QueryIterator(lambda: []).results()) == []
 
 
 def test_query_iterator_results_from_wrapper(test_cache):
@@ -132,7 +143,7 @@ def test_query_iterator_table_no_result_by_default(test_cache):
 
 def test_query_iterator_table_empty():
     """table() on an empty QueryIterator returns an empty DataFrame."""
-    df = QueryIterator([]).table()
+    df = QueryIterator(lambda: []).table()
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 0
 
@@ -350,7 +361,7 @@ def test_only_returns_single_call(test_cache):
 
 def test_only_raises_on_empty():
     with pytest.raises(IndexError):
-        QueryIterator([]).only()
+        QueryIterator(lambda: []).only()
 
 
 def test_only_raises_on_multiple(test_cache):
@@ -380,11 +391,11 @@ def test_any_returns_call(test_cache):
 
 
 def test_any_returns_none_on_empty():
-    assert QueryIterator([]).any() is None
+    assert QueryIterator(lambda: []).any() is None
 
 
 def test_empty_true():
-    assert QueryIterator([]).empty() is True
+    assert QueryIterator(lambda: []).empty() is True
 
 
 def test_empty_false(test_cache):
@@ -402,7 +413,7 @@ def test_take_returns_first_n(test_cache):
         test_cache.save(Call(name="f", arguments={"x": i}, result=i * 10))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     calls = list(test_cache.query(tpl))
-    qi = QueryIterator(iter(calls))
+    qi = QueryIterator(lambda: iter(calls))
     assert list(qi.take(3)) == calls[:3]
 
 
@@ -424,7 +435,7 @@ def test_skip_drops_first_n(test_cache):
         test_cache.save(Call(name="f", arguments={"x": i}, result=i * 10))
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     calls = list(test_cache.query(tpl))
-    qi = QueryIterator(iter(calls))
+    qi = QueryIterator(lambda: iter(calls))
     assert list(qi.skip(2)) == calls[2:]
 
 
@@ -521,7 +532,7 @@ def test_unique_callable(test_cache):
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
     all_calls = list(test_cache.query(tpl))
     assert len(all_calls) == 3, "both x=1 calls must be stored as separate entries"
-    unique = list(QueryIterator(iter(all_calls)).unique(lambda c: c.arguments["x"]))
+    unique = list(QueryIterator(lambda: iter(all_calls)).unique(lambda c: c.arguments["x"]))
     assert len(unique) == 2
 
 
@@ -590,12 +601,12 @@ def test_oldest_returns_earliest(test_cache):
 
 def test_latest_raises_on_empty():
     with pytest.raises(IndexError):
-        QueryIterator([]).latest()
+        QueryIterator(lambda: []).latest()
 
 
 def test_oldest_raises_on_empty():
     with pytest.raises(IndexError):
-        QueryIterator([]).oldest()
+        QueryIterator(lambda: []).oldest()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -50,6 +50,20 @@ def test_query_iterator_is_re_iterable(test_cache):
     assert first == second == [1, 2]
 
 
+def test_query_iterator_reflects_cache_changes(test_cache):
+    """Re-iterating a QueryIterator picks up calls added to the cache after it was created."""
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    qi = test_cache.query(tpl)
+
+    first = sorted(c.arguments["x"] for c in qi)
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    second = sorted(c.arguments["x"] for c in qi)
+
+    assert first == [1]
+    assert second == [1, 2]
+
+
 def test_query_iterator_can_be_iterated_from_wrapper(test_cache):
     """The iterator returned by a fleche-decorated function's .query() method is a QueryIterator."""
     with cache(test_cache):


### PR DESCRIPTION
## Summary

- `QueryIterator.calls` was a live generator object; consuming it once left nothing for a second traversal, silently returning empty results
- Change `calls` to a `Callable[[], Iterable[LazyCall]]` factory; `__iter__` now calls `self.calls()` to get a fresh generator on every iteration
- `caches.py` passes `_safe_iter` (the function) instead of `_safe_iter()` (the generator object)
- All lazy methods (`filter`, `take`, `skip`, `unique`, `sorted`, `groupby`) updated to wrap their generator expressions in lambdas that close over `self`, which is itself now re-iterable
- New test `test_query_iterator_is_re_iterable` verifies that iterating a `QueryIterator` twice yields the same results

## Test plan

- [ ] `pytest tests/unit/fleche/test_query_iterator.py` — all 58 tests pass
- [ ] `pytest tests/unit/ tests/integration/` — passes (pre-existing failure in `test_parallel_execution.py::test_process_executor_bound_wrapper` is unrelated, reproduces on `main` without these changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW1STsLJh7Amwi4CjVEfx8)_