### PR TITLE
refactor: factor compress_all/decompress_all into _rewrite_all on PickleFileBackend

### DIFF
--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -85,8 +85,12 @@ class PickleFileBackend(FileStorage):
         except SignatureError:
             raise KeyError(path, "Value present but failed signature check.")
 
-    def compress_all(self) -> None:
-        """Rewrite all stored files in gzip-compressed form."""
+    def _rewrite_all(self, transform: Callable[[bytes], bytes | None]) -> None:
+        """Lock, read, and conditionally rewrite every stored file via *transform*.
+
+        *transform* receives the raw file bytes and returns the new bytes to
+        write, or ``None`` to leave the file unchanged.
+        """
         for key in list(self.list()):
             path = self._path(key)
             lock_path = self._path(f"{key}.lock")
@@ -95,21 +99,21 @@ class PickleFileBackend(FileStorage):
                     content = path.read_bytes()
                 except FileNotFoundError:
                     continue
-                if content[:2] != b"\x1f\x8b":
-                    path.write_bytes(gzip.compress(content))
+                result = transform(content)
+                if result is not None:
+                    path.write_bytes(result)
+
+    def compress_all(self) -> None:
+        """Rewrite all stored files in gzip-compressed form."""
+        self._rewrite_all(
+            lambda c: None if c[:2] == b"\x1f\x8b" else gzip.compress(c)
+        )
 
     def decompress_all(self) -> None:
         """Rewrite all stored files in uncompressed form."""
-        for key in list(self.list()):
-            path = self._path(key)
-            lock_path = self._path(f"{key}.lock")
-            with filelock.FileLock(lock_path, timeout=self.lock_timeout):
-                try:
-                    content = path.read_bytes()
-                except FileNotFoundError:
-                    continue
-                if content[:2] == b"\x1f\x8b":
-                    path.write_bytes(gzip.decompress(content))
+        self._rewrite_all(
+            lambda c: gzip.decompress(c) if c[:2] == b"\x1f\x8b" else None
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/unit/storage/test_pickle_file.py
+++ b/tests/unit/storage/test_pickle_file.py
@@ -1,5 +1,5 @@
 import pytest
-from fleche.storage.pickle_file import ValuePickleFile as PickleFile
+from fleche.storage.pickle_file import ValuePickleFile as PickleFile, CallPickleFile
 from fleche.digest import Digest
 
 
@@ -160,3 +160,31 @@ def test_compress_then_decompress_roundtrip(tmp_path):
 
     for key, value in values.items():
         assert storage.load(key) == value
+
+
+def test_rewrite_all_custom_transform(tmp_path):
+    """_rewrite_all() applies an arbitrary byte transform to every file."""
+    # Use CallPickleFile (no DestructuringMixin) so exactly one file is created.
+    storage = CallPickleFile.with_pickle(root=tmp_path, compress=False)
+    key = Digest("a" * 64)
+    value = {"x": 1}
+    storage.put(value, key)
+    original = (tmp_path / str(key)).read_bytes()
+
+    seen = []
+    storage._rewrite_all(lambda c: seen.append(c) or None)
+
+    assert seen == [original]
+    assert (tmp_path / str(key)).read_bytes() == original  # file unchanged when None returned
+
+
+def test_rewrite_all_skips_missing_files(tmp_path):
+    """_rewrite_all() silently skips files deleted between list() and read."""
+    storage = CallPickleFile.with_pickle(root=tmp_path, compress=False)
+    key = Digest("a" * 64)
+    storage.put({"x": 1}, key)
+    (tmp_path / str(key)).unlink()
+
+    called = []
+    storage._rewrite_all(lambda c: called.append(c) or None)
+    assert called == []


### PR DESCRIPTION
Introduce `PickleFileBackend._rewrite_all(transform)` as a shared loop for bulk file rewrites. `compress_all` and `decompress_all` now delegate to it, eliminating the duplicated lock/read/write skeleton.

Two new tests exercise the helper directly.

Closes #505

Generated with [Claude Code](https://claude.ai/code)