### PR TITLE
feat(digest): make dataclasses._FIELD_BASE instances digestible

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -307,6 +307,10 @@ def _digest_bytes(value: Any) -> bytes:
             m.update(_digest_bytes(dict(_attrs.field_items(value))))
         case _ if value is dataclasses.MISSING:
             m.update(b"__MISSING__")
+        case _ if isinstance(value, dataclasses._FIELD_BASE):
+            # _FIELD_BASE singletons (_FIELD, _FIELD_CLASSVAR, _FIELD_INITVAR) carry
+            # a stable .name attribute; use it as the digest key.
+            m.update(value.name.encode())
         case _ if isinstance(value, enum.Enum):
             return _digest_bytes((type(value).__qualname__, value.value))
         case _ if (

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -90,6 +90,11 @@ _C_DESCRIPTOR_TYPES = (
     types.MemberDescriptorType,
 )
 
+# dataclasses._FIELD_BASE is a private sentinel class (Python 3.10+).  Access via
+# getattr to avoid type-checker errors on an unresolved private attribute; None
+# disables the match arm gracefully if a future Python removes it.
+_DATACLASSES_FIELD_BASE: type | None = getattr(dataclasses, "_FIELD_BASE", None)
+
 
 def get_hooks():
     return list(reversed(_HOOKS)) + _EP_HOOKS
@@ -307,7 +312,7 @@ def _digest_bytes(value: Any) -> bytes:
             m.update(_digest_bytes(dict(_attrs.field_items(value))))
         case _ if value is dataclasses.MISSING:
             m.update(b"__MISSING__")
-        case _ if isinstance(value, dataclasses._FIELD_BASE):
+        case _ if _DATACLASSES_FIELD_BASE is not None and isinstance(value, _DATACLASSES_FIELD_BASE):
             # _FIELD_BASE singletons (_FIELD, _FIELD_CLASSVAR, _FIELD_INITVAR) carry
             # a stable .name attribute; use it as the digest key.
             m.update(value.name.encode())

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -1016,3 +1016,54 @@ def test_type_digest_stable_across_cloudpickle_roundtrip():
     original = digest(cls)
     reloaded = cloudpickle.loads(cloudpickle.dumps(cls))
     assert digest(reloaded) == original
+
+
+# --- Tests for dataclasses._FIELD_BASE (Python 3.12: _FIELD / _FIELD_CLASSVAR / _FIELD_INITVAR) ---
+
+
+def test_field_base_singletons_are_digestible():
+    """The three _FIELD_BASE singletons must be digestible."""
+    import dataclasses as dc
+    assert isinstance(digest(dc._FIELD), Digest)
+    assert isinstance(digest(dc._FIELD_CLASSVAR), Digest)
+    assert isinstance(digest(dc._FIELD_INITVAR), Digest)
+
+
+def test_field_base_singletons_have_distinct_digests():
+    """The three singletons must produce different digests."""
+    import dataclasses as dc
+    assert digest(dc._FIELD) != digest(dc._FIELD_CLASSVAR)
+    assert digest(dc._FIELD) != digest(dc._FIELD_INITVAR)
+    assert digest(dc._FIELD_CLASSVAR) != digest(dc._FIELD_INITVAR)
+
+
+def test_field_base_digest_is_stable():
+    """Digesting the same singleton twice returns the same value."""
+    import dataclasses as dc
+    assert digest(dc._FIELD) == digest(dc._FIELD)
+    assert digest(dc._FIELD_CLASSVAR) == digest(dc._FIELD_CLASSVAR)
+
+
+def test_field_instance_is_digestible():
+    """A dataclasses.Field instance (which carries _field_type) must be digestible."""
+    import dataclasses as dc
+
+    @dataclass
+    class Simple:
+        x: int = 0
+
+    field_obj = dc.fields(Simple)[0]
+    assert isinstance(digest(field_obj), Digest)
+
+
+def test_field_instance_digest_changes_with_value():
+    """Two Field instances for different field names must differ."""
+    import dataclasses as dc
+
+    @dataclass
+    class TwoFields:
+        a: int = 1
+        b: str = "hi"
+
+    fa, fb = dc.fields(TwoFields)
+    assert digest(fa) != digest(fb)


### PR DESCRIPTION
Splits off the `dataclasses._FIELD_BASE` digest support from #475 into its own PR so it can be reviewed and merged in separately.

## Changes

- Adds an `isinstance(value, _DATACLASSES_FIELD_BASE)` match case in `_digest_bytes` that uses the singleton's `.name` attribute (`'_FIELD'`, `'_FIELD_CLASSVAR'`, `'_FIELD_INITVAR'`) as the stable digest key
- Accesses `_FIELD_BASE` via `getattr(dataclasses, "_FIELD_BASE", None)` at module level to avoid the `ty` type-checker `unresolved-attribute` error (the `None` fallback disables the match arm gracefully on any future Python that removes the private class)
- Unblocks digesting `dataclasses.Field` instances: their `_field_type` slot holds one of these singletons and was the last blocker for `digest(type) == digest(dict(type.__dict__))` on dataclass *classes*

## Tests

5 new tests:
- `test_field_base_singletons_are_digestible` — all three singletons return a `Digest`
- `test_field_base_singletons_have_distinct_digests` — they differ from each other
- `test_field_base_digest_is_stable` — same singleton → same digest
- `test_field_instance_is_digestible` — a full `Field` object can be digested
- `test_field_instance_digest_changes_with_value` — two fields for different names differ

Merges into #475.

🤖 Generated with [Claude Code](https://claude.ai/code)