### PR TITLE
bench: fold contains columns and add save_fresh measurement

### DIFF
--- a/benchmarks/benchmark_storage.py
+++ b/benchmarks/benchmark_storage.py
@@ -57,7 +57,7 @@ def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
         keys = [digest(val) for val in values_to_store]
         valid_items = list(zip(values_to_store, keys))
 
-        # Benchmark Save
+        # Benchmark Save (re-save of existing key — collision path)
         save_times = []
         for val, key in valid_items:
             timer = timeit.Timer(partial(storage.save, val, key))
@@ -71,6 +71,24 @@ def benchmark_storage_ops(storage_name, storage_factory, values_to_store):
                 "storage": storage_name,
                 "iterations": len(valid_items) * 30,
                 "time": min(save_times),
+            }
+        )
+
+        # Benchmark Fresh Save (first-time insert per key)
+        save_fresh_times = []
+        for val, key in valid_items:
+            storage.evict(key)
+            start = time.perf_counter()
+            storage.save(val, key)
+            end = time.perf_counter()
+            save_fresh_times.append(end - start)
+
+        results.append(
+            {
+                "benchmark": "storage_save_fresh",
+                "storage": storage_name,
+                "iterations": len(valid_items),
+                "time": min(save_fresh_times),
             }
         )
 
@@ -155,7 +173,7 @@ def benchmark_sql_ops(storage_label, url, calls_data):
     results = []
     storage = Sql(url)
 
-    # Save
+    # Save (re-save of existing key — collision path)
     save_times = []
     keys = []
     for c in calls_data:
@@ -171,6 +189,24 @@ def benchmark_sql_ops(storage_label, url, calls_data):
             "storage": storage_label,
             "iterations": len(calls_data) * 30,
             "time": min(save_times),
+        }
+    )
+
+    # Fresh Save (first-time insert per key)
+    save_fresh_times = []
+    for c, key in zip(calls_data, keys):
+        storage.evict(key)
+        start = time.perf_counter()
+        storage.save(c)
+        end = time.perf_counter()
+        save_fresh_times.append(end - start)
+
+    results.append(
+        {
+            "benchmark": "storage_save_fresh",
+            "storage": storage_label,
+            "iterations": len(calls_data),
+            "time": min(save_fresh_times),
         }
     )
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -174,6 +174,13 @@ def main():
             workload = ""
             function = b
 
+        # Fold contains_hit/contains_miss into a single "contains" column
+        # showing the hit case; drop the miss case from display.
+        if function == "contains_miss":
+            continue
+        if function == "contains_hit":
+            function = "contains"
+
         # Apply formatting and color mapping
         colored_config = f"{get_storage_color(config)} {config}" if config else config
 


### PR DESCRIPTION
## Summary

- Folds `contains_hit` / `contains_miss` into a single `contains` column in the output table (shows the hit case); both measurements are still emitted to JSON from the benchmark scripts
- Adds a `save_fresh` measurement to `benchmark_storage_ops` and `benchmark_sql_ops`: evicts each key then measures a single first-time insert, so the no-collision fast path is benchmarked independently of the re-save (collision) path
- Output tables now show both `save` (repeated re-save) and `save_fresh` (first-time insert) columns side-by-side

Feeds into #510 / #499 where the optimistic-insert PR was seen to slow down `save` because the benchmark was measuring re-saves (the collision path) rather than first-time inserts (the fast path the optimization targets).

## Test plan

- [x] Run `python benchmarks/run_benchmarks.py` and confirm output table has `contains` (not `contains_hit`/`contains_miss`) and both `save` + `save_fresh` columns
- [x] Confirm `save_fresh` values for SqlFile/SqlMemory are lower than `save` values (fast path vs collision path)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)