### PR TITLE
docs(parallel_execution): lead ThreadPoolExecutor section with wrap_executor

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -27,7 +27,33 @@ Three complementary APIs cover the common cases:
 ThreadPoolExecutor
 ------------------
 
-Use :class:`~fleche.BoundWrapper` with a ``with cache(...)`` block.
+For the most compact call site, use :func:`~fleche.wrap_executor` — it patches
+the executor's ``submit`` once and then handles any fleche-decorated function
+automatically, serving cache hits from a pre-completed
+:class:`~concurrent.futures.Future` without ever submitting a task:
+
+.. code-block:: python
+
+   import concurrent.futures
+   import fleche
+   from fleche.caches import Cache
+   from fleche.storage.memory import ValueMemory, CallMemory
+
+   @fleche.fleche
+   def compute(x):
+       return x ** 2
+
+   my_cache = Cache(ValueMemory({}), CallMemory({}))
+
+   with fleche.cache(my_cache):
+       with concurrent.futures.ThreadPoolExecutor() as executor:
+           fleche.wrap_executor(executor)
+           futures = [executor.submit(compute, i) for i in range(4)]
+           results = [f.result() for f in futures]  # all cached in my_cache
+
+Alternatively, use :class:`~fleche.BoundWrapper` when you need explicit
+control over which callable is submitted — for example, to share a single
+bound callable across multiple pools or helper modules.
 ``BoundWrapper.bind(func)`` captures the active cache at bind time and
 restores it on every call — including inside worker threads — so all tasks
 write to the same store:


### PR DESCRIPTION
## Summary

The Quick Reference table at the bottom of `docs/parallel_execution.rst` already identified `wrap_executor` as the **simplest** pattern for `ThreadPoolExecutor`. But the `ThreadPoolExecutor` section itself opened with `BoundWrapper` — readers who stopped reading before reaching the Quick Reference would never know a simpler option existed.

This creates a confusing inconsistency: the section teaches `BoundWrapper` for thread pools, but the summary contradicts it by recommending `wrap_executor` first.

## What changed

Restructured the **ThreadPoolExecutor** section to:

1. **Lead with `wrap_executor`** — patch the executor once, then `submit` the decorated function directly. Cache hits return a pre-completed `Future` without ever entering the thread pool, which is also more efficient than `BoundWrapper` (which always submits and lets the worker do the cache lookup).

2. **Show `BoundWrapper` as the alternative** for cases that need explicit control — sharing a bound callable across multiple pools, passing it to helper modules, or pickling across process boundaries.

The "Passing a bound function around" subsection and all other sections are unchanged.

## Why `wrap_executor` is simpler for threads

| | `wrap_executor` | `BoundWrapper` |
|---|---|---|
| Setup | Patch once: `fleche.wrap_executor(executor)` | Wrap every submit: `executor.submit(BoundWrapper.bind(func), ...)` |
| Cache hit | Pre-completed `Future`, no thread submission | Thread still runs, does a fast cache lookup |
| Call site | `executor.submit(func, arg)` — unchanged | `executor.submit(BoundWrapper.bind(func), arg)` |

## Test plan

- [x] Verified new `wrap_executor` + `ThreadPoolExecutor` example runs correctly: results `[0, 1, 4, 9]`, cache hits return `fut.done() == True`
- [x] Existing `BoundWrapper` example is preserved and unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01TaPYuCmW5oMjWCznKRZvEn)_