### PR TITLE
test: tighten coverage on CacheStack and prune two redundant tests

### DIFF
--- a/tests/integration/test_hash_code_integration.py
+++ b/tests/integration/test_hash_code_integration.py
@@ -30,30 +30,3 @@ def test_hash_code_integration():
         assert not wrapped_v2.fleche.contains(10)
         assert wrapped_v2(10) == 12
         assert wrapped_v2.fleche.contains(10)
-
-
-def test_hash_code_disabled_integration():
-    with cache(Cache(ValueMemory({}), CallMemory({}))):
-
-        def func_v1(x):
-            return x + 1
-
-        func_v1.__name__ = "my_func"
-        func_v1.__qualname__ = "my_func"
-        func_v1.__module__ = "my_module"
-
-        wrapped_v1 = fleche(hash_code=False)(func_v1)
-        assert wrapped_v1(10) == 11
-        assert wrapped_v1.fleche.contains(10)
-
-        def func_v2(x):
-            return x + 2
-
-        func_v2.__name__ = "my_func"
-        func_v2.__qualname__ = "my_func"
-        func_v2.__module__ = "my_module"
-
-        wrapped_v2 = fleche(hash_code=False)(func_v2)
-        # Should BE in cache because code change is ignored
-        assert wrapped_v2.fleche.contains(10)
-        assert wrapped_v2(10) == 11  # Returns old value!

--- a/tests/unit/caches/test_cache_stack.py
+++ b/tests/unit/caches/test_cache_stack.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 import pytest
-from fleche.caches import CacheStack, Cache
+from fleche.caches import CacheStack, Cache, ReadOnlyCache
 from fleche.call import Call
 from fleche.storage import ValueMemory, CallMemory
 from fleche.digest import digest
@@ -210,3 +210,60 @@ def test_cache_stack_multi_level_transfer():
     assert c1.contains(key)
     # c2 should STILL NOT have it
     assert not c2.contains(key)
+
+
+def test_cache_stack_contains_true_if_any_layer_has_key():
+    c1 = Cache(ValueMemory({}), CallMemory({}))
+    c2 = Cache(ValueMemory({}), CallMemory({}))
+    call = Call(name="f", arguments={"x": 1}, result="r")
+    key = c2.save(call)
+    stack = CacheStack((c1, c2))
+
+    assert stack.contains(key)
+
+
+def test_cache_stack_contains_false_if_no_layer_has_key():
+    stack = CacheStack((
+        Cache(ValueMemory({}), CallMemory({})),
+        Cache(ValueMemory({}), CallMemory({})),
+    ))
+    assert not stack.contains("a" * 64)
+
+
+def test_cache_stack_load_value_raises_keyerror_when_missing_everywhere():
+    stack = CacheStack((
+        Cache(ValueMemory({}), CallMemory({})),
+        Cache(ValueMemory({}), CallMemory({})),
+    ))
+    with pytest.raises(KeyError):
+        stack.load_value(digest("nope"))
+
+
+def test_cache_stack_rejects_nested_cache_stack():
+    inner = CacheStack((Cache(ValueMemory({}), CallMemory({})),))
+    with pytest.raises(ValueError, match="cannot be nested"):
+        CacheStack((inner,))
+
+
+def test_cache_stack_load_with_readonly_base_logs_warning_but_returns_hit(caplog):
+    """A hit in a higher cache must still be returned when the base rejects the transfer.
+
+    When the base of a stack is read-only, the back-fill ``save`` raises
+    :class:`Rejected`; the load itself must still succeed (the higher
+    cache's hit is propagated to the caller) and a warning is logged.
+    """
+    import logging
+
+    backing = Cache(ValueMemory({}), CallMemory({}))
+    base = ReadOnlyCache(backing)
+    top = Cache(ValueMemory({}), CallMemory({}))
+
+    call = Call(name="f", arguments={"x": 1}, result="r")
+    key = top.save(call)
+    stack = CacheStack((base, top))
+
+    with caplog.at_level(logging.WARNING, logger="fleche.caches"):
+        lc = stack.load(key)
+
+    assert lc.result == "r"
+    assert any("Failed to transfer" in rec.message for rec in caplog.records)

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -283,23 +283,6 @@ def test_query_iterator_table_no_metadata(test_cache):
     assert set(df.columns) == {"name", "module"}
 
 
-def test_query_iterator_table_end_to_end_via_wrapper(test_cache):
-    """Integration: using .query().table() from a fleche-decorated function."""
-    with cache(test_cache):
-        @fleche
-        def multiply(a, b):
-            return a * b
-
-        multiply(2, 3)
-        multiply(4, 5)
-
-        df = multiply.fleche.query().table(arguments=["a", "b"], results=True)
-        assert isinstance(df, pd.DataFrame)
-        assert len(df) == 2
-        assert set(df.columns) >= {"name", "a", "b", "result"}
-        assert set(df["result"]) == {6, 20}
-
-
 # ---------------------------------------------------------------------------
 # Partial query binding through the wrapper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two atomic commits, one per step of the coverage exercise.

## Step 1 — `test(caches): cover CacheStack contract gaps` (c973eb8)

Branch coverage sweep with `coverage run --branch --source=src/fleche -m pytest tests/ --ignore=tests/integration/test_notebooks.py` flagged `caches.py` as one of the least-covered modules (91%). The biggest cluster of gaps was on `CacheStack` — several public-API methods had no test at all or were tested only on a single branch.

Added five singly-orthogonal unit tests in `tests/unit/caches/test_cache_stack.py`:

- `test_cache_stack_contains_true_if_any_layer_has_key` — `contains` returns True when any layer has the key (`caches.py:522`, hit branch)
- `test_cache_stack_contains_false_if_no_layer_has_key` — `contains` returns False when none has it (`caches.py:522`, miss branch)
- `test_cache_stack_load_value_raises_keyerror_when_missing_everywhere` — `load_value` raises `KeyError` when no layer has the digest (`caches.py:519`)
- `test_cache_stack_rejects_nested_cache_stack` — `__post_init__` validation that a `CacheStack` cannot contain another `CacheStack` (`caches.py:492`)
- `test_cache_stack_load_with_readonly_base_logs_warning_but_returns_hit` — when the base layer is a `ReadOnlyCache`, a hit in a higher layer is still returned and the failed back-fill is logged (`caches.py:505-506`)

## Step 2 — `test: drop two tests with zero coverage impact` (005c9d2)

Randomly selected eight tests from the suite to knock out and re-measured coverage. Final report after deselecting all eight matched the baseline on every module **except** `query.py` (2 statements lost, lines 237-238 — `QueryIterator.results()` body). The pair-isolation experiment narrowed the loss to `test_query_iterator_results`. The other tests were investigated individually:

| Knocked-out test | Coverage delta | Decision |
|---|---|---|
| `test_hash_code_disabled_integration` | 0 | **Remove** — end-to-end mirror of `tests/unit/fleche/test_hash_code.py::test_hash_code_default_ignores_change` |
| `test_query_iterator_table_end_to_end_via_wrapper` | 0 | **Remove** — wrapper integration verified at `test_query_iterator_can_be_iterated_from_wrapper`; `.table()` has 15+ unit tests directly above |
| `test_cache_load_restores_complex_arguments_and_result` | 0 | **Keep** — distinct save+load contract test (other tests use Mocks or `query`, not real save+load) |
| `test_fallback_no_config_file_is_singleton` | 0 | **Keep** — singleton-identity contract test (`load_cache_config()` returns same instance across calls) |
| `test_dill_file` | 0 | **Keep** — distinct `dill` serializer config-type contract; combining with `test_pickle_file` would conflate orthogonal contracts |
| `test_query_iterator_results` | −2 stmts (`query.py:237-238`) | **Keep** — only test exercising `QueryIterator.results()` body in the running suite |
| `test_call_mixin_query_empty_store` | 0 | **Keep** — empty-store branch contract |
| `test_path_coercion_and_creation` | 0 | **Keep** — unique bare-path branch + parent-dir creation contract |

Two clear removals. Final commit removes only those; coverage reports are bit-identical to step 1's baseline.

## Coverage report

Before step 1 (baseline on `main`):

```
src/fleche/__init__.py                       13      3      2      1    73%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/caches.py                        301     28     80      6    91%
src/fleche/storage/sql.py                   249     16     90      7    92%
src/fleche/storage/bagofholding_file.py      49      3     10      1    93%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/digest.py                        159      7     92      8    94%
src/fleche/config.py                        164      6     76      5    95%
...
TOTAL                                      2168     87    646     41    95%
```

After step 1 (and after step 2 — identical):

```
src/fleche/caches.py                        301     23     80      4    93%
...
TOTAL                                      2168     80    646     39    96%
```

`caches.py` 91% → 93% (5 statements + 2 partial branches closed); overall 95% → 96%.

## Test plan

- [x] `pytest tests/unit/caches/test_cache_stack.py -q` → 14 passed
- [x] Full suite: `pytest tests/ --ignore=tests/integration/test_notebooks.py -q -p no:randomly` → 904 passed, 11 skipped
- [x] `coverage report` byte-identical to step-1 baseline after step 2 removals
- [x] `coverage report --include="src/fleche/caches.py" --show-missing` confirms the targeted lines are now covered

https://claude.ai/code/session_01QoEP7Y8iKxKhq2KLXFcfr9