### PR TITLE
docs(StorageBackends): fix cleanup cell — it was duplicating setup code instead of removing dirs

### DIFF
--- a/notebooks/StorageBackends.ipynb
+++ b/notebooks/StorageBackends.ipynb
@@ -215,7 +215,15 @@
     }
    },
    "outputs": [],
-   "source": "import shutil\nshutil.rmtree('.compressed_pickle_cache', ignore_errors=True)\ncompressed_cache = Cache(\n    values=ValuePickleFile.with_pickle(root='.compressed_pickle_cache/values', compress=True),\n    calls=CallPickleFile.with_pickle(root='.compressed_pickle_cache/calls', compress=True)\n)\n\nwith cache(compressed_cache):\n    @fleche\n    def big_result(n):\n        return \"a\" * n\n    \n    big_result(1000)\n\nfile_path = list(Path('.compressed_pickle_cache/values').iterdir())[0]\nwith open(file_path, 'rb') as f:\n    header = f.read(2)\n    # check for gzip magic number 0x1f 0x8b\n    is_compressed = (header[0] == 0x1f) and (header[1] == 0x8b)\n    print(f\"Is gzip compressed: {is_compressed}\")"
+   "source": [
+    "import shutil, os\n",
+    "for d in ('.pickle_cache', '.compressed_pickle_cache', '.cloudpickle_cache',\n",
+    "          '.dill_cache', '.boh_cache', '.mixed_cache'):\n",
+    "    shutil.rmtree(d, ignore_errors=True)\n",
+    "if os.path.exists('calls.db'):\n",
+    "    os.remove('calls.db')\n",
+    "print('Cleaned up temporary cache directories.')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- `notebooks/StorageBackends.ipynb` cell 18 is labelled "Clean Up — Remove temporary cache directories" but its source was a verbatim copy of the compressed-pickle setup cell (cell 6).
- Running the notebook therefore never cleaned up the five temp directories (`.pickle_cache`, `.compressed_pickle_cache`, `.cloudpickle_cache`, `.dill_cache`, `.boh_cache`, `.mixed_cache`) or the SQLite file (`calls.db`).

## What changed

Replaced the bogus cell 18 source with an actual cleanup block:

```python
import shutil, os
for d in ('.pickle_cache', '.compressed_pickle_cache', '.cloudpickle_cache',
          '.dill_cache', '.boh_cache', '.mixed_cache'):
    shutil.rmtree(d, ignore_errors=True)
if os.path.exists('calls.db'):
    os.remove('calls.db')
print('Cleaned up temporary cache directories.')
```

Cleared the stale output on the cell (it will be regenerated on next notebook execution).

## Test plan

- [ ] Run `notebooks/StorageBackends.ipynb` end-to-end; the final cell should print "Cleaned up temporary cache directories." and leave no leftover directories.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh7ygKRdjeS1rrG9L3hJe8)_