### PR TITLE
docs(query): clarify Digest-vs-string comparison semantics in behavior details

### DIFF
--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -65,7 +65,7 @@ You can also construct a ``QueryCall`` template manually and query against the a
 Behavior details
 ----------------
 - None is a wildcard for name/module/version and also for individual argument values (interpreted as "key present").
-- For arguments and result, equality is by digest (so Digest objects and matching 64-char hex strings are treated equivalently).
+- For arguments and result, equality is by digest: the template value and the stored value are each passed through :func:`~fleche.digest.digest` and the resulting hex strings are compared.  Pass a :class:`~fleche.digest.Digest` instance (e.g. via :func:`~fleche.D`) to match by a known digest without re-hashing; a plain ``str`` — even one that looks like a hex digest — is hashed as a string value and will not match.
 - Metadata filtering supports presence checks (empty dict) and equality on simple types (str, bool, int, float). Complex types (e.g., lists) are handled correctly via client-side filtering.
 
 


### PR DESCRIPTION
## Summary

- `docs/usage/query.rst` stated: *"For arguments and result, equality is by digest (so Digest objects and matching 64-char hex strings are treated equivalently)."*
- This is inaccurate: a plain Python `str` — even one that is 64 hex characters long — is **hashed as a string value** by `fleche.digest.digest()`, whereas a `Digest` instance (subclass of `str`) **passes through verbatim**.  The two therefore produce different hashes and a plain string will *not* match a stored `Digest`.

## Proof

```python
from fleche.digest import digest, Digest

full_hex = digest(42)           # a real 64-char Digest
as_str   = str(full_hex)        # same chars, plain str

digest(Digest(full_hex)) == full_hex   # True  — passthrough
digest(as_str) == full_hex             # False — hashed as string
```

## What changed

Replaced the imprecise one-liner with a precise description:

> For arguments and result, equality is by digest: the template value and the stored value are each passed through `digest()` and the resulting hex strings are compared.  Pass a `Digest` instance (e.g. via `D()`) to match by a known digest without re-hashing; a plain `str` — even one that looks like a hex digest — is hashed as a string value and will not match.

## Test plan

- [ ] Read `docs/usage/query.rst` Behavior details section — the new wording explains the `Digest` passthrough and the consequence for plain strings

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh7ygKRdjeS1rrG9L3hJe8)_