### PR TITLE
fix: rename put() parameter call→value to match parent class signature

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -219,11 +219,11 @@ class Sql(PerKeyLockMixin, CallStorage):
             with super()._operation_context(key):
                 yield
 
-    def put(self, call: DigestedCall, key: Digest) -> Digest:
+    def put(self, value: DigestedCall, key: Digest) -> Digest:
         session = self._local.session
         existing = session.get(CallModel, str(key))
         if existing is not None:
-            if self.get(key) == call:
+            if self.get(key) == value:
                 return key
 
             session.delete(existing)
@@ -231,26 +231,26 @@ class Sql(PerKeyLockMixin, CallStorage):
 
         call_model = CallModel(
             key=str(key),
-            name=call.name,
-            module=call.module,
-            version=json.dumps(call.version) if call.version is not None else None,
-            code_digest=call.code_digest,
-            result=call.result if call.result is None else str(call.result),
+            name=value.name,
+            module=value.module,
+            version=json.dumps(value.version) if value.version is not None else None,
+            code_digest=value.code_digest,
+            result=value.result if value.result is None else str(value.result),
         )
         session.add(call_model)
 
-        for i, (k, v) in enumerate(call.arguments.items()):
+        for i, (k, v) in enumerate(value.arguments.items()):
             session.add(
                 ArgumentModel(
                     call_key=str(key), position=i, name=str(k), value=str(v)
                 )
             )
 
-        if call.metadata:
+        if value.metadata:
             session.add_all(
                 [
                     MetaModel(call_key=str(key), name=name, data=data)
-                    for name, data in call.metadata.items()
+                    for name, data in value.metadata.items()
                 ]
             )
         session.commit()


### PR DESCRIPTION
## Summary

- Renames the `call` parameter to `value` in `SQLStorage.put()` to match the parent class (`PerKeyLockMixin`) signature
- Fixes a Liskov Substitution Principle violation caught by the type checker

## Details

The `put` method in `sql.py` overrode the parent class method with a mismatched parameter name (`call` instead of `value`). This was detected as a type error:

```
src/fleche/storage/sql.py:222 — def put(self, call: DigestedCall, key: Digest) -> Digest:
src/fleche/storage/thread_safe.py:248 — def put(self, value: Any, key: Digest) -> Digest:
```

All usages within the method body were updated accordingly.

Cherry-picked from `25185c14cbcdbb4ccf6558fd62cb9cb5dd4dd1b4` on `claude/issue-453-20260513-1618`.

🤖 Generated with [Claude Code](https://claude.ai/code)