### PR TITLE
feat(remote): SshCache for sharing fleche caches across machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ __pycache__/
 .hypothesis/
 notebooks/.*
 notebooks/*.db
+notebooks/*.db-shm
+notebooks/*.db-wal
 docs/_build
 src/fleche/_version.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ python benchmarks/run_benchmarks.py                    # benchmarks (writes benc
 
 Python `>=3.11,<3.15`. No committed lint config; `pyproject.toml` has no `[tool.ruff]`/`[tool.flake8]`.
 
-Optional dep extras: `cloudpickle`, `dill`, `sqlalchemy`, `bagofholding`, `executorlib`, `docs`, `tests` (the `tests` extra already pulls in cloudpickle/dill/sqlalchemy/bagofholding/attrs). `attrs` itself has no dedicated extra — it is only required to exercise the `attrs`-class digest/destructuring paths in tests; runtime support degrades gracefully when `attrs` is missing. Other optional deps are gated via `pyiron_snippets.import_alarm.ImportAlarm` — importing a backend without its extra installed raises at construction, not at module import.
+Optional dep extras: `cloudpickle`, `dill`, `sqlalchemy`, `bagofholding`, `ssh` (cloudpickle — **hard-required** for `SshCache`'s wire protocol, not optional within that feature), `executorlib`, `docs`, `tests` (the `tests` extra already pulls in cloudpickle/dill/sqlalchemy/bagofholding/attrs). `attrs` itself has no dedicated extra — it is only required to exercise the `attrs`-class digest/destructuring paths in tests; runtime support degrades gracefully when `attrs` is missing. Other optional deps are gated via `pyiron_snippets.import_alarm.ImportAlarm` — importing a backend without its extra installed raises at construction, not at module import.
 
 ## Architecture notes
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ pip install fleche[cloudpickle,dill]
 # For Bagofholding storage
 pip install fleche[bagofholding]
 
+# For SshCache (sharing caches across machines over SSH) — requires cloudpickle
+pip install fleche[ssh]
+
 # For documentation
 pip install fleche[docs]
 
@@ -125,6 +128,11 @@ def my_function(x):
 - **Call storage only** — stores call records (function name, arguments, metadata) in a SQL database; a separate value backend (file or memory) is still required for results
 - SQLite is the primary tested backend; any SQLAlchemy-supported database should work
 - Enables efficient server-side filtering when querying cached calls
+
+### SSH (remote) Cache
+- **Requires `cloudpickle`** (`pip install fleche[ssh]`) — used as the wire protocol between client and remote server; not optional
+- Forwards every cache operation over a persistent `ssh host python -m fleche.remote --serve` subprocess
+- Stack with a local cache to read-through to a shared remote one — see `fleche.remote.SshCache`
 
 ### In-Memory Storage
 - For testing or temporary caching

--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -1,0 +1,406 @@
+.. _ssh-cache-internals:
+
+``SshCache`` internals
+======================
+
+This page is a tour of :mod:`fleche.remote` for contributors hacking on the
+cross-machine cache.  End-user documentation lives in
+:doc:`/storage/configuration`; this page explains *how* the pieces fit
+together.
+
+Security model
+--------------
+
+The wire format is :mod:`cloudpickle` in **both directions**.  That has
+two unavoidable consequences:
+
+- A hostile **server** can run arbitrary code on the **client** by
+  returning a crafted payload that the client's ``cloudpickle.loads``
+  executes.
+- A hostile **client** can run arbitrary code on the **server**
+  symmetrically.
+
+The trust boundary is therefore exactly the same as ``ssh user@host``
+itself: SSH provides confidentiality and authentication of the
+endpoints, and we trust both ends not to ship hostile pickled objects.
+**Do not point** :class:`~fleche.remote.SshCache` **at a host you would
+not** ``ssh`` **into**, and do not expose the server entry point
+(``python -m fleche.remote --serve``) on any transport other than the
+spawned SSH stdin/stdout — there is no authentication on the RPC
+stream itself.
+
+Cloudpickle is the right call for this feature (we need to ship
+arbitrary Python objects across, including user value types) but a
+JSON / msgpack / protobuf wire format with a strict schema would have
+removed this trust requirement at the cost of constraining the kind of
+values fleche can cache. That trade-off was made deliberately; revisit
+it if SshCache ever needs to support untrusted multi-tenant use.
+
+Credentials in ``info()``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``info`` RPC ships
+:func:`~fleche.config.cache_to_config` of the served cache back to the
+client.  The raw config contains credentials —
+:class:`~fleche.storage.pickle_file.PickleFileBackend` writes its HMAC
+signing keys (``secret_key``) as hex strings, and the SQL backend's
+``url`` may include a database password in the userinfo component.
+:func:`fleche.remote._server_info` therefore walks the config through
+:func:`fleche.remote._redact_config` before putting it on the wire:
+``secret_key`` values are replaced with ``"<redacted>"`` and URL
+passwords are masked to ``***``.  This matters because the client's
+DEBUG-level RPC tracing logs the full response payload — without the
+redactor, signing keys would land in any DEBUG log file by default.
+
+If you add a new storage type that round-trips credentials through
+``cache_to_config``, extend
+:data:`fleche.remote._SENSITIVE_CONFIG_KEYS` to cover the new field
+name.
+
+Version handshake
+~~~~~~~~~~~~~~~~~
+
+The first cache operation on a fresh :class:`~fleche.remote.SshCache`
+implicitly fetches an :ref:`info <ssh-cache-internals>` dict via
+:meth:`fleche.remote.SshCache._ensure_handshake`, which calls
+:func:`fleche.remote._warn_on_version_skew` on the response.  Mismatched
+``fleche_version`` or ``cloudpickle_version`` between client and server
+logs a ``WARNING`` on the ``fleche.remote`` logger — schema or wire
+format drift is the most common root cause of silently-wrong records
+across a fleche upgrade, and this surfaces it without forcing a hard
+failure (forwards-compatible patch releases are common in practice and
+the user has no recourse mid-session from a raise).
+
+The handshake fires on the first BaseCache method on the SshCache,
+even reads — every method calls ``_ensure_handshake()`` at its top.
+Cost is exactly one extra RPC per session.
+
+Goals and constraints
+---------------------
+
+The cross-machine cache exists to let two (or more) machines share results of
+expensive ``@fleche()`` calls without copying their cache files around by
+hand.  The constraints that shaped the design:
+
+- **No always-on daemon.**  The remote side is a vanilla Python process
+  spawned on demand by the client.  Nothing has to be running before the
+  first cache lookup.
+- **Single authentication.**  Most multi-user clusters require 2FA.  A
+  client that silently reconnects whenever the connection drops would
+  re-prompt the user, possibly while they are away.  Auto-reconnect is
+  therefore explicitly out of scope (see *Lifecycle* below).
+- **Backend agnosticism.**  The remote keeps full freedom over which
+  :class:`~fleche.caches.BaseCache` it serves — including stacks
+  containing further :class:`~fleche.remote.SshCache` instances, if a
+  user really wants chained shares.
+- **Cheap round-trips.**  Cache ops are typically tiny payloads
+  (digest hits, ``contains`` probes).  The wire protocol favours
+  per-call latency over fan-out.
+
+Process and stream layout
+-------------------------
+
+One :class:`~fleche.remote.SshCache` owns exactly one
+:class:`fleche.remote._SshConnection`, which in turn owns at most one
+``Popen``:
+
+.. code-block:: text
+
+   client                                       remote
+   ──────                                       ──────
+
+   SshCache.<op>(...)            <op> ∈ save / load / load_value /
+       │    ▲                            contains / expand / shrink /
+   call│    │return                      query / evict / info
+       ▼    │
+   ┌──────────────┐                        ┌─────────────────────┐
+   │_SshConnection│   (stdin) request   ─▶ │ python -m           │
+   │              │                        │   fleche.remote     │
+   │ ssh host     │ ◀─ (stdout) response   │   --serve           │
+   │ python -m    │                        │                     │
+   │ fleche.remote│ ◀─ (stderr) lines      │   serve(...) loop   │
+   │ --serve      │                        └─────────────────────┘
+   └──────────────┘
+       │
+       │ stderr drained by a daemon thread
+       ▼
+   fleche.remote.host.<host>  +  50-line ring buffer
+
+Three streams cross the SSH boundary:
+
+* **stdin / stdout** carry length-prefixed cloudpickle RPC frames.  All
+  cache operations multiplex over this single pair; there is no
+  fan-out and no parallel requests.  ``_Connection.call`` takes a
+  :class:`threading.Lock` for the entire write→read round-trip so
+  threaded callers serialise naturally.
+* **stderr** is drained by a daemon thread running
+  :func:`fleche.remote._forward_stderr`.  Each line is logged at
+  ``INFO`` on the per-host logger ``fleche.remote.host.<host>`` *and*
+  appended to a 50-line ring buffer on the connection.  When the
+  subprocess dies,
+  :meth:`fleche.remote._SshConnection._diagnose` returns the buffered
+  tail plus the exit code so
+  :class:`~fleche.remote.RemoteConnectionError` carries the actual
+  cause instead of just ``EOFError``.
+
+  The logger name is constructed in
+  :meth:`fleche.remote._SshConnection._open` from the SSH host string;
+  dots and ``@`` are substituted with ``_`` so the host name doesn't
+  fragment the logger hierarchy.  Because the name uses ``.`` as the
+  separator, each host's logger is a real child of ``fleche.remote``
+  and standard logger configuration propagates: setting
+  ``logging.getLogger("fleche.remote").setLevel(...)`` controls every
+  per-host child, while
+  ``logging.getLogger("fleche.remote.host.bigpc_example_com")`` lets
+  you raise or silence one host independently.
+
+Wire protocol
+-------------
+
+Every frame is a 4-byte big-endian length prefix (``struct.Struct(">I")``)
+followed by a cloudpickle payload.  See :func:`fleche.remote._write_frame`
+and :func:`fleche.remote._read_frame`.
+
+Requests are 3-tuples ``(method: str, args: tuple, kwargs: dict)``;
+responses are 2-tuples either ``("ok", value)`` or ``("err", exception)``.
+Exceptions re-raise on the client side, so a server-side
+:exc:`KeyError` becomes a :exc:`KeyError` to the caller, a
+:exc:`~fleche.caches.Rejected` stays a :exc:`~fleche.caches.Rejected`,
+and so on.
+
+If the exception itself can't be cloudpickled (some C-extension types
+refuse), the server downgrades it to a :exc:`RuntimeError` carrying the
+formatted traceback so the client at least sees what went wrong.
+
+Server-side dispatch
+~~~~~~~~~~~~~~~~~~~~
+
+:func:`fleche.remote._dispatch` is an explicit ``if`` chain — one branch
+per :class:`~fleche.caches.BaseCache` method, plus ``info`` handled at
+the :func:`~fleche.remote.serve` level.  The explicit table is
+deliberate: it documents the full API surface, gives any future method
+addition a clear place to wire up server-side translation, and avoids
+giving remote callers reflective access to arbitrary attributes of the
+cache.
+
+Two pieces need server-side translation rather than raw passthrough:
+
+- :meth:`~fleche.caches.BaseCache.load` and
+  :meth:`~fleche.caches.BaseCache._query` produce
+  :class:`~fleche.call.LazyCall` instances whose ``_cache`` field
+  points at the *server's* cache.  That pointer cannot travel across
+  the wire (it would reach back into a different process on
+  deserialisation).  :func:`fleche.remote._strip_cache` strips it and
+  returns a plain :class:`~fleche.call.DigestedCall`; the client then
+  calls ``DigestedCall.fetch(self)`` to re-bind it to the local
+  :class:`~fleche.remote.SshCache`.  Subsequent ``.result`` accesses
+  on the lazy call therefore round-trip through ``load_value`` on the
+  client's SshCache and back to the remote — fetching the value only
+  when actually used.
+- :meth:`~fleche.caches.BaseCache.query` is a generator on the server
+  side.  ``_dispatch`` materialises the whole iterator into a tuple
+  before sending it back, because the wire protocol is request /
+  response, not streaming.  Large query results pay the cost up front
+  in one frame.
+
+Client side
+~~~~~~~~~~~
+
+:meth:`fleche.remote._Connection.call` is the one entry point for every
+RPC.  It acquires the lock, lazily opens the connection if needed,
+writes the request frame, reads exactly one response frame, and
+dispatches on the response tag.  On
+``(BrokenPipeError, EOFError, OSError)`` it calls ``_diagnose()`` to
+collect transport-specific detail, closes the connection, and raises
+:class:`~fleche.remote.RemoteConnectionError`.
+
+A note on logging: every RPC is logged at ``DEBUG`` on the
+``fleche.remote`` logger as ``rpc → method args=...`` and ``rpc ←
+method ok``.  Enabling debug-level logging on that namespace gives a
+complete trace of the wire traffic without instrumenting any code.
+
+Lifecycle
+---------
+
+The subprocess is spawned lazily on the first cache operation.  Once
+opened it lives for the lifetime of the Python process and is closed
+via :py:mod:`atexit` (the client's hook is registered on first
+``_open``).
+
+.. note:: **Subprocesses are not closed on garbage collection.**
+
+   ``atexit.register(self.close)`` keeps a reference to the connection
+   alive for the whole process, so a :class:`~fleche.remote.SshCache`
+   that goes out of scope is *not* eligible for collection and its SSH
+   subprocess stays up until interpreter exit.  In a long-running
+   interactive session that creates and discards many ``SshCache``
+   instances (e.g. repeatedly re-reading a config), the subprocesses
+   accumulate.  Call :meth:`~fleche.remote.SshCache.close` explicitly
+   when done with a cache you won't reuse.  A future revision could use
+   a ``weakref``-based atexit hook so dropped caches clean themselves
+   up, but the simple always-on-exit cleanup is correct for the common
+   case of a handful of long-lived caches.
+
+.. note:: **Reading** ``info()`` / ``read_only`` **costs an RPC.**
+
+   :meth:`~fleche.remote.SshCache.info` and the
+   :attr:`~fleche.remote.SshCache.read_only` property are not free: the
+   first access fetches the server info dict over the wire (and drives
+   the version handshake).  The result is cached for the lifetime of
+   the connection, so only the first access pays; but a user poking
+   ``sc.read_only`` in a REPL should know it is a network round-trip,
+   not a local attribute.  :meth:`~fleche.remote.SshCache.reconnect`
+   invalidates the cache, so the next access re-fetches.
+
+There is no automatic reconnect.  If the SSH subprocess dies — network
+hiccup, server reboot, idle timeout — every subsequent op raises
+:class:`~fleche.remote.RemoteConnectionError` until the caller invokes
+:meth:`~fleche.remote.SshCache.reconnect` explicitly.  The error
+message produced in
+:meth:`fleche.remote._Connection.call` names ``SshCache.reconnect()``
+directly so the user doesn't have to know about the lifecycle helper
+ahead of time.  This is the single most opinionated decision in the
+module: an auto-reconnect would silently re-trigger interactive 2FA
+prompts (often while the user is away from the terminal).  Forcing the
+call to be explicit means the user can decide *when* to pay that cost.
+
+For sessions that span multiple Python runs, the recommended pattern is
+OpenSSH ``ControlMaster`` + ``ControlPersist``: the first connection
+authenticates and the multiplexer keeps the underlying TCP session
+alive across child processes, so subsequent ``ssh`` invocations within
+the persist window skip the handshake entirely.  Wire it up either in
+``~/.ssh/config`` or via the ``ssh_options`` field on
+:class:`~fleche.remote.SshCache` (see the docstring for an example).
+
+Setup-commands chain
+~~~~~~~~~~~~~~~~~~~~
+
+When the user passes ``setup_commands``, the constructed remote command
+looks like:
+
+.. code-block:: text
+
+   <snippet1> && <snippet2> && ... && exec <python> -m fleche.remote --serve
+
+The trailing ``exec`` replaces the wrapping shell so stdin/stdout pipe
+straight through to the server process — no extra layer to corrupt the
+binary RPC stream.  Any setup failure short-circuits via ``&&`` and the
+ssh process exits non-zero; the client's next read raises ``EOFError``
+and the diagnostic captured from stderr surfaces the actual reason.
+
+Without ``setup_commands``, the server argv is passed directly to
+``ssh`` as separate arguments, so SSH ``exec``\\ s it as-is — no remote
+shell is involved at all.
+
+Diagnostics: the ``info`` RPC
+-----------------------------
+
+:func:`fleche.remote._server_info` is the introspection back-channel.
+It is the only method dispatched at the :func:`~fleche.remote.serve`
+level (alongside the data plane in :func:`~fleche.remote._dispatch`),
+because it needs access to two things the dispatcher doesn't have: the
+``cache_name`` the server was launched with, and the active cache from
+the :data:`fleche.state._CACHE` ``ContextVar``.
+
+It returns:
+
+================ =================================================
+Key              Meaning
+================ =================================================
+``cache``        :func:`~fleche.config.cache_to_config` of the
+                 served cache — a structured dict (or list, for
+                 stacks) that round-trips back through
+                 :func:`~fleche.config.cache_from_config`.
+``cache_name``   The ``--cache`` argument the server was launched
+                 with, or ``None`` for the default cache.
+``read_only``    ``True`` when the served cache (or, for a
+                 :class:`~fleche.caches.CacheStack`, its
+                 ``stack[0]``) is a
+                 :class:`~fleche.caches.ReadOnlyMixin`.
+``cwd``          ``os.getcwd()`` on the remote.
+``hostname``     ``socket.gethostname()`` on the remote.
+``python``       ``sys.executable`` on the remote.
+``pid``          The server process's PID.
+================ =================================================
+
+``info()`` is the debugging back-channel for any "the remote isn't
+doing what I expected" question — wrong cache loaded, wrong working
+directory, unexpected ``read_only`` flag, surprising Python
+interpreter, surprising host.  Calling it from the client surfaces the
+remote's view of itself in one round-trip, with no need to
+``ssh host`` separately and poke around.
+
+Active cache on the remote
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The server's served cache *is* its active cache.  ``python -m
+fleche.remote --serve`` installs the named cache on the
+``fleche.state._CACHE`` ContextVar before entering the request loop,
+so any code path on the remote that consults ``fleche.cache()``
+independently — metadata hooks, ``LazyCall._cache`` references, nested
+``@fleche()`` calls — sees the same instance the RPC layer is
+dispatching against.  The server process is single-threaded and
+serves exactly one cache, so there's no other sensible default.
+
+Read-only short-circuit
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:meth:`~fleche.remote.SshCache.save` and
+:meth:`~fleche.remote.SshCache.evict` check the cached ``read_only``
+flag from the server info dict before issuing the RPC.  If the flag is
+``True`` they raise :class:`~fleche.caches.Rejected` locally with no
+round-trip.
+
+The flag is populated lazily — the first time ``read_only`` (or
+``info()``) is consulted, an ``info`` RPC fires and the result is
+cached on the :class:`~fleche.remote.SshCache` instance.  Subsequent
+saves consult the cache directly.  Cost is therefore at most one
+extra round-trip per session, and zero in the common case where the
+first cache op is itself a write.
+
+:meth:`~fleche.remote.SshCache.reconnect` invalidates the cached info
+so the next read re-fetches against the new subprocess.
+
+Testing strategy
+----------------
+
+The module ships two layers of tests, both in ``tests/{unit,integration}/test_remote.py``:
+
+- **Unit tests** drive :func:`~fleche.remote.serve` in a background
+  daemon thread with two ``os.pipe()`` pairs in place of an SSH
+  subprocess.  The same wire-protocol machinery is exercised — frame
+  layout, dispatch, exception propagation, the
+  :class:`~fleche.remote._Connection` lifecycle — without SSH or
+  process spawning.  Tests that need the *transport*'s behaviour
+  (subprocess exit codes, stderr capture) drive a
+  :class:`fleche.remote._Connection` subclass directly with no server
+  on the other side; see ``test_connection_drop_includes_diagnose_output``.
+
+- **Integration tests** launch ``python -m fleche.remote --serve`` as
+  a local subprocess (still no SSH involved) so the full
+  ``Popen``-with-three-pipes handshake, module loading, and config-file
+  parsing on the server side are all exercised.  Each test uses a
+  ``tmp_path``-scoped ``fleche.toml`` so server state lives in an
+  isolated directory.
+
+Adding a new RPC
+----------------
+
+The path is short and entirely mechanical:
+
+1. Add a server-side branch in :func:`fleche.remote._dispatch` (or, if
+   the RPC needs server-only state like ``cache_name``, branch in
+   :func:`~fleche.remote.serve` itself the way ``info`` does).  Be
+   explicit about translating any cache-bound return value via
+   :func:`~fleche.remote._strip_cache`.
+2. Add a client method on :class:`~fleche.remote.SshCache` that calls
+   ``self._conn.call("method_name", *args)``.  If the response carries
+   :class:`~fleche.call.DigestedCall` instances, ``.fetch(self)`` them
+   back into client-bound :class:`~fleche.call.LazyCall`\\ s.
+3. Add tests at both layers: a unit test that drives the new method
+   through the in-process pipe, and (when it's worth it) an
+   integration test that exercises it across the subprocess boundary.
+
+Avoid adding more methods than necessary — every new method is wire
+surface that has to round-trip from any user.  Prefer threading the
+new operation through one of the existing methods where possible.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,7 @@ Welcome to the **Fleche** library documentation.
 
    dev/custom_digests
    dev/developer
+   dev/ssh_cache
 
 .. toctree::
    :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ sqlalchemy = [
 bagofholding = [
     "bagofholding == 0.1.12",
 ]
+ssh = [
+    # SshCache uses cloudpickle for its wire protocol — required, not optional.
+    "cloudpickle",
+]
 tests = [
     "pytest",
     "hypothesis",

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -263,7 +263,7 @@ def _combine_shrink(key: "Digest | str", results: "Iterable[Digest]") -> "Digest
     all_results = list(results)
     if not all_results:
         raise KeyError(key)
-    return max(all_results, key=len)  # type: ignore
+    return max(all_results, key=len)
 
 
 @dataclass(frozen=True)

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -113,6 +113,28 @@ Example fleche.toml
     calls.type = "cloudpickle"
     calls.root = "~/.fleche/calls"
 
+    # SshCache — share results with another machine over SSH.  The remote
+    # runs `python -m fleche.remote --serve` and proxies into its own
+    # configured cache.  Compose with a local cache by stacking two
+    # entries (saves go to the first entry; reads fall back to the SSH
+    # remote and back-fill hits into the local layer).
+    [[shared]]
+    values.type = "cloudpickle"
+    values.root = "~/.fleche/values"
+    calls.type = "cloudpickle"
+    calls.root = "~/.fleche/calls"
+
+    [[shared]]
+    type = "ssh"
+    host = "user@bigpc.example.com"
+    cache_name = "shared"               # optional: named cache on remote
+    python = "python3"                  # optional: remote python interpreter
+    ssh_options = ["-o", "ControlMaster=auto",
+                   "-o", "ControlPath=~/.ssh/cm-%r@%h:%p",
+                   "-o", "ControlPersist=10m"]
+    setup_commands = ["module load python/3.11",  # optional: shell snippets
+                      "source ~/.venv/bin/activate"]  # run before the server
+
 Config file discovery
 ---------------------
 
@@ -139,6 +161,7 @@ import os
 from typing import Any
 
 from . import storage, metadata, caches
+from .remote import SshCache
 
 logger = logging.getLogger("fleche.config")
 
@@ -398,6 +421,9 @@ def cache_from_config(d: "dict[str, Any] | list[dict[str, Any]]") -> caches.Base
         return caches.CacheStack(tuple(cache_from_config(c) for c in d))
 
     d = dict(d)
+    if d.get("type") == "ssh":
+        d.pop("type")
+        return SshCache(**d)
     read_only = d.pop("read_only", False)
     max_size = d.pop("max_size", None)
 
@@ -456,6 +482,17 @@ def cache_to_config(c: caches.BaseCache) -> "dict[str, Any] | list[dict[str, Any
         case caches.CacheStack():
             return cast("list[dict[str, Any]]", [cache_to_config(s) for s in c.stack])
         case _:
+            if isinstance(c, SshCache):
+                d: dict[str, Any] = {"type": "ssh", "host": c.host}
+                if c.cache_name is not None:
+                    d["cache_name"] = c.cache_name
+                if c.python != "python3":
+                    d["python"] = c.python
+                if c.ssh_options:
+                    d["ssh_options"] = list(c.ssh_options)
+                if c.setup_commands:
+                    d["setup_commands"] = list(c.setup_commands)
+                return d
             raise ValueError(f"Cannot convert cache of type {type(c).__name__!r} to config")
 
 

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -1,0 +1,868 @@
+"""SSH-connected cache for sharing fleche results across machines.
+
+:class:`SshCache` is a :class:`~fleche.caches.BaseCache` that forwards every
+operation to a remote ``python -m fleche.remote`` process over a single
+persistent SSH subprocess.  The remote process loads its own ``fleche.toml``
+and proxies operations into whichever cache it has configured, so the remote
+side keeps full freedom to use any backend (file / SQL / HDF5 / stack).
+
+Typical configuration in ``fleche.toml`` — local cache first, remote cache
+second, composed automatically into a :class:`~fleche.caches.CacheStack`::
+
+    [default]
+    cache = "shared"
+
+    [[shared]]                          # local layer (saves go here)
+    values.type = "cloudpickle"
+    values.root = "~/.fleche/values"
+    calls.type = "sql"
+    calls.url = "sqlite:///~/.fleche/calls.db"
+
+    [[shared]]                          # remote layer (read-through)
+    type = "ssh"
+    host = "marvin@bigpc.example.com"
+    cache_name = "shared"               # optional: named cache on remote
+    python = "python3"                  # optional
+    ssh_options = ["-o", "ControlMaster=auto",
+                   "-o", "ControlPath=~/.ssh/cm-%r@%h:%p",
+                   "-o", "ControlPersist=10m"]
+    setup_commands = ["module load python/3.11",
+                      "source ~/.venv/bin/activate"]    # optional
+
+ControlMaster + ControlPersist in ``~/.ssh/config`` (or via ``ssh_options``)
+mean 2FA is prompted once and then re-used across multiple fleche sessions
+within the persist window.  The SSH subprocess is spawned lazily on the first
+cache operation and reused for the lifetime of the Python process, so within
+a single run only one authentication round-trip is required.
+"""
+
+import abc
+import argparse
+import atexit
+import collections
+import logging
+import os
+import shlex
+import socket
+import struct
+import subprocess
+import sys
+import threading
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Iterable, overload
+
+from pyiron_snippets.import_alarm import ImportAlarm
+
+from . import call as _call
+from .caches import BaseCache, Rejected
+from .call import Call, DigestedCall, LazyCall, QueryCall
+from .digest import Digest
+
+logger = logging.getLogger("fleche.remote")
+
+with ImportAlarm(
+    "SshCache requires 'cloudpickle' (used for the client/server wire "
+    "protocol). Install it with `pip install fleche[ssh]`.",
+    raise_exception=True,
+) as cloudpickle_alarm:
+    import cloudpickle
+
+
+# ---------------------------------------------------------------------------
+# Wire protocol
+# ---------------------------------------------------------------------------
+
+_HEADER = struct.Struct(">I")
+
+
+def _write_frame(stream, obj: Any) -> None:
+    """Write a length-prefixed cloudpickle frame to *stream*."""
+    data = cloudpickle.dumps(obj)
+    stream.write(_HEADER.pack(len(data)))
+    stream.write(data)
+    stream.flush()
+
+
+def _read_frame(stream) -> Any:
+    """Read a length-prefixed cloudpickle frame from *stream*.
+
+    Raises:
+        EOFError: stream closed before a full frame was available.
+    """
+    header = stream.read(_HEADER.size)
+    if len(header) < _HEADER.size:
+        raise EOFError("connection closed before frame header")
+    (n,) = _HEADER.unpack(header)
+    chunks = []
+    remaining = n
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            raise EOFError("connection closed mid-frame")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return cloudpickle.loads(b"".join(chunks))
+
+
+# ---------------------------------------------------------------------------
+# Server side
+# ---------------------------------------------------------------------------
+
+
+def _strip_cache(lc: LazyCall) -> DigestedCall:
+    """Return the cache-free :class:`DigestedCall` shadow of a :class:`LazyCall`.
+
+    The remote-bound ``_cache`` reference inside :class:`LazyCall` cannot
+    travel across the wire — the client wraps the returned ``DigestedCall``
+    back into a :class:`LazyCall` bound to itself via ``DigestedCall.fetch``.
+    """
+    return DigestedCall(
+        name=lc.name,
+        arguments=dict(lc._arguments),
+        result=lc._result,
+        metadata=dict(lc.metadata),
+        module=lc.module,
+        version=lc.version,
+        code_digest=lc.code_digest,
+    )
+
+
+def _dispatch(cache: BaseCache, method: str, args: tuple, kwargs: dict) -> Any:
+    if method == "save":
+        (c,) = args
+        return cache.save(c)
+    if method == "load":
+        (key,) = args
+        return _strip_cache(cache.load(key))
+    if method == "load_value":
+        (key,) = args
+        return cache.load_value(key)
+    if method == "evict":
+        (key,) = args
+        cache.evict(key)
+        return None
+    if method == "contains":
+        (key,) = args
+        return cache.contains(key)
+    if method == "expand":
+        (key,) = args
+        return cache.expand(key)
+    if method == "shrink":
+        # Variadic: single key → Digest, multiple keys → tuple[Digest, ...].
+        return cache.shrink(*args)
+    if method == "query":
+        (template,) = args
+        return tuple(_strip_cache(lc) for lc in cache.query(template))
+    raise ValueError(f"Unknown remote cache method: {method!r}")
+
+
+def _is_read_only(cache: BaseCache) -> bool:
+    """Best-effort check of whether *cache* will reject every ``save``.
+
+    Recognises :class:`~fleche.caches.ReadOnlyMixin` directly (covers
+    :class:`~fleche.caches.ReadOnlyCache` and
+    :class:`~fleche.caches.FilteredCache`); for a
+    :class:`~fleche.caches.CacheStack` checks ``stack[0]`` since that is
+    where ``CacheStack.save`` writes.  Returns ``False`` for anything
+    else — at worst the client falls back to the round-trip path.
+    """
+    from .caches import CacheStack, ReadOnlyMixin
+
+    if isinstance(cache, ReadOnlyMixin):
+        return True
+    if isinstance(cache, CacheStack):
+        return bool(cache.stack) and _is_read_only(cache.stack[0])
+    return False
+
+
+# Config keys whose values are credentials we must not put on the wire.
+# ``secret_key`` carries HMAC signing keys; ``url`` may carry a database
+# password in its userinfo component (postgres / mysql).
+_SENSITIVE_CONFIG_KEYS = frozenset({"secret_key"})
+
+
+def _redact_url_password(url: str) -> str:
+    """Replace the password component of a SQLAlchemy URL with ``"***"``.
+
+    Plain sqlite URLs (no userinfo) round-trip unchanged.  Anything that
+    doesn't parse as a URL with a userinfo component is returned as-is.
+    """
+    try:
+        import urllib.parse as _up
+
+        parsed = _up.urlsplit(url)
+    except Exception:
+        return url
+    if not parsed.password:
+        return url
+    user = parsed.username or ""
+    host_and_port = parsed.hostname or ""
+    if parsed.port is not None:
+        host_and_port = f"{host_and_port}:{parsed.port}"
+    netloc = f"{user}:***@{host_and_port}" if user else f":***@{host_and_port}"
+    return _up.urlunsplit(
+        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+    )
+
+
+def _redact_config(value: Any) -> Any:
+    """Recursively redact credential-ish fields from a cache_to_config dict.
+
+    Walks dicts and lists; for any dict whose key is in
+    :data:`_SENSITIVE_CONFIG_KEYS`, replaces the value with
+    ``"<redacted>"``.  For ``url`` keys whose value is a string with a
+    password component, the password component alone is masked so the
+    rest of the URL still appears in info output.
+    """
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            if k in _SENSITIVE_CONFIG_KEYS:
+                out[k] = "<redacted>"
+            elif k == "url" and isinstance(v, str):
+                out[k] = _redact_url_password(v)
+            else:
+                out[k] = _redact_config(v)
+        return out
+    if isinstance(value, list):
+        return [_redact_config(item) for item in value]
+    return value
+
+
+def _server_info(cache: BaseCache, cache_name: str | None) -> dict[str, Any]:
+    """Diagnostic snapshot of the server's view of itself.
+
+    Surfaces the same things a user would `ssh host` to check by hand: which
+    Python is running, in which directory, with what cache loaded.  The
+    served cache config plus the CWD is usually enough to spot the common
+    "remote loaded a different fleche.toml than I expected" failure mode.
+
+    Credential fields (``secret_key``, URL passwords) are redacted by
+    :func:`_redact_config` before going on the wire — the info dict is
+    visible to anyone the client logs against, including the DEBUG
+    ``rpc ←`` lines, and signing keys must not leak there.
+
+    ``fleche_version`` and ``cloudpickle_version`` are exposed so the
+    client can fail fast (or warn) on version skew with the server.
+    The ``read_only`` flag lets the client short-circuit ``save`` and
+    ``evict`` locally instead of paying a round-trip just to receive
+    :class:`~fleche.caches.Rejected`.
+    """
+    from .config import cache_to_config
+
+    try:
+        cache_config: Any = _redact_config(cache_to_config(cache))
+    except Exception as e:
+        cache_config = f"<cache_to_config failed: {e}>"
+    return {
+        "cache": cache_config,
+        "cache_name": cache_name,
+        "read_only": _is_read_only(cache),
+        "fleche_version": _fleche_version(),
+        "cloudpickle_version": cloudpickle.__version__,
+        "cwd": os.getcwd(),
+        "hostname": socket.gethostname(),
+        "python": sys.executable,
+        "pid": os.getpid(),
+    }
+
+
+def _fleche_version() -> str:
+    """Return the installed fleche version, or ``"unknown"`` on failure."""
+    try:
+        from ._version import version
+
+        return version
+    except Exception:
+        return "unknown"
+
+
+def serve(
+    input_stream,
+    output_stream,
+    cache: BaseCache,
+    *,
+    cache_name: str | None = None,
+) -> None:
+    """Run the remote cache request loop until *input_stream* reaches EOF.
+
+    Reads RPC frames from *input_stream*, dispatches them against *cache*,
+    and writes responses to *output_stream*.  Exceptions from the cache are
+    propagated to the client as ``("err", exception)`` frames; if an
+    exception cannot be cloudpickled it is replaced with a
+    :class:`RuntimeError` carrying its repr.
+
+    Args:
+        input_stream: binary readable stream (e.g. ``sys.stdin.buffer``).
+        output_stream: binary writable stream (e.g. ``sys.stdout.buffer``).
+        cache: the cache to serve.
+        cache_name: Optional name the server was launched with — echoed back
+            in ``info`` responses for debugging.
+    """
+    while True:
+        try:
+            req = _read_frame(input_stream)
+        except EOFError:
+            return
+        try:
+            method, args, kwargs = req
+        except (TypeError, ValueError):
+            logger.error("Malformed request frame: %r", req)
+            continue
+        try:
+            if method == "info":
+                result = _server_info(cache, cache_name)
+            else:
+                result = _dispatch(cache, method, args, kwargs)
+            _write_frame(output_stream, ("ok", result))
+        except BaseException as exc:
+            try:
+                _write_frame(output_stream, ("err", exc))
+            except Exception:
+                # exc itself failed to cloudpickle; fall back to a string.
+                tb = traceback.format_exc()
+                fallback = RuntimeError(f"{type(exc).__name__}: {exc}\n{tb}")
+                _write_frame(output_stream, ("err", fallback))
+
+
+# ---------------------------------------------------------------------------
+# Client side
+# ---------------------------------------------------------------------------
+
+
+class RemoteConnectionError(RuntimeError):
+    """Raised when the SSH subprocess cannot be reached or has died."""
+
+
+def _warn_on_version_skew(info: dict[str, Any]) -> None:
+    """Log a warning when the remote's fleche or cloudpickle version differs.
+
+    The cloudpickle wire format and the fleche ``Call`` / ``LazyCall``
+    schemas are tied to those library versions; a mismatch is the most
+    common root cause of silently-wrong records when this PR ages.  We
+    log instead of raising because forwards-compatible drift is common
+    in practice (patch releases) and the user has no recourse from a
+    hard failure mid-session.
+    """
+    local_fleche = _fleche_version()
+    remote_fleche = info.get("fleche_version")
+    if remote_fleche and remote_fleche != local_fleche:
+        logger.warning(
+            "fleche version skew: local=%s remote=%s — schemas may differ",
+            local_fleche,
+            remote_fleche,
+        )
+    local_cp = cloudpickle.__version__
+    remote_cp = info.get("cloudpickle_version")
+    if remote_cp and remote_cp != local_cp:
+        logger.warning(
+            "cloudpickle version skew: local=%s remote=%s — wire format may differ",
+            local_cp,
+            remote_cp,
+        )
+
+
+class _Connection(abc.ABC):
+    """Frame-passing channel over a pair of binary streams.
+
+    Subclasses provide :meth:`_open` (called lazily on first use) and
+    optionally :meth:`_close` / :meth:`_diagnose`.  The serialised RPC
+    over the channel itself is the same in every transport, so test
+    transports (in-process pipes) share the request/response machinery
+    with the SSH transport.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._stdin = None
+        self._stdout = None
+        self._opened = False
+        self._atexit_registered = False
+
+    # ------------------------------------------------------------------
+    # subclass hooks
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def _open(self) -> tuple:
+        """Open the transport.
+
+        Returns:
+            ``(stdin, stdout)`` — a binary writable and a binary readable
+            stream connecting to the remote ``serve()`` loop.
+        """
+
+    def _close(self) -> None:
+        """Release any transport-level resources."""
+        return None
+
+    def _diagnose(self) -> str:
+        """Return diagnostic detail to append to a connection-lost error.
+
+        Subclasses with access to subprocess state (exit code, captured
+        stderr) override this to enrich the bare EOF with whatever the
+        transport can see.  The default returns an empty string.
+        """
+        return ""
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+
+    def call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        with self._lock:
+            self._ensure_open()
+            logger.debug("rpc → %s args=%r kwargs=%r", method, args, kwargs)
+            try:
+                _write_frame(self._stdin, (method, args, kwargs))
+                tag, payload = _read_frame(self._stdout)
+            except (BrokenPipeError, EOFError, OSError) as e:
+                diag = self._diagnose()
+                self._close_locked()
+                msg = (
+                    f"Remote cache connection lost during {method!r}: {e}\n"
+                    f"Call SshCache.reconnect() to spawn a fresh subprocess."
+                )
+                if diag:
+                    msg = f"{msg}\n{diag}"
+                    logger.error("%s", msg)
+                raise RemoteConnectionError(msg) from e
+        logger.debug("rpc ← %s %s", method, tag)
+        if tag == "ok":
+            return payload
+        if tag == "err":
+            raise payload
+        raise RuntimeError(f"Unexpected response tag from remote cache: {tag!r}")
+
+    def reconnect(self) -> None:
+        with self._lock:
+            self._close_locked()
+
+    def close(self) -> None:
+        with self._lock:
+            self._close_locked()
+
+    # ------------------------------------------------------------------
+    # internal
+    # ------------------------------------------------------------------
+
+    def _ensure_open(self) -> None:
+        if self._opened:
+            return
+        self._stdin, self._stdout = self._open()
+        self._opened = True
+        if not self._atexit_registered:
+            atexit.register(self.close)
+            self._atexit_registered = True
+
+    def _close_locked(self) -> None:
+        if not self._opened:
+            return
+        self._opened = False
+        try:
+            self._close()
+        except Exception:
+            logger.debug("error while closing remote connection", exc_info=True)
+        self._stdin = None
+        self._stdout = None
+
+
+class _SshConnection(_Connection):
+    """Persistent ``ssh host python -m fleche.remote --serve`` subprocess.
+
+    One subprocess per :class:`SshCache` instance.  Spawned lazily on the
+    first RPC and reused for the lifetime of the Python process; never
+    auto-reconnected (an automatic reconnect would silently re-trigger
+    interactive 2FA prompts).  :meth:`reconnect` lets the caller force a
+    fresh spawn after a hang or a credential rotation.
+
+    Stream layout:
+
+    * **stdin / stdout** carry length-prefixed cloudpickle RPC frames
+      (see :func:`_write_frame` / :func:`_read_frame`).  All cache
+      operations multiplex over this single pair — there is no fan-out
+      and no parallel requests; :meth:`_Connection.call` holds a lock
+      across the round-trip.
+    * **stderr** is drained by a daemon thread (:func:`_forward_stderr`)
+      into the ``fleche.remote[<host>]`` logger at INFO and also into a
+      bounded ring buffer.  When the subprocess dies, the buffer plus
+      the exit code surface via :meth:`_diagnose` so the user sees the
+      remote shell's last words instead of just a bare EOF.
+
+    Command construction (:meth:`_build_command`):
+
+    * The base command is ``ssh [ssh_options...] host``.
+    * If *setup_commands* is empty, the server argv is passed directly
+      so SSH ``exec``\\ s it as-is — no remote shell wraps stdin/stdout.
+    * If *setup_commands* is non-empty, the snippets are joined with
+      ``&&`` and prefixed in front of ``exec <server>``; the final
+      ``exec`` replaces the shell so the pipe is still unwrapped.  Any
+      setup failure short-circuits via ``&&`` and the SSH process exits
+      non-zero — the next :func:`_read_frame` raises ``EOFError`` and
+      the client surfaces the captured stderr through
+      :class:`RemoteConnectionError`.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        python: str,
+        cache_name: str | None,
+        ssh_options: tuple[str, ...],
+        setup_commands: tuple[str, ...],
+    ) -> None:
+        super().__init__()
+        self._host = host
+        self._python = python
+        self._cache_name = cache_name
+        self._ssh_options = ssh_options
+        self._setup_commands = setup_commands
+        self._proc: subprocess.Popen | None = None
+        self._stderr_thread: threading.Thread | None = None
+        # Last few lines of remote stderr, surfaced in RemoteConnectionError
+        # so REPL users see the cause without needing logging configured.
+        self._stderr_buffer: collections.deque[str] = collections.deque(maxlen=50)
+
+    def _build_command(self) -> list[str]:
+        cmd = ["ssh"]
+        cmd.extend(self._ssh_options)
+        cmd.append(self._host)
+        server_argv = [self._python, "-m", "fleche.remote", "--serve"]
+        if self._cache_name is not None:
+            server_argv.extend(["--cache", self._cache_name])
+        if self._setup_commands:
+            # Run user setup snippets in the remote shell, then `exec` into the
+            # server so stdin/stdout pipe straight through with no shell wrapper.
+            # Any setup failure short-circuits via `&&` and the SSH process exits
+            # non-zero — the client surfaces this as RemoteConnectionError.
+            server_cmd = " ".join(shlex.quote(a) for a in server_argv)
+            remote = " && ".join((*self._setup_commands, f"exec {server_cmd}"))
+            cmd.append(remote)
+        else:
+            cmd.extend(server_argv)
+        return cmd
+
+    def _open(self) -> tuple:
+        cmd = self._build_command()
+        logger.info("spawning remote cache via: %s", " ".join(cmd))
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+            )
+        except FileNotFoundError as e:
+            raise RemoteConnectionError(f"failed to launch ssh: {e}") from e
+        self._proc = proc
+        self._stderr_buffer.clear()
+        # Per-host child logger of `fleche.remote` (dots in host become
+        # underscores so they don't create spurious sub-levels in the
+        # logger hierarchy).  setLevel on `fleche.remote` cascades here.
+        host_tag = self._host.replace(".", "_").replace("@", "_at_")
+        self._stderr_thread = threading.Thread(
+            target=_forward_stderr,
+            args=(proc.stderr, f"fleche.remote.host.{host_tag}", self._stderr_buffer),
+            daemon=True,
+        )
+        self._stderr_thread.start()
+        return proc.stdin, proc.stdout
+
+    def _diagnose(self) -> str:
+        # Give the stderr forwarder a moment to drain anything written just
+        # before the process died — the stderr pipe is independent of stdout
+        # so its EOF and the buffer flush race the read-frame failure.
+        thread = self._stderr_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=0.5)
+        parts: list[str] = []
+        proc = self._proc
+        if proc is not None:
+            rc = proc.poll()
+            if rc is not None:
+                parts.append(f"remote exit code: {rc}")
+        if self._stderr_buffer:
+            tail = "".join(self._stderr_buffer).rstrip()
+            parts.append(f"remote stderr (last {len(self._stderr_buffer)} lines):\n{tail}")
+        return "\n".join(parts)
+
+    def _close(self) -> None:
+        proc = self._proc
+        if proc is None:
+            return
+        self._proc = None
+        try:
+            if proc.stdin is not None:
+                try:
+                    proc.stdin.close()
+                except Exception:
+                    pass
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+        finally:
+            if self._stderr_thread is not None:
+                self._stderr_thread.join(timeout=1.0)
+                self._stderr_thread = None
+
+
+def _forward_stderr(
+    stream, prefix: str, buffer: "collections.deque[str] | None" = None
+) -> None:
+    remote_logger = logging.getLogger(prefix)
+    try:
+        for line in iter(stream.readline, b""):
+            text = line.decode("utf-8", "replace")
+            remote_logger.info("%s", text.rstrip("\n"))
+            if buffer is not None:
+                buffer.append(text)
+    except Exception:
+        pass
+
+
+@dataclass(frozen=True)
+class SshCache(BaseCache):
+    """A cache that forwards every operation to a remote fleche over SSH.
+
+    The remote side runs ``python -m fleche.remote --serve``; its active
+    cache is determined by its own ``fleche.toml`` (optionally overridden by
+    *cache_name* — looked up via :func:`fleche.config.load_cache_config`).
+
+    The SSH subprocess is spawned lazily on the first cache operation and
+    reused for the lifetime of the Python process.  Set up ControlMaster /
+    ControlPersist in ``~/.ssh/config`` or via *ssh_options* to share the
+    underlying connection across multiple fleche runs.
+
+    Args:
+        host: SSH target, e.g. ``"user@host"`` or any alias from
+            ``~/.ssh/config``.
+        cache_name: Optional named cache on the remote.  ``None`` (default)
+            uses the remote's default cache.
+        python: Remote python executable.  Defaults to ``"python3"``.
+        ssh_options: Extra command-line arguments inserted between ``ssh``
+            and *host*, e.g. ``("-o", "ControlMaster=auto")``.
+        setup_commands: Shell snippets run on the remote *before* the server
+            process starts, joined with ``&&`` so any failure aborts the
+            launch.  Typical uses are HPC environment setup —
+            ``("module load python/3.11", "source ~/.venv/bin/activate")`` —
+            or ``cd`` into a working directory.  Each snippet is passed to the
+            remote shell verbatim; quote any user-provided values yourself.
+    """
+
+    host: str
+    cache_name: str | None = None
+    python: str = "python3"
+    ssh_options: tuple[str, ...] = ()
+    setup_commands: tuple[str, ...] = ()
+    _conn: _Connection = field(init=False, repr=False, compare=False, hash=False)
+    _info_cache: "dict[str, Any] | None" = field(
+        init=False, default=None, repr=False, compare=False, hash=False
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "ssh_options", tuple(self.ssh_options))
+        object.__setattr__(self, "setup_commands", tuple(self.setup_commands))
+        conn = _SshConnection(
+            host=self.host,
+            python=self.python,
+            cache_name=self.cache_name,
+            ssh_options=self.ssh_options,
+            setup_commands=self.setup_commands,
+        )
+        object.__setattr__(self, "_conn", conn)
+
+    # ------------------------------------------------------------------
+    # BaseCache surface
+    # ------------------------------------------------------------------
+
+    def _ensure_handshake(self) -> None:
+        """Trigger the lazy version handshake (idempotent).
+
+        Called at the top of every BaseCache method so the first RPC of
+        a session implicitly fetches the server's info dict, which both
+        populates the read-only short-circuit cache and runs the
+        fleche/cloudpickle version-skew check via
+        :func:`_warn_on_version_skew`.  Subsequent ops are zero-cost.
+        """
+        if self._info_cache is None:
+            self._cached_info()
+
+    def save(self, call: Call) -> str:
+        self._ensure_handshake()
+        if self._info_cache and self._info_cache.get("read_only", False):
+            raise Rejected(self, call)
+        return self._conn.call("save", call)
+
+    def load(self, key: str) -> LazyCall:
+        self._ensure_handshake()
+        dc: DigestedCall = self._conn.call("load", key)
+        return dc.fetch(self)
+
+    def load_value(self, key: str) -> Any:
+        self._ensure_handshake()
+        return self._conn.call("load_value", key)
+
+    def evict(self, key: str | Digest) -> None:
+        self._ensure_handshake()
+        if self._info_cache and self._info_cache.get("read_only", False):
+            raise Rejected("Cannot evict from a read-only remote cache", self, key)
+        self._conn.call("evict", key)
+
+    def contains(self, key: str) -> bool:
+        self._ensure_handshake()
+        return self._conn.call("contains", key)
+
+    def expand(self, key: Digest | str) -> Digest:
+        self._ensure_handshake()
+        return self._conn.call("expand", key)
+
+    @overload
+    def shrink(self, key: Digest | str, /) -> Digest: ...
+    @overload
+    def shrink(
+        self, key: Digest | str, /, *keys: Digest | str
+    ) -> "tuple[Digest, ...]": ...
+
+    def shrink(self, *keys: Digest | str) -> "Digest | tuple[Digest, ...]":
+        self._ensure_handshake()
+        return self._conn.call("shrink", *keys)
+
+    def _query(self, call: QueryCall) -> Iterable[LazyCall]:
+        self._ensure_handshake()
+        results: tuple[DigestedCall, ...] = self._conn.call("query", call)
+        for dc in results:
+            yield dc.fetch(self)
+
+    # ------------------------------------------------------------------
+    # lifecycle helpers
+    # ------------------------------------------------------------------
+
+    def reconnect(self) -> None:
+        """Drop the current SSH subprocess; the next operation reconnects.
+
+        Useful if the underlying transport hangs or the remote needs to be
+        re-authenticated.  Not invoked automatically — auto-reconnect would
+        silently re-trigger 2FA prompts.
+        """
+        # Cached info reflects the *previous* server process — invalidate so
+        # the next `read_only` check re-fetches against whatever is on the
+        # other end of the new subprocess.
+        object.__setattr__(self, "_info_cache", None)
+        self._conn.reconnect()
+
+    def close(self) -> None:
+        """Close the SSH subprocess if it is currently open."""
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # debug helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def read_only(self) -> bool:
+        """Whether the remote cache will reject every ``save`` / ``evict``.
+
+        Read from the cached server info (one ``info`` RPC on first
+        access, then reused for the lifetime of the connection). Used to
+        short-circuit ``save`` and ``evict`` locally so the client
+        doesn't pay a round-trip just to receive
+        :class:`~fleche.caches.Rejected`.
+        """
+        return self._cached_info().get("read_only", False)
+
+    def info(self, *, refresh: bool = True) -> dict[str, Any]:
+        """Return a snapshot of the remote server's view of itself.
+
+        Keys: ``cache`` (the served cache serialised via
+        :func:`fleche.config.cache_to_config` — a structured dict that
+        round-trips through :func:`~fleche.config.cache_from_config`,
+        with credential fields like ``secret_key`` and URL passwords
+        redacted server-side), ``cache_name`` (the ``--cache`` argument
+        the server was launched with, if any), ``read_only`` (whether
+        saves/evicts will be rejected), ``fleche_version``,
+        ``cloudpickle_version``, ``cwd``, ``hostname``, ``python``,
+        ``pid``.
+
+        Primary use: any "the remote isn't doing what I expected"
+        question (wrong cache, wrong cwd, surprising read_only,
+        surprising Python).  The first lazy fetch also drives the
+        version handshake — see :meth:`_cached_info`.
+
+        Args:
+            refresh: When True (default), make a fresh ``info`` RPC and
+                update the local cache.  When False, return the cached
+                copy if one exists (fetching on first call).
+        """
+        info = self._info_cache
+        if refresh or info is None:
+            info = self._conn.call("info")
+            object.__setattr__(self, "_info_cache", info)
+            _warn_on_version_skew(info)
+        return info
+
+    def _cached_info(self) -> dict[str, Any]:
+        """Internal accessor: fetch info once, then reuse it.
+
+        The first fetch doubles as a version handshake — see
+        :func:`_warn_on_version_skew`.  Any RPC method that
+        short-circuits on the cached info (currently ``save`` /
+        ``evict`` via the ``read_only`` flag) therefore implicitly
+        triggers the handshake on its first call.
+        """
+        if self._info_cache is None:
+            return self.info(refresh=False)
+        return self._info_cache
+
+
+# ---------------------------------------------------------------------------
+# Module entry point: `python -m fleche.remote --serve [--cache NAME]`
+# ---------------------------------------------------------------------------
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="python -m fleche.remote")
+    parser.add_argument(
+        "--serve",
+        action="store_true",
+        help="run the remote cache server reading RPC frames from stdin",
+    )
+    parser.add_argument(
+        "--cache",
+        default=None,
+        help="named cache from the remote fleche.toml (default: the file's default)",
+    )
+    args = parser.parse_args(argv)
+    if not args.serve:
+        parser.error("nothing to do; pass --serve to run the cache server")
+    from . import cache as activate_cache
+
+    # Install the requested cache as the *active* one (via the ContextVar in
+    # state.py) so anything executed inside the served cache — metadata
+    # hooks, value-loading through LazyCall references, nested @fleche()
+    # calls — sees the same cache the RPC layer is dispatching against.
+    # `load_cache_config()` alone only constructs the cache; it doesn't
+    # activate it.
+    if args.cache is not None:
+        activate_cache(args.cache)
+    cache = activate_cache()
+    logger.info("serving remote fleche cache (name=%r): %r", args.cache, cache)
+    serve(sys.stdin.buffer, sys.stdout.buffer, cache, cache_name=args.cache)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))
+
+
+__all__ = [
+    "RemoteConnectionError",
+    "SshCache",
+    "serve",
+]

--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -39,10 +39,9 @@ class BagOfHoldingH5FileBackend(FileStorage):
 
     def _from_file(self, path: Path) -> Any:
         try:
-            kwargs = {}
             if self.version_validator is not None:
-                kwargs["version_validator"] = self.version_validator
-            return H5Bag(path).load(**kwargs)
+                return H5Bag(path).load(version_validator=self.version_validator)
+            return H5Bag(path).load()
         except FileNotFoundError:
             raise KeyError(path) from None
         except OSError as e:

--- a/tests/integration/test_remote.py
+++ b/tests/integration/test_remote.py
@@ -1,0 +1,167 @@
+"""End-to-end integration tests for :class:`fleche.remote.SshCache`.
+
+These tests bypass SSH entirely: ``python -m fleche.remote --serve`` is
+launched as a local subprocess so the same stdin/stdout RPC machinery used
+in production is exercised in full, including module loading, config file
+parsing on the server side, and the ``Popen`` handshake on the client side.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from fleche.call import Call
+from fleche.remote import SshCache, _Connection
+
+
+class _LocalSubprocessConnection(_Connection):
+    """Launch ``python -m fleche.remote --serve`` directly (no SSH)."""
+
+    def __init__(self, cache_name=None, env=None, cwd=None):
+        super().__init__()
+        self._cache_name = cache_name
+        self._env = env
+        self._cwd = cwd
+        self._proc = None
+
+    def _open(self):
+        cmd = [sys.executable, "-m", "fleche.remote", "--serve"]
+        if self._cache_name is not None:
+            cmd.extend(["--cache", self._cache_name])
+        self._proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            env=self._env,
+            cwd=self._cwd,
+        )
+        return self._proc.stdin, self._proc.stdout
+
+    def _close(self):
+        if self._proc is None:
+            return
+        proc = self._proc
+        self._proc = None
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+
+
+def _build_remote(tmp_path, cache_name=None, toml=None):
+    """Construct an :class:`SshCache` that talks to a local subprocess.
+
+    The server subprocess runs with ``cwd=tmp_path`` so its ``./fleche.toml``
+    is the test-controlled config — fleche's config loader checks the local
+    file first.
+    """
+    cfg = tmp_path / "fleche.toml"
+    cfg.write_text(toml if toml is not None else _DEFAULT_TOML.format(root=tmp_path))
+    env = dict(os.environ)
+    # Belt-and-braces: also point the XDG fallback away from the user's home.
+    env["XDG_CONFIG_HOME"] = str(tmp_path)
+    env.pop("HOME", None)
+    sc = SshCache(host="ignored")
+    object.__setattr__(
+        sc,
+        "_conn",
+        _LocalSubprocessConnection(cache_name=cache_name, env=env, cwd=str(tmp_path)),
+    )
+    return sc
+
+
+_DEFAULT_TOML = textwrap.dedent(
+    """
+    [default]
+    cache = "persistent"
+
+    [persistent]
+    values.type = "cloudpickle"
+    values.root = "{root}/values"
+    calls.type = "cloudpickle"
+    calls.root = "{root}/calls"
+    """
+).strip()
+
+
+def test_subprocess_save_and_load(tmp_path):
+    """Save a call via the subprocess, load it back, see the same result."""
+    remote_root = tmp_path / "remote"
+    remote_root.mkdir()
+    sc = _build_remote(remote_root)
+    try:
+        c = Call(name="example", arguments={"x": 41}, result=42)
+        key = sc.save(c)
+        assert sc.contains(key)
+        lc = sc.load(key)
+        assert lc.result == 42
+        assert dict(lc.arguments) == {"x": 41}
+    finally:
+        sc.close()
+
+
+def test_subprocess_survives_across_two_processes(tmp_path):
+    """Data saved through one subprocess must be visible to a fresh one.
+
+    This mirrors the cross-machine use case: machine A saves a result,
+    machine B reads it back from the same on-disk cache.
+    """
+    remote_root = tmp_path / "remote"
+    remote_root.mkdir()
+
+    sc1 = _build_remote(remote_root)
+    try:
+        key = sc1.save(Call(name="shared_fn", arguments={"a": 7}, result="payload"))
+    finally:
+        sc1.close()
+
+    sc2 = _build_remote(remote_root)
+    try:
+        assert sc2.contains(key)
+        lc = sc2.load(key)
+        assert lc.result == "payload"
+    finally:
+        sc2.close()
+
+
+def test_subprocess_named_cache(tmp_path):
+    """``--cache`` selects a named cache from the remote's config."""
+    remote_root = tmp_path / "remote"
+    remote_root.mkdir()
+    toml = textwrap.dedent(
+        f"""
+        [default]
+        cache = "main"
+
+        [main]
+        values.type = "cloudpickle"
+        values.root = "{remote_root}/main_values"
+        calls.type = "cloudpickle"
+        calls.root = "{remote_root}/main_calls"
+
+        [alt]
+        values.type = "cloudpickle"
+        values.root = "{remote_root}/alt_values"
+        calls.type = "cloudpickle"
+        calls.root = "{remote_root}/alt_calls"
+        """
+    ).strip()
+
+    sc_main = _build_remote(remote_root, toml=toml)
+    sc_alt = _build_remote(remote_root, toml=toml, cache_name="alt")
+    try:
+        key = sc_main.save(Call(name="f", arguments={"x": 1}, result=1))
+        assert sc_main.contains(key)
+        # The alt cache lives at a different root and should be empty.
+        assert not sc_alt.contains(key)
+    finally:
+        sc_main.close()
+        sc_alt.close()

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -1,0 +1,609 @@
+"""Unit tests for :mod:`fleche.remote`.
+
+These tests drive the server loop in a background thread with ``os.pipe()``
+streams in place of an SSH subprocess.  The same wire protocol is exercised;
+only the transport is swapped.
+"""
+
+import io
+import os
+import sys
+import threading
+
+import pytest
+
+from fleche.call import Call, QueryCall
+from fleche.caches import Cache, Rejected
+from fleche.digest import Digest
+from fleche.remote import (
+    RemoteConnectionError,
+    SshCache,
+    _Connection,
+    _read_frame,
+    _write_frame,
+    serve,
+)
+from fleche.storage import CallMemory, ValueMemory
+
+
+class _PipeConnection(_Connection):
+    """In-process transport for tests: run ``serve()`` in a thread.
+
+    Two ``os.pipe()`` pairs connect the client's write/read to the server's
+    read/write.  No SSH involved.
+    """
+
+    def __init__(self, cache):
+        super().__init__()
+        self._cache = cache
+        self._thread = None
+        self._server_stdin = None
+        self._server_stdout = None
+
+    def _open(self):
+        server_in_r, client_out_w = os.pipe()
+        client_in_r, server_out_w = os.pipe()
+        client_stdin = os.fdopen(client_out_w, "wb", buffering=0)
+        client_stdout = os.fdopen(client_in_r, "rb", buffering=0)
+        self._server_stdin = os.fdopen(server_in_r, "rb", buffering=0)
+        self._server_stdout = os.fdopen(server_out_w, "wb", buffering=0)
+        self._thread = threading.Thread(
+            target=serve,
+            args=(self._server_stdin, self._server_stdout, self._cache),
+            daemon=True,
+        )
+        self._thread.start()
+        return client_stdin, client_stdout
+
+    def _close(self):
+        # Closing client's stdin signals EOF on server's stdin -> serve() returns.
+        for s in (self._stdin, self._stdout):
+            try:
+                if s is not None:
+                    s.close()
+            except Exception:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+        for s in (self._server_stdin, self._server_stdout):
+            try:
+                if s is not None:
+                    s.close()
+            except Exception:
+                pass
+        self._server_stdin = None
+        self._server_stdout = None
+
+
+def _make_remote(cache):
+    """Return an :class:`SshCache` whose connection is an in-process pipe."""
+    sc = SshCache(host="test-host")
+    object.__setattr__(sc, "_conn", _PipeConnection(cache))
+    return sc
+
+
+@pytest.fixture
+def server_cache():
+    return Cache(ValueMemory({}), CallMemory({}))
+
+
+@pytest.fixture
+def remote(server_cache):
+    sc = _make_remote(server_cache)
+    yield sc
+    sc.close()
+
+
+# ---------------------------------------------------------------------------
+# Frame protocol
+# ---------------------------------------------------------------------------
+
+
+def test_frame_round_trip():
+    buf = io.BytesIO()
+    payload = ("hello", {"a": 1, "b": [1, 2, 3]}, None)
+    _write_frame(buf, payload)
+    buf.seek(0)
+    assert _read_frame(buf) == payload
+
+
+def test_frame_eof_raises():
+    with pytest.raises(EOFError):
+        _read_frame(io.BytesIO())
+
+
+def test_frame_truncated_raises():
+    buf = io.BytesIO()
+    _write_frame(buf, ("x" * 100,))
+    buf.truncate(8)  # half a header + nothing
+    buf.seek(0)
+    with pytest.raises(EOFError):
+        _read_frame(buf)
+
+
+# ---------------------------------------------------------------------------
+# BaseCache surface
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load(remote, server_cache):
+    c = Call(name="f", arguments={"x": 1}, result=42)
+    key = remote.save(c)
+    # The remote cache actually holds the data.
+    assert server_cache.contains(key)
+    # The client can load it back through the SSH layer.
+    lc = remote.load(key)
+    assert lc.result == 42
+    assert dict(lc.arguments) == {"x": 1}
+
+
+def test_contains_miss(remote):
+    assert remote.contains("0" * 64) is False
+
+
+def test_load_value(remote):
+    c = Call(name="f", arguments={"x": 7}, result="hello")
+    remote.save(c)
+    # The result digest is content-addressed; load_value pulls bytes back.
+    # We don't know the digest a priori — use query() to discover it.
+    [lc] = list(remote.query(name="f"))
+    assert lc.result == "hello"
+
+
+def test_evict(remote, server_cache):
+    c = Call(name="f", arguments={"x": 1}, result=99)
+    key = remote.save(c)
+    assert server_cache.contains(key)
+    remote.evict(key)
+    assert not server_cache.contains(key)
+
+
+def test_load_missing_raises_keyerror(remote):
+    with pytest.raises(KeyError):
+        remote.load("0" * 64)
+
+
+def test_query_returns_lazy_calls(remote):
+    keys = []
+    for x in range(3):
+        keys.append(remote.save(Call(name="f", arguments={"x": x}, result=x * 2)))
+    results = list(remote.query(name="f"))
+    assert len(results) == 3
+    by_x = {lc.arguments["x"]: lc.result for lc in results}
+    assert by_x == {0: 0, 1: 2, 2: 4}
+
+
+def test_query_lazy_load_value_round_trips(remote):
+    """``LazyCall._cache`` should point at the client, not the server."""
+    remote.save(Call(name="f", arguments={"x": 5}, result="payload"))
+    [lc] = list(remote.query(name="f"))
+    # Accessing result triggers another RPC via the client cache.
+    assert lc.result == "payload"
+
+
+def test_expand_and_shrink(remote):
+    key = remote.save(Call(name="g", arguments={"a": 1}, result=1))
+    expanded = remote.expand(key[:8])
+    assert expanded == key
+    shrunk = remote.shrink(key)
+    assert key.startswith(shrunk)
+
+
+def test_shrink_variadic(remote):
+    """shrink(*keys): single key → Digest, multiple → tuple in order."""
+    k1 = remote.save(Call(name="g", arguments={"a": 1}, result=1))
+    k2 = remote.save(Call(name="g", arguments={"a": 2}, result=2))
+    # Single key returns a scalar Digest.
+    single = remote.shrink(k1)
+    assert isinstance(single, str)
+    assert k1.startswith(single)
+    # Multiple keys return a tuple in input order.
+    many = remote.shrink(k1, k2)
+    assert isinstance(many, tuple)
+    assert len(many) == 2
+    assert k1.startswith(many[0])
+    assert k2.startswith(many[1])
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+def test_keyerror_propagates(remote):
+    # An empty cache has no entries to match a short prefix, so expand
+    # raises KeyError; the exception must travel back across the wire.
+    with pytest.raises(KeyError):
+        remote.expand("deadbeef")
+
+
+def test_rejected_propagates():
+    """A server-side ``Rejected`` arrives at the client as ``Rejected``."""
+    server = Cache(ValueMemory({}), CallMemory({})).readonly()
+    sc = _make_remote(server)
+    try:
+        with pytest.raises(Rejected):
+            sc.save(Call(name="f", arguments={}, result=1))
+    finally:
+        sc.close()
+
+
+def test_read_only_short_circuits_save_and_evict():
+    """`save`/`evict` against a read-only remote raise locally, no RPC."""
+    server = Cache(ValueMemory({}), CallMemory({})).readonly()
+    sc = _make_remote(server)
+    try:
+        # Trigger the info fetch once so the read_only flag is cached.
+        assert sc.read_only is True
+
+        # Now spy on the connection: any further RPC means we failed to
+        # short-circuit.  `save` and `evict` should raise without
+        # touching the wire.
+        rpc_calls = []
+        original_call = sc._conn.call
+
+        def spy(method, *args, **kwargs):
+            rpc_calls.append(method)
+            return original_call(method, *args, **kwargs)
+
+        sc._conn.call = spy  # type: ignore[method-assign]
+
+        with pytest.raises(Rejected):
+            sc.save(Call(name="f", arguments={}, result=1))
+        with pytest.raises(Rejected):
+            sc.evict("deadbeef")
+        assert rpc_calls == [], f"unexpected RPCs: {rpc_calls}"
+    finally:
+        sc.close()
+
+
+def test_read_only_false_for_writable_remote(remote):
+    """A normal remote cache reports `read_only == False`."""
+    assert remote.read_only is False
+
+
+def test_reconnect_invalidates_info_cache(remote, server_cache):
+    """`reconnect()` drops the cached info so the next read re-fetches."""
+    info1 = remote.info()
+    pid1 = info1["pid"]
+    assert remote._info_cache is not None
+    remote.reconnect()
+    assert remote._info_cache is None
+    # First post-reconnect read_only access re-populates the cache.
+    _ = remote.read_only
+    assert remote._info_cache is not None
+    # Same in-process server thread → same pid; the point is the
+    # cache was repopulated, not its content.
+    assert remote._info_cache["pid"] == pid1
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_reopens_subprocess(remote, server_cache):
+    key = remote.save(Call(name="f", arguments={"x": 1}, result=1))
+    remote.reconnect()
+    # After reconnect a new server thread is running against a *fresh* cache
+    # in our test fixture — wait, actually the fixture reuses server_cache,
+    # so the data should still be there.
+    assert remote.contains(key)
+
+
+def test_close_is_idempotent(remote):
+    remote.close()
+    remote.close()
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics on connection drop
+# ---------------------------------------------------------------------------
+
+
+class _DeadConnection(_Connection):
+    """Transport whose 'server' is already EOF — first call raises immediately."""
+
+    def __init__(self, diag: str = ""):
+        super().__init__()
+        self._diag = diag
+
+    def _open(self):
+        # Write side has no reader; read side is already at EOF.
+        client_in_r, _server_out_w = os.pipe()
+        os.close(_server_out_w)
+        _server_in_r, client_out_w = os.pipe()
+        os.close(_server_in_r)
+        stdin = os.fdopen(client_out_w, "wb", buffering=0)
+        stdout = os.fdopen(client_in_r, "rb", buffering=0)
+        return stdin, stdout
+
+    def _diagnose(self) -> str:
+        return self._diag
+
+
+def test_connection_drop_includes_diagnose_output():
+    """When the remote dies, the diagnose() string is part of the error."""
+    from fleche.remote import RemoteConnectionError
+
+    conn = _DeadConnection(diag="remote exit code: 127\nmodule: command not found")
+    with pytest.raises(RemoteConnectionError) as excinfo:
+        conn.call("contains", "abc")
+    msg = str(excinfo.value)
+    assert "Remote cache connection lost during 'contains'" in msg
+    assert "SshCache.reconnect()" in msg
+    assert "remote exit code: 127" in msg
+    assert "module: command not found" in msg
+
+
+def test_connection_drop_without_diagnose_keeps_old_message():
+    """Empty _diagnose() (base default) leaves the error message unchanged."""
+    from fleche.remote import RemoteConnectionError
+
+    conn = _DeadConnection(diag="")
+    with pytest.raises(RemoteConnectionError) as excinfo:
+        conn.call("contains", "abc")
+    msg = str(excinfo.value)
+    assert "Remote cache connection lost during 'contains'" in msg
+    assert "SshCache.reconnect()" in msg
+    # No spurious blank lines appended.
+    assert not msg.endswith("\n")
+
+
+def test_info_round_trip(remote, server_cache):
+    """`SshCache.info()` returns the server's self-snapshot."""
+    from fleche.config import cache_to_config
+
+    info = remote.info()
+    assert info["cache"] == cache_to_config(server_cache)
+    assert info["cwd"] == os.getcwd()
+    assert isinstance(info["hostname"], str) and info["hostname"]
+    assert info["python"] == sys.executable
+    assert info["pid"] == os.getpid()
+    # cache_name is None in the test rig (the in-process serve() takes no arg).
+    assert info["cache_name"] is None
+
+
+def test_info_echoes_cache_name():
+    """`serve(..., cache_name=...)` makes the name visible to info()."""
+    import sys as _sys
+
+    server = Cache(ValueMemory({}), CallMemory({}))
+    sc = SshCache(host="test-host")
+
+    class _NamedPipe(_PipeConnection):
+        def _open(self):
+            import os as _os
+
+            server_in_r, client_out_w = _os.pipe()
+            client_in_r, server_out_w = _os.pipe()
+            client_stdin = _os.fdopen(client_out_w, "wb", buffering=0)
+            client_stdout = _os.fdopen(client_in_r, "rb", buffering=0)
+            self._server_stdin = _os.fdopen(server_in_r, "rb", buffering=0)
+            self._server_stdout = _os.fdopen(server_out_w, "wb", buffering=0)
+            self._thread = threading.Thread(
+                target=serve,
+                args=(self._server_stdin, self._server_stdout, self._cache),
+                kwargs={"cache_name": "myname"},
+                daemon=True,
+            )
+            self._thread.start()
+            return client_stdin, client_stdout
+
+    object.__setattr__(sc, "_conn", _NamedPipe(server))
+    try:
+        assert sc.info()["cache_name"] == "myname"
+    finally:
+        sc.close()
+
+
+# ---------------------------------------------------------------------------
+# Info redaction and version handshake
+# ---------------------------------------------------------------------------
+
+
+def test_info_redacts_secret_key():
+    """`secret_key` in the served cache config must not leak via info()."""
+    from fleche.remote import _redact_config
+
+    # Direct test of the redactor — independent of the in-process server.
+    raw = {
+        "values": {"type": "cloudpickle", "root": "/x", "secret_key": ["a" * 64]},
+        "calls": {"type": "cloudpickle", "root": "/y", "secret_key": ["b" * 64]},
+    }
+    redacted = _redact_config(raw)
+    assert redacted["values"]["secret_key"] == "<redacted>"
+    assert redacted["calls"]["secret_key"] == "<redacted>"
+    # Non-sensitive fields pass through.
+    assert redacted["values"]["root"] == "/x"
+
+
+def test_info_redacts_url_password():
+    """URL passwords in non-sqlite SQL configs are masked."""
+    from fleche.remote import _redact_url_password
+
+    assert (
+        _redact_url_password("postgresql://alice:hunter2@db.example.com:5432/x")
+        == "postgresql://alice:***@db.example.com:5432/x"
+    )
+    # No password component → pass through.
+    assert (
+        _redact_url_password("sqlite:///tmp/foo.db")
+        == "sqlite:///tmp/foo.db"
+    )
+    assert (
+        _redact_url_password("postgresql://alice@db.example.com/x")
+        == "postgresql://alice@db.example.com/x"
+    )
+
+
+def test_info_exposes_versions(remote):
+    """info() includes `fleche_version` and `cloudpickle_version`."""
+    info = remote.info()
+    assert "fleche_version" in info
+    assert "cloudpickle_version" in info
+    # Same process, same versions.
+    import cloudpickle as _cp
+    from fleche.remote import _fleche_version
+
+    assert info["fleche_version"] == _fleche_version()
+    assert info["cloudpickle_version"] == _cp.__version__
+
+
+def test_version_skew_logs_warning(remote, caplog):
+    """Mismatched fleche/cloudpickle versions in info trigger a warning."""
+    import logging
+    from fleche.remote import _warn_on_version_skew
+
+    caplog.set_level(logging.WARNING, logger="fleche.remote")
+    _warn_on_version_skew(
+        {"fleche_version": "999.0.0", "cloudpickle_version": "999.0"}
+    )
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("fleche version skew" in m for m in msgs)
+    assert any("cloudpickle version skew" in m for m in msgs)
+
+
+def test_handshake_runs_on_first_op(remote, server_cache):
+    """The first BaseCache method drives the handshake (populates info cache)."""
+    assert remote._info_cache is None
+    remote.contains("deadbeef")  # any op
+    assert remote._info_cache is not None
+    assert "fleche_version" in remote._info_cache
+
+
+def test_forward_stderr_appends_to_buffer():
+    """The stderr forwarder mirrors lines into the diagnostic buffer."""
+    import collections as _c
+    from fleche.remote import _forward_stderr
+
+    buf: _c.deque[str] = _c.deque(maxlen=5)
+    stream = io.BytesIO(b"module: command not found\nbash: line 1: oops\n")
+    _forward_stderr(stream, "test.remote", buf)
+    assert list(buf) == ["module: command not found\n", "bash: line 1: oops\n"]
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+def test_cache_from_config_builds_sshcache():
+    from fleche.config import cache_from_config
+
+    c = cache_from_config(
+        {
+            "type": "ssh",
+            "host": "user@example.com",
+            "cache_name": "shared",
+            "python": "python3.12",
+            "ssh_options": ["-o", "ControlMaster=auto"],
+        }
+    )
+    assert isinstance(c, SshCache)
+    assert c.host == "user@example.com"
+    assert c.cache_name == "shared"
+    assert c.python == "python3.12"
+    assert c.ssh_options == ("-o", "ControlMaster=auto")
+    c.close()
+
+
+def test_cache_to_config_round_trip():
+    from fleche.config import cache_from_config, cache_to_config
+
+    original = {
+        "type": "ssh",
+        "host": "user@example.com",
+        "cache_name": "shared",
+        "ssh_options": ["-o", "ControlMaster=auto"],
+    }
+    c = cache_from_config(original)
+    try:
+        d = cache_to_config(c)
+    finally:
+        c.close()
+    assert d["type"] == "ssh"
+    assert d["host"] == "user@example.com"
+    assert d["cache_name"] == "shared"
+    assert d["ssh_options"] == ["-o", "ControlMaster=auto"]
+
+
+def test_sshcache_default_command_has_no_shell_wrapper():
+    """Without setup_commands, args are passed as a list — no shell parsing."""
+    c = SshCache(host="user@example.com", cache_name="shared")
+    try:
+        cmd = c._conn._build_command()
+    finally:
+        c.close()
+    assert cmd[:2] == ["ssh", "user@example.com"]
+    assert cmd[2:] == ["python3", "-m", "fleche.remote", "--serve", "--cache", "shared"]
+
+
+def test_sshcache_setup_commands_prefixed_with_exec():
+    """setup_commands run via the remote shell and `exec` into the server."""
+    c = SshCache(
+        host="user@example.com",
+        cache_name="shared",
+        setup_commands=("module load python/3.11", "source ~/.venv/bin/activate"),
+    )
+    try:
+        cmd = c._conn._build_command()
+    finally:
+        c.close()
+    assert cmd[:2] == ["ssh", "user@example.com"]
+    assert len(cmd) == 3, f"setup_commands should collapse into one shell arg, got {cmd!r}"
+    remote = cmd[2]
+    assert remote.startswith("module load python/3.11 && source ~/.venv/bin/activate && exec ")
+    # The server invocation is shell-quoted so paths with spaces survive.
+    assert "python3 -m fleche.remote --serve --cache shared" in remote
+
+
+def test_sshcache_setup_commands_config_round_trip():
+    from fleche.config import cache_from_config, cache_to_config
+
+    original = {
+        "type": "ssh",
+        "host": "user@example.com",
+        "setup_commands": ["module load python/3.11", "source ~/.venv/bin/activate"],
+    }
+    c = cache_from_config(original)
+    try:
+        assert c.setup_commands == (
+            "module load python/3.11",
+            "source ~/.venv/bin/activate",
+        )
+        d = cache_to_config(c)
+    finally:
+        c.close()
+    assert d["setup_commands"] == [
+        "module load python/3.11",
+        "source ~/.venv/bin/activate",
+    ]
+
+
+def test_sshcache_setup_commands_omitted_from_config_when_empty():
+    from fleche.config import cache_to_config
+
+    c = SshCache(host="user@example.com")
+    try:
+        d = cache_to_config(c)
+    finally:
+        c.close()
+    assert "setup_commands" not in d
+
+
+def test_cache_stack_with_ssh_layer():
+    """A stack of [local, ssh] composes via the existing array-of-tables path."""
+    from fleche.config import cache_from_config
+    from fleche.caches import CacheStack
+
+    c = cache_from_config(
+        [
+            {"values": {"type": "memory"}, "calls": {"type": "memory"}},
+            {"type": "ssh", "host": "user@example.com"},
+        ]
+    )
+    assert isinstance(c, CacheStack)
+    assert isinstance(c.stack[1], SshCache)
+    c.stack[1].close()


### PR DESCRIPTION
## Summary

Adds SshCache(BaseCache) — a cache that forwards every operation to a remote python -m fleche.remote --serve process over a single persistent SSH subprocess. The remote loads its own fleche.toml and proxies into whichever cache it has configured, so the remote side keeps full freedom of backend (file / SQL / HDF5 / stack). Compose it with a local layer via the existing CacheStack machinery for read-through sharing across machines.

## Usage

```
[default]
cache = "shared"

[[shared]]                          # local layer (saves go here)
values.type = "cloudpickle"
values.root = "~/.fleche/values"
calls.type = "sql"
calls.url = "sqlite:///~/.fleche/calls.db"

[[shared]]                          # remote layer (read-through)
type = "ssh"
host = "user@bigpc.example.com"
cache_name = "shared"               # optional: named cache on remote
python = "python3"                  # optional
ssh_options = ["-o", "ControlMaster=auto",
               "-o", "ControlPath=~/.ssh/cm-%r@%h:%p",
               "-o", "ControlPersist=10m"]
setup_commands = ["module load python/3.11",
                  "source ~/.venv/bin/activate"]   # optional
```

Reads check the local layer first, fall through to the SSH layer, and back-fill hits into local — all through CacheStack, no special-casing. Requires pip install fleche[ssh] (cloudpickle is the wire format, not optional for this feature).
## How it works

    Wire protocol. 4-byte big-endian length prefix + cloudpickle payload. Requests are (method, args, kwargs); responses are ("ok", value) / ("err", exception), so server-side exceptions (KeyError, Rejected, …) re-raise on the client with their real type. An exception that can't be cloudpickled is downgraded to a RuntimeError carrying the traceback.
    One method = one round-trip, serialised behind a per-connection lock. query materialises the server-side generator into a tuple before sending. Each returned DigestedCall is re-bound to the client SshCache as a LazyCall, so values round-trip lazily on first .result access. shrink follows the variadic BaseCache contract (single key → Digest, multiple → tuple).
    Same module is client and server. python -m fleche.remote --serve [--cache NAME] runs the request loop against the active cache; --cache NAME is installed as the active cache (ContextVar), not just loaded, so metadata hooks / nested @fleche() calls on the remote see the same cache.

## Lifecycle & operability

    Subprocess spawned lazily on first op, reused for the process lifetime, closed at atexit. Never auto-reconnects (would silently re-trigger interactive 2FA); reconnect() forces a fresh spawn. ControlMaster + ControlPersist share one authentication across runs.
    setup_commands run pre-launch in the remote shell, &&-joined and exec-ed into the server so the pipe stays unwrapped; a setup failure surfaces via captured stderr.
    Remote stderr is drained by a daemon thread into the per-host fleche.remote.host.<host> logger and a 50-line ring buffer; on connection drop the buffer + exit code are surfaced in RemoteConnectionError, which also names reconnect() directly.

## Security model

The wire format is cloudpickle in both directions, so a hostile endpoint can execute code on the other — the trust boundary is exactly ssh user@host. Don't point SshCache at a host you wouldn't ssh into, and don't expose --serve on any transport other than the spawned ssh stdin/stdout (the RPC stream itself is unauthenticated). The info RPC redacts credentials (secret_key, URL passwords) before they go on the wire, since the client's DEBUG tracing logs full payloads.
Diagnostics

    info() reports the served cache config (credentials redacted), cache_name, read_only, fleche_version, cloudpickle_version, cwd, hostname, python, pid — one round-trip to answer "the remote isn't doing what I expected."
    First op runs a version handshake that warns on fleche / cloudpickle skew.
    read_only short-circuits save/evict locally to avoid a pointless round-trip.
    Every RPC is logged at DEBUG (rpc → … / rpc ← …) on the fleche.remote logger.

## Config integration

Single type = "ssh" clause in cache_from_config / cache_to_config; the array-of-tables form already gives stack composition. New [ssh] extra pulls in cloudpickle.
Testing

    Unit ([tests/unit/test_remote.py](https://github.com/pmrv/fleche/blob/claude/affectionate-pasteur-fYOy1/tests/unit/test_remote.py)): in-process os.pipe() transport runs serve() in a daemon thread — full wire protocol, dispatch, exception propagation, lifecycle, info redaction, version handshake, read-only short-circuit, variadic shrink, connection-drop diagnostics. No SSH or subprocess.
    Integration ([tests/integration/test_remote.py](https://github.com/pmrv/fleche/blob/claude/affectionate-pasteur-fYOy1/tests/integration/test_remote.py)): real python -m fleche.remote --serve subprocess (still no SSH) — cross-process round-trips, --cache NAME selection.

## Commits

    fix(types): resolve latent ty 0.0.40 errors surfaced by this branch — two pre-existing main type errors that the path-gated ty job let through on dependabot bumps (see #587); this branch is the first to touch src/ under ty 0.0.40.
    feat(remote): SshCache for sharing fleche caches across machines
    docs(remote): SshCache usage and internals

## Known limitations / follow-ups

    query() materialises the full result set on both ends — no streaming/cursor; large remote caches pay it all up front.
    Dropped SshCache instances aren't closed on GC (atexit holds a ref); call close() explicitly for caches you won't reuse.
    info() / read_only cost one RPC on first access (cached after; reconnect() invalidates).
    The per-connection lock serialises a slow query() ahead of other threads' RPCs.
    _strip_cache reaches into LazyCall internals → tracked in #588 (promote to a public LazyCall.to_digested_call()).