### PR TITLE
ci(claude): use Anthropic Claude App token, drop PAT

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -23,13 +23,9 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     steps:
-      - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.PAT_TOKEN }}
           claude_args: |
             --model claude-sonnet-4-6
             --allowedTools "Bash(git *) Bash(python *)" "Bash(pip install *)" "Bash(pytest *)" "Bash(gh *)" "mcp__github__*"


### PR DESCRIPTION
## Summary
- Drop `github_token: ${{ secrets.PAT_TOKEN }}` and the standalone `actions/checkout` step from the Claude workflow.
- `anthropics/claude-code-action@v1` will now mint and use the Anthropic Claude GitHub App's installation token itself (and revoke it after the run).
- Commits and comments are authored as `claude[bot]` (the action's default `bot_name`), and downstream workflows trigger normally — no PAT required.

## Test plan
- [ ] Comment `@claude ping` on an issue/PR and confirm the action runs, posts as `claude[bot]`, and that any push it does triggers CI.
- [ ] After verification, delete the `PAT_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)