### PR TITLE
ci(claude): drop PAT from CI failure summarizer

### DIFF
--- a/.github/workflows/claude_ci_details.yaml
+++ b/.github/workflows/claude_ci_details.yaml
@@ -24,7 +24,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GH_PAT }}
           claude_args: |
             --model claude-haiku-4-5
             --allowedTools "Bash(gh run view:*),Bash(gh run download:*),Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue create:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(wc:*),Bash(ls:*)"


### PR DESCRIPTION
## Summary
- Remove `github_token: ${{ secrets.GH_PAT }}` from the CI failure summary workflow.
- `anthropics/claude-code-action@v1` will mint and use the Anthropic Claude App's installation token instead — same pattern as #555.

## Test plan
- [ ] Wait for a Tests/ty workflow failure (or trigger one) and confirm the summary still gets posted as `claude[bot]` on the relevant PR/issue.
- [ ] After confirming both Claude workflows work without it, delete the `GH_PAT` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)