### PR TITLE
ci(claude): restore actions/checkout step

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -23,6 +23,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     steps:
+      - uses: actions/checkout@v6
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Restore the `actions/checkout@v6` step removed in #555.
- The action doesn't clone the repo itself — runs failed with `fatal: not a git repository` when trying to create the `claude/issue-*` branch.
- No `token:` on checkout: default `GITHUB_TOKEN` reads the repo; the action still mints its Anthropic Claude App token via OIDC for pushes (visible in the failing run: "Using GITHUB_TOKEN from OIDC").

## Test plan
- [ ] `@claude` mention on an issue/PR — confirm checkout succeeds and the new `claude/issue-*` branch gets created and pushed as `claude[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)