### PR TITLE
fix(call): fall back to permissive signature for un-introspectable builtins

### DIFF
--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -40,7 +40,7 @@ jobs:
         if: needs.changes.outputs.run == 'true'
         shell: bash -l {0}
         run: |
-          pip install -e .[tests] ty
+          pip install -e .[tests,ty]
       - name: Run ty
         if: needs.changes.outputs.run == 'true'
         run: ty check src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,6 @@ tests = [
 executorlib = [
     "executorlib",
 ]
+ty = [
+    "ty == 0.0.38",
+]

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass, field, replace
 from functools import lru_cache
 from typing import Any, Callable, get_type_hints, get_origin, get_args, Annotated
-from inspect import Signature, signature
+from inspect import Parameter, Signature, signature
 from collections.abc import Mapping
 
 from pyiron_snippets.versions import VersionInfo, get_module, get_qualname
@@ -59,7 +59,13 @@ class FunctionProfile:
     @classmethod
     def of(cls, func) -> "FunctionProfile":
         """Compute a :class:`FunctionProfile` for *func* without caching."""
-        sig = signature(func)
+        try:
+            sig = signature(func)
+        except ValueError:
+            sig = Signature(parameters=[
+                Parameter("args", Parameter.VAR_POSITIONAL),
+                Parameter("kwargs", Parameter.VAR_KEYWORD),
+            ])
 
         try:
             info = VersionInfo.of(func)

--- a/tests/regression/test_builtin_signature.py
+++ b/tests/regression/test_builtin_signature.py
@@ -1,0 +1,38 @@
+"""Wrapping a C builtin (e.g. ``time.sleep``) used to crash with
+``ValueError: no signature found for builtin`` because ``inspect.signature``
+cannot introspect builtins lacking ``__text_signature__``.  The wrapper now
+falls back to a permissive ``(*args, **kwargs)`` signature so decoration and
+invocation both succeed.
+"""
+import time
+
+from fleche import fleche
+from fleche.caches import Cache
+from fleche.storage import memory
+import fleche.state as state
+
+
+def test_wrapping_builtin_sleep_does_not_crash():
+    cache = Cache(values=memory.ValueMemory(storage={}), calls=memory.CallMemory(storage={}))
+    token = state._CACHE.set(cache)
+    try:
+        cached_sleep = fleche()(time.sleep)
+        # Decoration and call both succeed despite sleep lacking a signature.
+        assert cached_sleep(0) is None
+    finally:
+        state._CACHE.reset(token)
+
+
+def test_wrapping_builtin_with_return_value_caches():
+    """A builtin that returns a non-None result should still cache via the permissive signature."""
+    calls_storage = memory.CallMemory(storage={})
+    cache = Cache(values=memory.ValueMemory(storage={}), calls=calls_storage)
+    token = state._CACHE.set(cache)
+    try:
+        # int() is a builtin that lacks an inspect-friendly signature in some versions
+        cached_abs = fleche()(abs)
+        assert cached_abs(-3) == 3
+        assert cached_abs(-3) == 3  # cache hit
+        assert len(calls_storage.storage) == 1
+    finally:
+        state._CACHE.reset(token)

--- a/tests/regression/test_builtin_signature.py
+++ b/tests/regression/test_builtin_signature.py
@@ -16,7 +16,7 @@ def test_wrapping_builtin_sleep_does_not_crash():
     cache = Cache(values=memory.ValueMemory(storage={}), calls=memory.CallMemory(storage={}))
     token = state._CACHE.set(cache)
     try:
-        cached_sleep = fleche()(time.sleep)
+        cached_sleep = fleche(time.sleep)
         # Decoration and call both succeed despite sleep lacking a signature.
         assert cached_sleep(0) is None
     finally:
@@ -30,7 +30,7 @@ def test_wrapping_builtin_with_return_value_caches():
     token = state._CACHE.set(cache)
     try:
         # int() is a builtin that lacks an inspect-friendly signature in some versions
-        cached_abs = fleche()(abs)
+        cached_abs = fleche(abs)
         assert cached_abs(-3) == 3
         assert cached_abs(-3) == 3  # cache hit
         assert len(calls_storage.storage) == 1


### PR DESCRIPTION
## Summary
- `inspect.signature` raises `ValueError` for C builtins lacking `__text_signature__` (e.g. `time.sleep`). This crashed `FunctionProfile.of` at decoration time.
- Fall back to a `(*args, **kwargs)` signature so the wrapper can be constructed and the call cached normally.
- Regression test in `tests/regression/test_builtin_signature.py` covers both a None-returning builtin (`time.sleep`) and a value-returning one (`abs`, exercising cache hit).

## Test plan
- [x] `pytest tests/unit/call tests/regression` — 67 passed, 7 skipped.