### PR TITLE
ci(ty): pin ty to 0.0.38 so dependabot tracks the upgrade

### DIFF
--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -40,7 +40,7 @@ jobs:
         if: needs.changes.outputs.run == 'true'
         shell: bash -l {0}
         run: |
-          pip install -e .[tests] ty
+          pip install -e .[tests,ty]
       - name: Run ty
         if: needs.changes.outputs.run == 'true'
         run: ty check src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,6 @@ tests = [
 executorlib = [
     "executorlib",
 ]
+ty = [
+    "ty == 0.0.38",
+]


### PR DESCRIPTION
## Summary
- ty 0.0.39 newly flags the \`**kwargs\` splat in \`src/fleche/storage/bagofholding_file.py:45\`, breaking the \`ty\` check on every open PR.
- Add a \`ty\` optional extra in \`pyproject.toml\` pinned to \`==0.0.38\` and switch the workflow to \`pip install -e .[tests,ty]\` so dependabot proposes the bump (where the call-site fix can land alongside it).

## Test plan
- [ ] \`ty\` job on this PR uses 0.0.38 and passes.