### PR TITLE
docs: fix undefined file_cache references in parallel_execution examples

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -189,6 +189,9 @@ processes, the same rules as ``ProcessPoolExecutor`` apply:
 
 .. code-block:: python
 
+   # file_cache and heavy_computation as set up in the ProcessPoolExecutor example above
+   import fleche
+   from fleche import BoundWrapper
    from executorlib import SingleNodeExecutor
 
    with fleche.cache(file_cache):
@@ -252,27 +255,35 @@ automatically:
 
 .. code-block:: python
 
-   import concurrent.futures
+   import concurrent.futures, tempfile, os
    import fleche
+   from fleche.caches import Cache
+   from fleche.storage.pickle_file import ValuePickleFile, CallPickleFile
 
    @fleche.fleche
    def heavy_computation(x):
        return x ** 3
 
-   with fleche.cache(file_cache):
-       with concurrent.futures.ProcessPoolExecutor() as executor:
-           fleche.wrap_executor(executor)             # patch once
+   with tempfile.TemporaryDirectory() as tmpdir:
+       file_cache = Cache(
+           ValuePickleFile.with_pickle(root=os.path.join(tmpdir, "values")),
+           CallPickleFile.with_pickle(root=os.path.join(tmpdir, "calls")),
+       )
 
-           # Submit exactly as you would a plain function.
-           futures = [executor.submit(heavy_computation, i) for i in range(8)]
-           results = [f.result() for f in futures]
+       with fleche.cache(file_cache):
+           with concurrent.futures.ProcessPoolExecutor() as executor:
+               fleche.wrap_executor(executor)             # patch once
 
-       # A second round with the same inputs never enters the worker pool:
-       with concurrent.futures.ProcessPoolExecutor() as executor:
-           fleche.wrap_executor(executor)
-           fut = executor.submit(heavy_computation, 3)
-           assert fut.done()                          # already-completed future
-           assert fut.result() == 27
+               # Submit exactly as you would a plain function.
+               futures = [executor.submit(heavy_computation, i) for i in range(8)]
+               results = [f.result() for f in futures]
+
+           # A second round with the same inputs never enters the worker pool:
+           with concurrent.futures.ProcessPoolExecutor() as executor:
+               fleche.wrap_executor(executor)
+               fut = executor.submit(heavy_computation, 3)
+               assert fut.done()                          # already-completed future
+               assert fut.result() == 27
 
 Executor-specific keyword arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -287,6 +298,7 @@ payload:
 
 .. code-block:: python
 
+   # file_cache and heavy_computation as set up in the wrap_executor example above
    from executorlib import SingleNodeExecutor
 
    with fleche.cache(file_cache):


### PR DESCRIPTION
## Summary

Three code blocks in `docs/parallel_execution.rst` referenced `file_cache` and `heavy_computation` without ever defining them, making those examples non-runnable as standalone snippets.

- Made the main `wrap_executor` code block self-contained: added full imports (`concurrent.futures`, `tempfile`, `os`, `fleche`, `Cache`, `ValuePickleFile`, `CallPickleFile`) and a `TemporaryDirectory`-based `file_cache` definition.
- Added a context comment to the `executorlib` subsection (`# file_cache and heavy_computation as set up in the ProcessPoolExecutor example above`) and restored missing `import fleche` / `from fleche import BoundWrapper` lines that were implicitly expected.
- Added a context comment to the "Executor-specific keyword arguments" subsection so readers know which earlier example the snippet builds on.

## Test plan

- [ ] Read through `docs/parallel_execution.rst` and verify all three affected code blocks are now either self-contained or clearly reference a prior example.
- [ ] Run the main `wrap_executor` example verbatim in a Python interpreter to confirm it executes without `NameError`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8o1XYeaiNr99SSGwE3GYB)_