### PR TITLE
feat(query): add QueryIterator.transfer for replaying matches into a target cache

### DIFF
--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -1,12 +1,15 @@
 import builtins
 import datetime
 import itertools
+import logging
 from dataclasses import dataclass
 from typing import Iterable, Iterator, Any, Literal, Callable
 
 import pandas as pd
 
 from . import call
+
+logger = logging.getLogger("fleche.query")
 
 
 def _resolve_key(key: "str | Callable[[call.LazyCall], Any]") -> "Callable[[call.LazyCall], Any]":
@@ -179,9 +182,14 @@ class QueryIterator(Iterable[call.LazyCall]):
         for c in self:
             key = c.to_lookup_key()
             conflict = not overwrite and target.contains(key)
-            if not conflict:
-                target.save(c.fetch())
-            if pop and not conflict:
+            if conflict:
+                logger.warning(
+                    "Not transferring %s: already exists in target and overwrite=False",
+                    key,
+                )
+                continue
+            target.save(c.fetch())
+            if pop:
                 c._cache.evict(key)
 
     def table(self, arguments: Iterable[str] | str | Literal[True] = (), results=False) -> pd.DataFrame:

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -183,9 +183,13 @@ class QueryIterator(Iterable[call.LazyCall]):
             key = c.to_lookup_key()
             conflict = not overwrite and target.contains(key)
             if conflict:
+                try:
+                    short = target.shrink(key)
+                except KeyError:
+                    short = key
                 logger.warning(
                     "Not transferring %s: already exists in target and overwrite=False",
-                    key,
+                    short,
                 )
                 continue
             target.save(c.fetch())

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -167,6 +167,23 @@ class QueryIterator(Iterable[call.LazyCall]):
         for c in self:
             c._cache.evict(c.to_lookup_key())
 
+    def transfer(self, target, pop: bool = False, overwrite: bool = False) -> None:
+        """Replay matching calls into the target cache.
+
+        Args:
+            target: destination :class:`~fleche.caches.BaseCache`.
+            pop: if True, evict transferred calls from the source cache.
+            overwrite: if True, overwrite entries already present in the target.
+                If False (default), conflicts are skipped.
+        """
+        for c in self:
+            key = c.to_lookup_key()
+            conflict = not overwrite and target.contains(key)
+            if not conflict:
+                target.save(c.fetch())
+            if pop and not conflict:
+                c._cache.evict(key)
+
     def table(self, arguments: Iterable[str] | str | Literal[True] = (), results=False) -> pd.DataFrame:
         """Return a pandas DataFrame summarizing queried calls.
 

--- a/src/fleche/query.py
+++ b/src/fleche/query.py
@@ -183,13 +183,9 @@ class QueryIterator(Iterable[call.LazyCall]):
             key = c.to_lookup_key()
             conflict = not overwrite and target.contains(key)
             if conflict:
-                try:
-                    short = target.shrink(key)
-                except KeyError:
-                    short = key
                 logger.warning(
                     "Not transferring %s: already exists in target and overwrite=False",
-                    short,
+                    target.shrink(key),
                 )
                 continue
             target.save(c.fetch())

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -621,3 +621,89 @@ def test_evict_only_removes_matched(test_cache):
     test_cache.query(tpl_f).evict()
     assert test_cache.query(tpl_f).count() == 0
     assert test_cache.query(tpl_g).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# .transfer()
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def other_cache():
+    return Cache(values=ValueMemory({}), calls=CallMemory({}))
+
+
+def test_transfer_copies_matched_calls(test_cache, other_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    test_cache.save(Call(name="g", arguments={"x": 3}, result=30))
+
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl).transfer(other_cache)
+
+    assert other_cache.query(tpl).count() == 2
+    # Non-matching call not copied
+    tpl_g = QueryCall(name="g", arguments=None, metadata=None, module=None, version=None, result=None)
+    assert other_cache.query(tpl_g).count() == 0
+    # Source untouched
+    assert test_cache.query(tpl).count() == 2
+
+
+def test_transfer_pop_evicts_source(test_cache, other_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl).transfer(other_cache, pop=True)
+
+    assert test_cache.query(tpl).count() == 0
+    assert other_cache.query(tpl).count() == 2
+
+
+def test_transfer_skips_existing_by_default(test_cache, other_cache):
+    c = Call(name="f", arguments={"x": 1}, result=10)
+    test_cache.save(c)
+    # Pre-populate target with the same key but a different stored result
+    other_cache.calls.save(Call(name="f", arguments={"x": 1}, result=999).stash(other_cache.values))
+
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl).transfer(other_cache)
+
+    # Target value not overwritten
+    assert other_cache.load(c.to_lookup_key()).result == 999
+
+
+def test_transfer_overwrite_replaces_existing(test_cache, other_cache):
+    c = Call(name="f", arguments={"x": 1}, result=10)
+    test_cache.save(c)
+    other_cache.calls.save(Call(name="f", arguments={"x": 1}, result=999).stash(other_cache.values))
+
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl).transfer(other_cache, overwrite=True)
+
+    assert other_cache.load(c.to_lookup_key()).result == 10
+
+
+def test_transfer_pop_skips_conflicts(test_cache, other_cache):
+    c = Call(name="f", arguments={"x": 1}, result=10)
+    test_cache.save(c)
+    other_cache.calls.save(Call(name="f", arguments={"x": 1}, result=999).stash(other_cache.values))
+
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl).transfer(other_cache, pop=True)
+
+    # Conflicting call left in source, target untouched
+    assert test_cache.query(tpl).count() == 1
+    assert other_cache.load(c.to_lookup_key()).result == 999
+
+
+def test_transfer_respects_filter(test_cache, other_cache):
+    test_cache.save(Call(name="f", arguments={"x": 1}, result=10))
+    test_cache.save(Call(name="f", arguments={"x": 2}, result=20))
+    test_cache.save(Call(name="f", arguments={"x": 3}, result=30))
+
+    tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
+    test_cache.query(tpl).filter(lambda c: c.arguments["x"] > 1).transfer(other_cache)
+
+    xs = sorted(c.arguments["x"] for c in other_cache.query(tpl))
+    assert xs == [2, 3]

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -672,8 +672,13 @@ def test_transfer_skips_existing_by_default(test_cache, other_cache, caplog):
 
     # Target value not overwritten
     assert other_cache.load(c.to_lookup_key()).result == 999
-    # Conflict is announced
-    assert any("already exists in target" in rec.message for rec in caplog.records)
+    # Exactly one warning, naming the shrunk key and the overwrite=False reason
+    warnings = [r for r in caplog.records if r.name == "fleche.query"]
+    assert len(warnings) == 1
+    short = other_cache.shrink(c.to_lookup_key())
+    assert warnings[0].getMessage() == (
+        f"Not transferring {short}: already exists in target and overwrite=False"
+    )
 
 
 def test_transfer_overwrite_replaces_existing(test_cache, other_cache):

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -660,17 +660,20 @@ def test_transfer_pop_evicts_source(test_cache, other_cache):
     assert other_cache.query(tpl).count() == 2
 
 
-def test_transfer_skips_existing_by_default(test_cache, other_cache):
+def test_transfer_skips_existing_by_default(test_cache, other_cache, caplog):
     c = Call(name="f", arguments={"x": 1}, result=10)
     test_cache.save(c)
     # Pre-populate target with the same key but a different stored result
     other_cache.calls.save(Call(name="f", arguments={"x": 1}, result=999).stash(other_cache.values))
 
     tpl = QueryCall(name="f", arguments=None, metadata=None, module=None, version=None, result=None)
-    test_cache.query(tpl).transfer(other_cache)
+    with caplog.at_level("WARNING", logger="fleche.query"):
+        test_cache.query(tpl).transfer(other_cache)
 
     # Target value not overwritten
     assert other_cache.load(c.to_lookup_key()).result == 999
+    # Conflict is announced
+    assert any("already exists in target" in rec.message for rec in caplog.records)
 
 
 def test_transfer_overwrite_replaces_existing(test_cache, other_cache):


### PR DESCRIPTION
## Summary

`QueryIterator.transfer(target, pop=False, overwrite=False)` replays the iterator's matching calls into a target cache. Mirrors `BaseCache.transfer` semantics but operates on the already-filtered subset, so callers can chain `.filter() / .skip() / .take() / .unique() / ...` before transferring.

```python
source.query(name="my_func").filter(lambda c: c.arguments["x"] > 10).transfer(target)
```

- `overwrite=False` (default) skips keys that already exist in the target.
- `pop=True` evicts transferred calls from their source cache (skipped on conflict, with the same rule as `BaseCache.transfer`).

## Test plan

- [x] `pytest tests/unit/fleche/test_query_iterator.py` — 63 passed (6 new)
- [x] `pytest tests/unit/caches/ tests/unit/fleche/` — 243 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01QhnBfrUJCM8DPLw6EjVVjm)_