### PR TITLE
refactor(caches): dispatch Cache.shrink by which sub-storage owns the key

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -274,13 +274,11 @@ class Cache(BaseCache):
         return _combine_expand(key, results)
 
     def shrink(self, key: Digest | str) -> Digest:
-        results = []
-        for sub in (self.calls, self.values):
-            try:
-                results.append(sub.shrink(key))
-            except KeyError:
-                pass
-        return _combine_shrink(key, results)
+        if self.calls.contains(key):
+            return self.calls.shrink(key)
+        if self.values.contains(key):
+            return self.values.shrink(key)
+        raise KeyError(key)
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         """Query for cached calls that match a template and return decoded results.

--- a/tests/unit/caches/test_expand_shrink.py
+++ b/tests/unit/caches/test_expand_shrink.py
@@ -58,16 +58,44 @@ def test_cache_shrink_unknown_key_raises_keyerror():
         cache.shrink("a" * 64)
 
 
-def test_cache_shrink_returns_longest_of_two_storages():
-    """When calls and values disagree on how short they can go, the Cache
-    must return the longer (safer) prefix so it remains unambiguous in both."""
+def test_cache_shrink_dispatches_to_call_storage_when_key_is_a_call():
+    """A key that exists in ``calls`` is shrunk against the call keyspace only."""
     calls = Mock()
     values = Mock()
+    calls.contains.return_value = True
     calls.shrink.return_value = Digest("abcd")
-    values.shrink.return_value = Digest("abcdef")
     cache = Cache(values, calls)
 
-    assert cache.shrink("a" * 64) == "abcdef"
+    assert cache.shrink("a" * 64) == "abcd"
+    values.contains.assert_not_called()
+    values.shrink.assert_not_called()
+
+
+def test_cache_shrink_dispatches_to_value_storage_when_key_is_a_value():
+    """A key that exists only in ``values`` is shrunk against the value keyspace."""
+    calls = Mock()
+    values = Mock()
+    calls.contains.return_value = False
+    values.contains.return_value = True
+    values.shrink.return_value = Digest("beef")
+    cache = Cache(values, calls)
+
+    assert cache.shrink("b" * 64) == "beef"
+    calls.shrink.assert_not_called()
+
+
+def test_cache_shrink_missing_key_raises_keyerror():
+    """If neither storage contains the key, ``shrink`` raises ``KeyError``."""
+    calls = Mock()
+    values = Mock()
+    calls.contains.return_value = False
+    values.contains.return_value = False
+    cache = Cache(values, calls)
+
+    with pytest.raises(KeyError):
+        cache.shrink("c" * 64)
+    calls.shrink.assert_not_called()
+    values.shrink.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `Cache.shrink` now dispatches based on which sub-storage owns the key: if `calls.contains(key)`, return `calls.shrink(key)`; else if `values.contains(key)`, return `values.shrink(key)`; else `KeyError`.
- Replaces the previous "shrink against both, take the longer (safer) prefix" combine logic.

## Rationale

Call keys and value keys are disjoint by construction — call keys digest `(name, args, module, version, code_digest)` while value keys digest the values themselves.  The previous combine logic produced prefixes unambiguous across the union of both keyspaces, which is only useful for an interactive "eyeball a digest and pick an API at random" workflow; every actual caller (`cache.load`, `cache.load_value`, `QueryIterator.table`, `QueryIterator.transfer`) already knows which keyspace its short prefix will be resolved against.

Trade-off: one extra `contains` check per `shrink` call.  Win: skips a full `list()` scan of the other sub-storage, which on filesystem/SQL backends is the dominant cost.

## Test plan

- [x] Replaced `test_cache_shrink_returns_longest_of_two_storages` with three new tests pinning the dispatch behaviour (call-key path, value-key path, missing-key `KeyError`).
- [x] Full unit + regression suite: 899 passed, 7 skipped.

#574 will be rebased on top of this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM8QGrdsiMAmLdY5Zrrw8s)_