### PR TITLE
Add workdir option to SshCache

### DIFF
--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -275,12 +275,12 @@ the persist window skip the handshake entirely.  Wire it up either in
 Setup-commands chain
 ~~~~~~~~~~~~~~~~~~~~
 
-When the user passes ``setup_commands``, the constructed remote command
-looks like:
+When the user passes ``workdir`` and/or ``setup_commands``, the
+constructed remote command looks like:
 
 .. code-block:: text
 
-   <snippet1> && <snippet2> && ... && exec <python> -m fleche.remote --serve
+   cd <workdir> && <snippet1> && <snippet2> && ... && exec <python> -m fleche.remote --serve
 
 The trailing ``exec`` replaces the wrapping shell so stdin/stdout pipe
 straight through to the server process — no extra layer to corrupt the
@@ -288,9 +288,15 @@ binary RPC stream.  Any setup failure short-circuits via ``&&`` and the
 ssh process exits non-zero; the client's next read raises ``EOFError``
 and the diagnostic captured from stderr surfaces the actual reason.
 
-Without ``setup_commands``, the server argv is passed directly to
-``ssh`` as separate arguments, so SSH ``exec``\\ s it as-is — no remote
-shell is involved at all.
+``workdir`` (when set) contributes the leading ``cd`` so it runs ahead
+of the user's ``setup_commands``.  Because the server boots the cache
+via ``python -m``, that working directory lands on ``sys.path``, letting
+the remote import the project-local modules referenced by unpickled
+calls.
+
+Without ``workdir`` or ``setup_commands``, the server argv is passed
+directly to ``ssh`` as separate arguments, so SSH ``exec``\\ s it as-is
+— no remote shell is involved at all.
 
 Diagnostics: the ``info`` RPC
 -----------------------------

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -134,6 +134,9 @@ Example fleche.toml
                    "-o", "ControlPersist=10m"]
     setup_commands = ["module load python/3.11",  # optional: shell snippets
                       "source ~/.venv/bin/activate"]  # run before the server
+    workdir = "~/project"               # optional: cd here before launching
+                                        # the server, so the remote can import
+                                        # the project's local modules
 
 Config file discovery
 ---------------------
@@ -492,6 +495,8 @@ def cache_to_config(c: caches.BaseCache) -> "dict[str, Any] | list[dict[str, Any
                     d["ssh_options"] = list(c.ssh_options)
                 if c.setup_commands:
                     d["setup_commands"] = list(c.setup_commands)
+                if c.workdir is not None:
+                    d["workdir"] = c.workdir
                 return d
             raise ValueError(f"Cannot convert cache of type {type(c).__name__!r} to config")
 

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -28,6 +28,7 @@ second, composed automatically into a :class:`~fleche.caches.CacheStack`::
                    "-o", "ControlPersist=10m"]
     setup_commands = ["module load python/3.11",
                       "source ~/.venv/bin/activate"]    # optional
+    workdir = "~/project"               # optional: cd before launching server
 
 ControlMaster + ControlPersist in ``~/.ssh/config`` (or via ``ssh_options``)
 mean 2FA is prompted once and then re-used across multiple fleche sessions
@@ -511,6 +512,7 @@ class _SshConnection(_Connection):
         cache_name: str | None,
         ssh_options: tuple[str, ...],
         setup_commands: tuple[str, ...],
+        workdir: str | None = None,
     ) -> None:
         super().__init__()
         self._host = host
@@ -518,6 +520,7 @@ class _SshConnection(_Connection):
         self._cache_name = cache_name
         self._ssh_options = ssh_options
         self._setup_commands = setup_commands
+        self._workdir = workdir
         self._proc: subprocess.Popen | None = None
         self._stderr_thread: threading.Thread | None = None
         # Last few lines of remote stderr, surfaced in RemoteConnectionError
@@ -531,13 +534,21 @@ class _SshConnection(_Connection):
         server_argv = [self._python, "-m", "fleche.remote", "--serve"]
         if self._cache_name is not None:
             server_argv.extend(["--cache", self._cache_name])
-        if self._setup_commands:
-            # Run user setup snippets in the remote shell, then `exec` into the
+        # A `cd` into the working directory runs first so the server process —
+        # and the `python -m` it execs — inherits that cwd; this puts the dir
+        # on sys.path so the remote can import modules referenced by unpickled
+        # calls.  It precedes setup_commands in case those expect to run there.
+        prefix_commands: list[str] = []
+        if self._workdir is not None:
+            prefix_commands.append(f"cd {shlex.quote(self._workdir)}")
+        prefix_commands.extend(self._setup_commands)
+        if prefix_commands:
+            # Run the prefix snippets in the remote shell, then `exec` into the
             # server so stdin/stdout pipe straight through with no shell wrapper.
-            # Any setup failure short-circuits via `&&` and the SSH process exits
+            # Any failure short-circuits via `&&` and the SSH process exits
             # non-zero — the client surfaces this as RemoteConnectionError.
             server_cmd = " ".join(shlex.quote(a) for a in server_argv)
-            remote = " && ".join((*self._setup_commands, f"exec {server_cmd}"))
+            remote = " && ".join((*prefix_commands, f"exec {server_cmd}"))
             cmd.append(remote)
         else:
             cmd.extend(server_argv)
@@ -651,9 +662,15 @@ class SshCache(BaseCache):
         setup_commands: Shell snippets run on the remote *before* the server
             process starts, joined with ``&&`` so any failure aborts the
             launch.  Typical uses are HPC environment setup —
-            ``("module load python/3.11", "source ~/.venv/bin/activate")`` —
-            or ``cd`` into a working directory.  Each snippet is passed to the
-            remote shell verbatim; quote any user-provided values yourself.
+            ``("module load python/3.11", "source ~/.venv/bin/activate")``.
+            Each snippet is passed to the remote shell verbatim; quote any
+            user-provided values yourself.
+        workdir: Optional remote directory to ``cd`` into before launching the
+            server.  Because the server starts the cache via ``python -m``, the
+            working directory lands on ``sys.path``, so setting it lets the
+            remote import the local modules referenced by unpickled calls (the
+            "fudge imports" use case).  The ``cd`` runs ahead of
+            *setup_commands*.
     """
 
     host: str
@@ -661,6 +678,7 @@ class SshCache(BaseCache):
     python: str = "python3"
     ssh_options: tuple[str, ...] = ()
     setup_commands: tuple[str, ...] = ()
+    workdir: str | None = None
     _conn: _Connection = field(init=False, repr=False, compare=False, hash=False)
     _info_cache: "dict[str, Any] | None" = field(
         init=False, default=None, repr=False, compare=False, hash=False
@@ -675,6 +693,7 @@ class SshCache(BaseCache):
             cache_name=self.cache_name,
             ssh_options=self.ssh_options,
             setup_commands=self.setup_commands,
+            workdir=self.workdir,
         )
         object.__setattr__(self, "_conn", conn)
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -593,6 +593,68 @@ def test_sshcache_setup_commands_omitted_from_config_when_empty():
     assert "setup_commands" not in d
 
 
+def test_sshcache_workdir_cds_before_exec():
+    """workdir prepends a `cd` ahead of the server exec."""
+    c = SshCache(
+        host="user@example.com",
+        cache_name="shared",
+        workdir="~/my project",
+    )
+    try:
+        cmd = c._conn._build_command()
+    finally:
+        c.close()
+    assert cmd[:2] == ["ssh", "user@example.com"]
+    assert len(cmd) == 3, f"workdir should collapse into one shell arg, got {cmd!r}"
+    remote = cmd[2]
+    # The workdir is shell-quoted so paths with spaces survive.
+    assert remote.startswith("cd '~/my project' && exec ")
+    assert "python3 -m fleche.remote --serve --cache shared" in remote
+
+
+def test_sshcache_workdir_runs_before_setup_commands():
+    """The `cd` precedes setup_commands in the combined shell snippet."""
+    c = SshCache(
+        host="user@example.com",
+        workdir="/opt/project",
+        setup_commands=("source ~/.venv/bin/activate",),
+    )
+    try:
+        cmd = c._conn._build_command()
+    finally:
+        c.close()
+    remote = cmd[2]
+    assert remote.startswith("cd /opt/project && source ~/.venv/bin/activate && exec ")
+
+
+def test_sshcache_workdir_config_round_trip():
+    from fleche.config import cache_from_config, cache_to_config
+
+    original = {
+        "type": "ssh",
+        "host": "user@example.com",
+        "workdir": "~/project",
+    }
+    c = cache_from_config(original)
+    try:
+        assert c.workdir == "~/project"
+        d = cache_to_config(c)
+    finally:
+        c.close()
+    assert d["workdir"] == "~/project"
+
+
+def test_sshcache_workdir_omitted_from_config_when_unset():
+    from fleche.config import cache_to_config
+
+    c = SshCache(host="user@example.com")
+    try:
+        d = cache_to_config(c)
+    finally:
+        c.close()
+    assert "workdir" not in d
+
+
 def test_cache_stack_with_ssh_layer():
     """A stack of [local, ssh] composes via the existing array-of-tables path."""
     from fleche.config import cache_from_config


### PR DESCRIPTION
## Summary

Adds a `workdir` config option to `SshCache` so the remote process can be launched from a specified directory.

The remote server boots the cache via `python -m fleche.remote --serve`, which puts the process's working directory on `sys.path`. By `cd`-ing into a configured `workdir` first, the remote can import the project-local modules referenced by unpickled calls — the "fudge imports" use case.

- New `workdir: str | None` field on `SshCache`, threaded through `_SshConnection`.
- `_build_command` prepends `cd <workdir>` (shell-quoted) ahead of any `setup_commands`, reusing the existing `&& exec` shell-wrapper path. When neither `workdir` nor `setup_commands` are set, the server argv is still passed directly (no shell wrapper).
- Honoured in TOML (`workdir = "~/project"`) and round-tripped by `cache_to_config` (omitted when unset).
- Updated docstrings, config examples, and `docs/dev/ssh_cache.rst`.

## Test plan

- [x] `pytest tests/unit/test_remote.py` (40 passed) — new tests cover the `cd` prefix, ordering before `setup_commands`, config round-trip, and omission when unset.
- [x] `pytest tests/integration/test_remote.py` (3 passed)
- [x] `ty check src/` (clean)

https://claude.ai/code/session_01Af1oFPCnGkEAFuaKMeCvUs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af1oFPCnGkEAFuaKMeCvUs)_