### PR TITLE
fix(config): intern the default cache under None so it is reused

### DIFF
--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -536,7 +536,9 @@ def load_cache_config(name: str | None = None) -> caches.BaseCache:
             return _default_memory_cache(None, "no default cache configured")
         default_cache = config["default"]["cache"]
         if isinstance(default_cache, str):
-            return load_cache_config(default_cache)
+            cache = load_cache_config(default_cache)
+            _live_caches[None] = cache
+            return cache
         cache_name, cache_config = "default", default_cache
     else:
         if name not in config:
@@ -545,4 +547,10 @@ def load_cache_config(name: str | None = None) -> caches.BaseCache:
 
     cache = cache_from_config(cache_config)
     _live_caches[cache_name] = cache
+    # Also intern under the requested name (``None`` for the default cache
+    # resolved from an inline ``[default.cache]`` table) so repeated lookups
+    # return the same instance instead of rebuilding it — otherwise the ``None``
+    # key is never populated and every call reconstructs the cache (re-spawning
+    # an SshCache subprocess, reopening file handles, etc.).
+    _live_caches[name] = cache
     return cache

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -537,20 +537,18 @@ def load_cache_config(name: str | None = None) -> caches.BaseCache:
         default_cache = config["default"]["cache"]
         if isinstance(default_cache, str):
             cache = load_cache_config(default_cache)
-            _live_caches[None] = cache
-            return cache
-        cache_name, cache_config = "default", default_cache
+        else:
+            cache = cache_from_config(default_cache)
     else:
         if name not in config:
             return _default_memory_cache(name, f"cache {name!r} not found in configuration")
-        cache_name, cache_config = name, config[name]
+        cache = cache_from_config(config[name])
 
-    cache = cache_from_config(cache_config)
-    _live_caches[cache_name] = cache
-    # Also intern under the requested name (``None`` for the default cache
-    # resolved from an inline ``[default.cache]`` table) so repeated lookups
-    # return the same instance instead of rebuilding it — otherwise the ``None``
-    # key is never populated and every call reconstructs the cache (re-spawning
-    # an SshCache subprocess, reopening file handles, etc.).
+    # Intern under the requested name (the same key callers look up by, ``None``
+    # for the default cache) so repeated lookups return the same instance rather
+    # than rebuilding it — otherwise resolving the default would reconstruct the
+    # cache every time, re-spawning an SshCache subprocess, reopening file
+    # handles, etc.  A string-alias default also interns under its own name via
+    # the recursive call above, so both keys map to the one instance.
     _live_caches[name] = cache
     return cache

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -174,6 +174,26 @@ def test_cache_instances_are_persistent(monkeypatch, config_file):
     assert cache1 is cache2
 
 
+def test_default_cache_is_interned_string_alias(monkeypatch, config_file):
+    """The default cache (resolved via a string alias) is interned under None."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
+
+    assert load_cache_config() is load_cache_config()
+
+
+def test_default_cache_is_interned_inline_table(monkeypatch, config_file_explicit_default):
+    """An inline ``[default.cache]`` table is interned, not rebuilt each call.
+
+    Regression: ``load_cache_config(None)`` used to intern the resolved cache
+    under ``"default"`` only, so the ``None`` lookup never hit and every call
+    reconstructed the cache — re-spawning an SshCache subprocess for a default
+    ssh cache.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", config_file_explicit_default)
+
+    assert load_cache_config() is load_cache_config()
+
+
 def test_load_default_metadata(restore_fleche_state, monkeypatch, config_file):
     monkeypatch.setenv("XDG_CONFIG_HOME", config_file)
 


### PR DESCRIPTION
`load_cache_config(None)` interned the resolved default cache under its resolved name (`"default"` for an inline `[default.cache]` table, the alias name for a string default) but not under `None`, so every call rebuilt the cache — re-spawning a default `SshCache` subprocess and reopening file handles instead of reusing the interned instance. Fix: always intern under the requested `name`.

https://claude.ai/code/session_01RjdebitoJvSPDoCF7u5Q7U