### PR TITLE
chore: add project description for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ fallback_version = "0.0.0"
 [project]
 name = "fleche"
 dynamic = ["version"]
+description = "Hierachical, persistant caches in python"
 authors = [
     { name="Marvin Poul", email="pmrv@posteo.de" },
 ]


### PR DESCRIPTION
## Summary
- Add `description = "Hierachical, persistant caches in python"` to `[project]` in `pyproject.toml` so it shows up as the PyPI package summary.

## Test plan
- [ ] `python -m build` succeeds and the resulting metadata includes the new description.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xo2J8xbSdMUntyRB9phToQ)_