### PR TITLE
refactor(remote): move CLI to `python -m fleche &lt;command&gt;` dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ def my_function(x):
 
 ### SSH (remote) Cache
 - **Requires `cloudpickle`** (`pip install fleche[ssh]`) — used as the wire protocol between client and remote server; not optional
-- Forwards every cache operation over a persistent `ssh host python -m fleche.remote --serve` subprocess
+- Forwards every cache operation over a persistent `ssh host python -m fleche remote --serve` subprocess
 - Stack with a local cache to read-through to a shared remote one — see `fleche.remote.SshCache`
 
 ### In-Memory Storage

--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -25,7 +25,7 @@ itself: SSH provides confidentiality and authentication of the
 endpoints, and we trust both ends not to ship hostile pickled objects.
 **Do not point** :class:`~fleche.remote.SshCache` **at a host you would
 not** ``ssh`` **into**, and do not expose the server entry point
-(``python -m fleche.remote --serve``) on any transport other than the
+(``python -m fleche remote --serve``) on any transport other than the
 spawned SSH stdin/stdout — there is no authentication on the RPC
 stream itself.
 
@@ -280,7 +280,7 @@ constructed remote command looks like:
 
 .. code-block:: text
 
-   cd <workdir> && <snippet1> && <snippet2> && ... && exec <python> -m fleche.remote --serve
+   cd <workdir> && <snippet1> && <snippet2> && ... && exec <python> -m fleche remote --serve
 
 The trailing ``exec`` replaces the wrapping shell so stdin/stdout pipe
 straight through to the server process — no extra layer to corrupt the
@@ -340,7 +340,7 @@ Active cache on the remote
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The server's served cache *is* its active cache.  ``python -m
-fleche.remote --serve`` installs the named cache on the
+fleche remote --serve`` installs the named cache on the
 ``fleche.state._CACHE`` ContextVar before entering the request loop,
 so any code path on the remote that consults ``fleche.cache()``
 independently — metadata hooks, ``LazyCall._cache`` references, nested
@@ -382,7 +382,7 @@ The module ships two layers of tests, both in ``tests/{unit,integration}/test_re
   :class:`fleche.remote._Connection` subclass directly with no server
   on the other side; see ``test_connection_drop_includes_diagnose_output``.
 
-- **Integration tests** launch ``python -m fleche.remote --serve`` as
+- **Integration tests** launch ``python -m fleche remote --serve`` as
   a local subprocess (still no SSH involved) so the full
   ``Popen``-with-three-pipes handshake, module loading, and config-file
   parsing on the server side are all exercised.  Each test uses a

--- a/src/fleche/__main__.py
+++ b/src/fleche/__main__.py
@@ -1,0 +1,57 @@
+"""``python -m fleche <command> ...`` dispatcher.
+
+Currently the only subcommand is ``remote``, which runs the cache RPC
+server :class:`fleche.remote.SshCache` connects to.  Register additional
+subcommands by adding a parser in :func:`_build_parser` and a branch in
+:func:`_main`.
+
+The CLI deliberately lives here rather than inside ``fleche.remote``:
+the package's ``__init__`` transitively imports ``fleche.remote`` (e.g.
+through :mod:`fleche.config`), so invoking the server as
+``python -m fleche.remote`` would load ``remote.py`` twice — once as the
+submodule and once as ``__main__`` — and emit the ``runpy`` "found in
+sys.modules ... prior to execution" warning, with two separate copies of
+every class and exception in the file.  ``__main__.py`` is never imported
+as a submodule, so routing through it avoids the duplicate.
+"""
+
+import argparse
+import sys
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m fleche")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    remote = sub.add_parser(
+        "remote",
+        help="run the remote cache RPC server (used by SshCache)",
+    )
+    remote.add_argument(
+        "--serve",
+        action="store_true",
+        help="run the cache server reading RPC frames from stdin",
+    )
+    remote.add_argument(
+        "--cache",
+        default=None,
+        help="named cache from the local fleche.toml (default: the file's default)",
+    )
+    return parser
+
+
+def _main(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "remote":
+        if not args.serve:
+            parser.error("nothing to do; pass --serve to run the cache server")
+        from .remote import _run_server
+
+        return _run_server(cache_name=args.cache)
+    parser.error(f"unknown command: {args.command!r}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -114,7 +114,7 @@ Example fleche.toml
     calls.root = "~/.fleche/calls"
 
     # SshCache — share results with another machine over SSH.  The remote
-    # runs `python -m fleche.remote --serve` and proxies into its own
+    # runs `python -m fleche remote --serve` and proxies into its own
     # configured cache.  Compose with a local cache by stacking two
     # entries (saves go to the first entry; reads fall back to the SSH
     # remote and back-fill hits into the local layer).

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -1,10 +1,11 @@
 """SSH-connected cache for sharing fleche results across machines.
 
 :class:`SshCache` is a :class:`~fleche.caches.BaseCache` that forwards every
-operation to a remote ``python -m fleche.remote`` process over a single
-persistent SSH subprocess.  The remote process loads its own ``fleche.toml``
-and proxies operations into whichever cache it has configured, so the remote
-side keeps full freedom to use any backend (file / SQL / HDF5 / stack).
+operation to a remote ``python -m fleche remote --serve`` process over a
+single persistent SSH subprocess.  The remote process loads its own
+``fleche.toml`` and proxies operations into whichever cache it has
+configured, so the remote side keeps full freedom to use any backend
+(file / SQL / HDF5 / stack).
 
 Typical configuration in ``fleche.toml`` — local cache first, remote cache
 second, composed automatically into a :class:`~fleche.caches.CacheStack`::
@@ -38,7 +39,6 @@ a single run only one authentication round-trip is required.
 """
 
 import abc
-import argparse
 import atexit
 import collections
 import logging
@@ -470,7 +470,7 @@ class _Connection(abc.ABC):
 
 
 class _SshConnection(_Connection):
-    """Persistent ``ssh host python -m fleche.remote --serve`` subprocess.
+    """Persistent ``ssh host python -m fleche remote --serve`` subprocess.
 
     One subprocess per :class:`SshCache` instance.  Spawned lazily on the
     first RPC and reused for the lifetime of the Python process; never
@@ -531,7 +531,7 @@ class _SshConnection(_Connection):
         cmd = ["ssh"]
         cmd.extend(self._ssh_options)
         cmd.append(self._host)
-        server_argv = [self._python, "-m", "fleche.remote", "--serve"]
+        server_argv = [self._python, "-m", "fleche", "remote", "--serve"]
         if self._cache_name is not None:
             server_argv.extend(["--cache", self._cache_name])
         # A `cd` into the working directory runs first so the server process —
@@ -642,7 +642,7 @@ def _forward_stderr(
 class SshCache(BaseCache):
     """A cache that forwards every operation to a remote fleche over SSH.
 
-    The remote side runs ``python -m fleche.remote --serve``; its active
+    The remote side runs ``python -m fleche remote --serve``; its active
     cache is determined by its own ``fleche.toml`` (optionally overridden by
     *cache_name* — looked up via :func:`fleche.config.load_cache_config`).
 
@@ -841,43 +841,31 @@ class SshCache(BaseCache):
 
 
 # ---------------------------------------------------------------------------
-# Module entry point: `python -m fleche.remote --serve [--cache NAME]`
+# Server entry point: invoked by `python -m fleche remote --serve` via
+# `fleche.__main__`.  Not exposed as `__main__` here because the package's
+# `__init__` transitively imports `fleche.remote`, so running this file
+# directly would trigger the `runpy` double-import warning.
 # ---------------------------------------------------------------------------
 
 
-def _main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(prog="python -m fleche.remote")
-    parser.add_argument(
-        "--serve",
-        action="store_true",
-        help="run the remote cache server reading RPC frames from stdin",
-    )
-    parser.add_argument(
-        "--cache",
-        default=None,
-        help="named cache from the remote fleche.toml (default: the file's default)",
-    )
-    args = parser.parse_args(argv)
-    if not args.serve:
-        parser.error("nothing to do; pass --serve to run the cache server")
+def _run_server(cache_name: str | None) -> int:
+    """Load *cache_name* (or the default) and run :func:`serve` over stdio.
+
+    Installs the requested cache as the *active* one (via the ContextVar in
+    :mod:`fleche.state`) so anything executed inside the served cache —
+    metadata hooks, value-loading through ``LazyCall`` references, nested
+    ``@fleche()`` calls — sees the same cache the RPC layer is dispatching
+    against.  ``load_cache_config()`` alone only constructs the cache; it
+    doesn't activate it.
+    """
     from . import cache as activate_cache
 
-    # Install the requested cache as the *active* one (via the ContextVar in
-    # state.py) so anything executed inside the served cache — metadata
-    # hooks, value-loading through LazyCall references, nested @fleche()
-    # calls — sees the same cache the RPC layer is dispatching against.
-    # `load_cache_config()` alone only constructs the cache; it doesn't
-    # activate it.
-    if args.cache is not None:
-        activate_cache(args.cache)
+    if cache_name is not None:
+        activate_cache(cache_name)
     cache = activate_cache()
-    logger.info("serving remote fleche cache (name=%r): %r", args.cache, cache)
-    serve(sys.stdin.buffer, sys.stdout.buffer, cache, cache_name=args.cache)
+    logger.info("serving remote fleche cache (name=%r): %r", cache_name, cache)
+    serve(sys.stdin.buffer, sys.stdout.buffer, cache, cache_name=cache_name)
     return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(_main(sys.argv[1:]))
 
 
 __all__ = [

--- a/tests/integration/test_remote.py
+++ b/tests/integration/test_remote.py
@@ -1,6 +1,6 @@
 """End-to-end integration tests for :class:`fleche.remote.SshCache`.
 
-These tests bypass SSH entirely: ``python -m fleche.remote --serve`` is
+These tests bypass SSH entirely: ``python -m fleche remote --serve`` is
 launched as a local subprocess so the same stdin/stdout RPC machinery used
 in production is exercised in full, including module loading, config file
 parsing on the server side, and the ``Popen`` handshake on the client side.
@@ -18,7 +18,7 @@ from fleche.remote import SshCache, _Connection
 
 
 class _LocalSubprocessConnection(_Connection):
-    """Launch ``python -m fleche.remote --serve`` directly (no SSH)."""
+    """Launch ``python -m fleche remote --serve`` directly (no SSH)."""
 
     def __init__(self, cache_name=None, env=None, cwd=None):
         super().__init__()
@@ -28,7 +28,7 @@ class _LocalSubprocessConnection(_Connection):
         self._proc = None
 
     def _open(self):
-        cmd = [sys.executable, "-m", "fleche.remote", "--serve"]
+        cmd = [sys.executable, "-m", "fleche", "remote", "--serve"]
         if self._cache_name is not None:
             cmd.extend(["--cache", self._cache_name])
         self._proc = subprocess.Popen(

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -537,7 +537,7 @@ def test_sshcache_default_command_has_no_shell_wrapper():
     finally:
         c.close()
     assert cmd[:2] == ["ssh", "user@example.com"]
-    assert cmd[2:] == ["python3", "-m", "fleche.remote", "--serve", "--cache", "shared"]
+    assert cmd[2:] == ["python3", "-m", "fleche", "remote", "--serve", "--cache", "shared"]
 
 
 def test_sshcache_setup_commands_prefixed_with_exec():
@@ -556,7 +556,7 @@ def test_sshcache_setup_commands_prefixed_with_exec():
     remote = cmd[2]
     assert remote.startswith("module load python/3.11 && source ~/.venv/bin/activate && exec ")
     # The server invocation is shell-quoted so paths with spaces survive.
-    assert "python3 -m fleche.remote --serve --cache shared" in remote
+    assert "python3 -m fleche remote --serve --cache shared" in remote
 
 
 def test_sshcache_setup_commands_config_round_trip():
@@ -609,7 +609,7 @@ def test_sshcache_workdir_cds_before_exec():
     remote = cmd[2]
     # The workdir is shell-quoted so paths with spaces survive.
     assert remote.startswith("cd '~/my project' && exec ")
-    assert "python3 -m fleche.remote --serve --cache shared" in remote
+    assert "python3 -m fleche remote --serve --cache shared" in remote
 
 
 def test_sshcache_workdir_runs_before_setup_commands():


### PR DESCRIPTION
## Summary

`python -m fleche.remote --serve` emitted a `runpy` warning:

```
<frozen runpy>:128: RuntimeWarning: 'fleche.remote' found in sys.modules
after import of package 'fleche', but prior to execution of 'fleche.remote';
this may result in unpredictable behaviour
```

Root cause: `fleche/__init__.py` transitively imports `fleche.remote`
(e.g. via `fleche.config`), so when `runpy` then loads `remote.py` as
`__main__`, two distinct module objects back the same file — meaning
two copies of every class, exception, and module-level constant. The
"unpredictable behaviour" the warning warns about.

Fix: move the CLI into a new `fleche/__main__.py` argparse-subparser
dispatcher (currently just `remote`, set up to grow more subcommands)
and reduce `remote.py` to a `_run_server(cache_name)` helper. The new
invocation is `python -m fleche remote --serve [--cache NAME]`;
`_SshConnection._build_command`, the integration & unit tests, the
README, and the ssh_cache dev guide are updated to match.

`__main__.py` is never imported as a submodule, so the duplicate
disappears — `python -W error::RuntimeWarning -m fleche remote --serve`
now runs clean.

## Test plan

- [x] `pytest tests/unit/test_remote.py` (40 passed)
- [x] `pytest tests/integration/test_remote.py` (3 passed)
- [x] `python -W error::RuntimeWarning -m fleche remote --help` — no warning
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01BWpKoRuGFpRT6uiiMVVjYR)_