### PR TITLE
refactor: deduplicate transfer policy between BaseCache.transfer and QueryIterator.transfer (#592)

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -63,21 +63,7 @@ class BaseCache(ABC):
             overwrite: If True, overwrite existing entries in the target cache.
                 If False (default), skip entries that already exist in the target.
         """
-        tpl = call.QueryCall(name=None, arguments=None, metadata=None, module=None, version=None, result=None)
-        for c in self.query(tpl):
-            c = c.fetch()
-            key = c.to_lookup_key()
-            conflict = not overwrite and other.contains(key)
-            if not conflict:
-                other.save(c)
-            if pop:
-                if conflict:
-                    logger.warning(
-                        "Not evicting %s from source: already exists in target and overwrite=False",
-                        key,
-                    )
-                else:
-                    self.evict(key)
+        self.query().transfer(other, pop=pop, overwrite=overwrite)
                     
     def readonly(self) -> "ReadOnlyCache":
         """Return a read-only view of this cache."""

--- a/tests/regression/test_issue_592.py
+++ b/tests/regression/test_issue_592.py
@@ -1,0 +1,140 @@
+"""Regression test for issue #592: BaseCache.transfer and QueryIterator.transfer equivalence.
+
+Pins two properties that make it safe to collapse BaseCache.transfer into a
+one-line delegator onto QueryIterator.transfer:
+
+1. cache.query() with no template binds ``_cache`` to the source cache on
+   every yielded LazyCall, so ``self.evict(key)`` ≡ ``c._cache.evict(key)``.
+2. Both surfaces produce identical data decisions (save/skip/evict) across all
+   combinations of pop/overwrite/conflict.
+"""
+
+import pytest
+from fleche.call import Call
+from fleche.caches import Cache
+from fleche.storage.memory import ValueMemory, CallMemory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _cache(*calls):
+    c = Cache(values=ValueMemory({}), calls=CallMemory({}))
+    for call in calls:
+        c.save(call)
+    return c
+
+
+_call_a = Call(name="f", arguments={"x": 1}, result=10)
+_call_b = Call(name="f", arguments={"x": 2}, result=20)
+_call_a_conflict = Call(name="f", arguments={"x": 1}, result=999)  # same key as _call_a
+
+
+# ---------------------------------------------------------------------------
+# 1. _cache identity on wildcard query
+# ---------------------------------------------------------------------------
+
+def test_wildcard_query_lazycall_cache_is_source():
+    """Every LazyCall from cache.query() has _cache pointing to that cache.
+
+    This is the invariant that makes self.evict(key) == c._cache.evict(key)
+    after the refactor.
+    """
+    src = _cache(_call_a, _call_b)
+    for lc in src.query():
+        assert lc._cache is src
+
+
+# ---------------------------------------------------------------------------
+# 2. Functional data equivalence: no conflict
+# ---------------------------------------------------------------------------
+
+def test_both_surfaces_copy_all_calls_no_conflict():
+    """Plain transfer: both surfaces save all source calls in the target."""
+    src1, dst1 = _cache(_call_a, _call_b), _cache()
+    src2, dst2 = _cache(_call_a, _call_b), _cache()
+
+    src1.transfer(dst1)
+    src2.query().transfer(dst2)
+
+    for call in (_call_a, _call_b):
+        key = call.to_lookup_key()
+        assert dst1.contains(key), "BaseCache.transfer missed a call"
+        assert dst2.contains(key), "QueryIterator.transfer missed a call"
+
+
+def test_both_surfaces_leave_source_intact_without_pop():
+    """Without pop=True, source is untouched on both surfaces."""
+    src1, dst1 = _cache(_call_a, _call_b), _cache()
+    src2, dst2 = _cache(_call_a, _call_b), _cache()
+
+    src1.transfer(dst1, pop=False)
+    src2.query().transfer(dst2, pop=False)
+
+    for call in (_call_a, _call_b):
+        key = call.to_lookup_key()
+        assert src1.contains(key), "BaseCache.transfer: source wrongly evicted"
+        assert src2.contains(key), "QueryIterator.transfer: source wrongly evicted"
+
+
+def test_both_surfaces_evict_source_on_pop():
+    """pop=True: both surfaces remove calls from source after transferring."""
+    src1, dst1 = _cache(_call_a, _call_b), _cache()
+    src2, dst2 = _cache(_call_a, _call_b), _cache()
+
+    src1.transfer(dst1, pop=True)
+    src2.query().transfer(dst2, pop=True)
+
+    for call in (_call_a, _call_b):
+        key = call.to_lookup_key()
+        assert not src1.contains(key), "BaseCache.transfer pop: source still has call"
+        assert not src2.contains(key), "QueryIterator.transfer pop: source still has call"
+        assert dst1.contains(key)
+        assert dst2.contains(key)
+
+
+# ---------------------------------------------------------------------------
+# 3. Functional data equivalence: conflict, overwrite=False (default)
+# ---------------------------------------------------------------------------
+
+def test_both_surfaces_skip_save_on_conflict():
+    """Conflict + overwrite=False: target entry kept on both surfaces."""
+    src1, dst1 = _cache(_call_a), _cache(_call_a_conflict)
+    src2, dst2 = _cache(_call_a), _cache(_call_a_conflict)
+
+    src1.transfer(dst1, overwrite=False)
+    src2.query().transfer(dst2, overwrite=False)
+
+    # Target retains conflicting value on both surfaces
+    assert dst1.load(_call_a.to_lookup_key()).result == 999
+    assert dst2.load(_call_a.to_lookup_key()).result == 999
+
+
+def test_both_surfaces_skip_source_evict_on_conflict_with_pop():
+    """Conflict + pop=True + overwrite=False: source not evicted on both surfaces."""
+    src1, dst1 = _cache(_call_a), _cache(_call_a_conflict)
+    src2, dst2 = _cache(_call_a), _cache(_call_a_conflict)
+
+    src1.transfer(dst1, pop=True, overwrite=False)
+    src2.query().transfer(dst2, pop=True, overwrite=False)
+
+    key = _call_a.to_lookup_key()
+    assert src1.contains(key), "BaseCache.transfer: conflict wrongly evicted from source"
+    assert src2.contains(key), "QueryIterator.transfer: conflict wrongly evicted from source"
+
+
+# ---------------------------------------------------------------------------
+# 4. Functional data equivalence: conflict, overwrite=True
+# ---------------------------------------------------------------------------
+
+def test_both_surfaces_overwrite_target_on_conflict():
+    """overwrite=True: both surfaces replace the target entry."""
+    src1, dst1 = _cache(_call_a), _cache(_call_a_conflict)
+    src2, dst2 = _cache(_call_a), _cache(_call_a_conflict)
+
+    src1.transfer(dst1, overwrite=True)
+    src2.query().transfer(dst2, overwrite=True)
+
+    assert dst1.load(_call_a.to_lookup_key()).result == 10
+    assert dst2.load(_call_a.to_lookup_key()).result == 10

--- a/tests/regression/test_issue_592.py
+++ b/tests/regression/test_issue_592.py
@@ -106,9 +106,9 @@ def test_both_surfaces_skip_save_on_conflict():
     src1.transfer(dst1, overwrite=False)
     src2.query().transfer(dst2, overwrite=False)
 
-    # Target retains conflicting value on both surfaces
-    assert dst1.load(_call_a.to_lookup_key()).result == 999
-    assert dst2.load(_call_a.to_lookup_key()).result == 999
+    # Target retains conflicting value on both surfaces (== _call_a_conflict.result, not _call_a.result)
+    assert dst1.load(_call_a.to_lookup_key()).result == _call_a_conflict.result
+    assert dst2.load(_call_a.to_lookup_key()).result == _call_a_conflict.result
 
 
 def test_both_surfaces_skip_source_evict_on_conflict_with_pop():
@@ -136,5 +136,6 @@ def test_both_surfaces_overwrite_target_on_conflict():
     src1.transfer(dst1, overwrite=True)
     src2.query().transfer(dst2, overwrite=True)
 
-    assert dst1.load(_call_a.to_lookup_key()).result == 10
-    assert dst2.load(_call_a.to_lookup_key()).result == 10
+    # Source value replaces the conflicting entry (== _call_a.result, not _call_a_conflict.result)
+    assert dst1.load(_call_a.to_lookup_key()).result == _call_a.result
+    assert dst2.load(_call_a.to_lookup_key()).result == _call_a.result

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -234,7 +234,7 @@ def test_base_cache_transfer_no_overwrite_and_pop(caplog):
     c1.save(call2)
     c2.save(call1_existing)
 
-    with caplog.at_level(logging.WARNING, logger="fleche.cache"):
+    with caplog.at_level(logging.WARNING, logger="fleche.query"):
         c1.transfer(c2, pop=True, overwrite=False)
 
     # call2 should now be in c2 (was new) and evicted from c1
@@ -244,8 +244,8 @@ def test_base_cache_transfer_no_overwrite_and_pop(caplog):
     assert c2.load(str(call1.to_lookup_key())).result == "existing"
     # call1 should still be in c1 — NOT evicted because it conflicted
     assert c1.contains(str(call1.to_lookup_key()))
-    # a warning should have been emitted for the skipped eviction
-    assert any("Not evicting" in m for m in caplog.messages)
+    # a warning should have been emitted for the skipped conflict
+    assert any("Not transferring" in m for m in caplog.messages)
 
 
 def test_cache_query_decodes_values_and_args(monkeypatch):


### PR DESCRIPTION
Closes #592

## Summary

- Pins the `_cache is source` invariant with a regression test before collapsing
- Reduces `BaseCache.transfer` to a one-line delegator onto `QueryIterator.transfer`
- Unifies conflict-skip warning (now always emitted, shrunk key, `fleche.query` logger)

## Test plan

- [x] `tests/regression/test_issue_592.py` — 7 new tests pinning functional equivalence
- [x] Existing `test_base_cache_transfer*` tests still pass
- [x] Existing `test_transfer_*` tests in `test_query_iterator.py` still pass
- [x] Full unit + regression suite: 959 passed

Generated with [Claude Code](https://claude.ai/code)