### PR TITLE
feat: add LazyCall.to_digested_call() — public inverse of DigestedCall.fetch()

### DIFF
--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -397,7 +397,7 @@ class LazyCall:
             result=self.result
         )
 
-    def to_digested_call(self) -> "DigestedCall":
+    def detach(self) -> "DigestedCall":
         """Return the cache-free :class:`DigestedCall` shadow of this :class:`LazyCall`.
 
         The inverse of :meth:`DigestedCall.fetch`: strips the ``_cache``

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -397,6 +397,23 @@ class LazyCall:
             result=self.result
         )
 
+    def to_digested_call(self) -> "DigestedCall":
+        """Return the cache-free :class:`DigestedCall` shadow of this :class:`LazyCall`.
+
+        The inverse of :meth:`DigestedCall.fetch`: strips the ``_cache``
+        reference so the result can cross process boundaries (e.g. over the
+        wire in :mod:`fleche.remote`) without carrying a live cache pointer.
+        """
+        return DigestedCall(
+            name=self.name,
+            arguments=dict(self._arguments),
+            result=self._result,
+            metadata=dict(self.metadata),
+            module=self.module,
+            version=self.version,
+            code_digest=self.code_digest,
+        )
+
     def __digest__(self):
         # Reconstruct a Call object to ensure identical digest calculation
         c = Call(

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -118,15 +118,7 @@ def _strip_cache(lc: LazyCall) -> DigestedCall:
     travel across the wire — the client wraps the returned ``DigestedCall``
     back into a :class:`LazyCall` bound to itself via ``DigestedCall.fetch``.
     """
-    return DigestedCall(
-        name=lc.name,
-        arguments=dict(lc._arguments),
-        result=lc._result,
-        metadata=dict(lc.metadata),
-        module=lc.module,
-        version=lc.version,
-        code_digest=lc.code_digest,
-    )
+    return lc.to_digested_call()
 
 
 def _dispatch(cache: BaseCache, method: str, args: tuple, kwargs: dict) -> Any:

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -118,7 +118,7 @@ def _strip_cache(lc: LazyCall) -> DigestedCall:
     travel across the wire — the client wraps the returned ``DigestedCall``
     back into a :class:`LazyCall` bound to itself via ``DigestedCall.fetch``.
     """
-    return lc.to_digested_call()
+    return lc.detach()
 
 
 def _dispatch(cache: BaseCache, method: str, args: tuple, kwargs: dict) -> Any:

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -277,3 +277,80 @@ class TestDigestedCallDigestEquivalence:
         call_a = _call(metadata={"Runtime": {"elapsed": 1.0}})
         call_b = _call(metadata={"Runtime": {"elapsed": 9.9}})
         assert digest(call_a.digest()) != digest(call_b.digest())
+
+
+# ---------------------------------------------------------------------------
+# LazyCall.to_digested_call  —  round-trip with DigestedCall.fetch
+#
+# Asserts field equality so any future LazyCall representation change that
+# breaks the coupling between call.py and remote.py fails loudly here.
+# ---------------------------------------------------------------------------
+
+class TestLazyCallToDigestedCall:
+    """LazyCall.to_digested_call() is the inverse of DigestedCall.fetch()."""
+
+    def _lazy(self, **kwargs):
+        values = _mem()
+        cache = _cache(values)
+        call = _call(**kwargs)
+        stashed = call.stash(values)
+        return stashed.fetch(cache)
+
+    def test_returns_digested_call(self):
+        lc = self._lazy()
+        assert isinstance(lc.to_digested_call(), DigestedCall)
+
+    def test_field_equality_with_originating_digested_call(self):
+        """to_digested_call() reproduces every field of the DigestedCall it came from."""
+        values = _mem()
+        cache = _cache(values)
+        call = _call(arguments={"x": 10, "y": 20}, result=42,
+                     metadata={"Runtime": {"elapsed": 1.5}},
+                     module="mymod", version=3, code_digest="abc")
+        dc = call.stash(values)
+        lc = dc.fetch(cache)
+        dc2 = lc.to_digested_call()
+
+        assert dc2.name == dc.name
+        assert dc2.arguments == dc.arguments
+        assert dc2.result == dc.result
+        assert dc2.metadata == dc.metadata
+        assert dc2.module == dc.module
+        assert dc2.version == dc.version
+        assert dc2.code_digest == dc.code_digest
+
+    def test_round_trip_fetch_to_digested_call(self):
+        """fetch(cache).to_digested_call() == original DigestedCall (field-wise)."""
+        values = _mem()
+        cache = _cache(values)
+        call = _call()
+        dc = call.stash(values)
+        assert dc == dc.fetch(cache).to_digested_call()
+
+    def test_to_digested_call_has_no_cache_reference(self):
+        """The returned DigestedCall carries no _cache field."""
+        lc = self._lazy()
+        dc = lc.to_digested_call()
+        assert not hasattr(dc, "_cache")
+
+    def test_arguments_are_independent_copy(self):
+        """Mutating the returned arguments dict does not affect the LazyCall."""
+        lc = self._lazy()
+        dc = lc.to_digested_call()
+        dc.arguments["injected"] = Digest("a" * 64)
+        assert "injected" not in lc._arguments
+
+    def test_metadata_is_independent_copy(self):
+        """Mutating the returned metadata dict does not affect the LazyCall."""
+        lc = self._lazy(metadata={"Runtime": {"elapsed": 1.0}})
+        dc = lc.to_digested_call()
+        dc.metadata["injected"] = {}
+        assert "injected" not in lc.metadata
+
+    def test_lookup_key_preserved(self):
+        """to_digested_call() preserves the lookup key."""
+        values = _mem()
+        cache = _cache(values)
+        call = _call()
+        lc = call.stash(values).fetch(cache)
+        assert lc.to_digested_call().to_lookup_key() == call.to_lookup_key()

--- a/tests/unit/call/test_dehydrate.py
+++ b/tests/unit/call/test_dehydrate.py
@@ -280,14 +280,14 @@ class TestDigestedCallDigestEquivalence:
 
 
 # ---------------------------------------------------------------------------
-# LazyCall.to_digested_call  —  round-trip with DigestedCall.fetch
+# LazyCall.detach  —  round-trip with DigestedCall.fetch
 #
 # Asserts field equality so any future LazyCall representation change that
 # breaks the coupling between call.py and remote.py fails loudly here.
 # ---------------------------------------------------------------------------
 
-class TestLazyCallToDigestedCall:
-    """LazyCall.to_digested_call() is the inverse of DigestedCall.fetch()."""
+class TestLazyCallDetach:
+    """LazyCall.detach() is the inverse of DigestedCall.fetch()."""
 
     def _lazy(self, **kwargs):
         values = _mem()
@@ -298,10 +298,10 @@ class TestLazyCallToDigestedCall:
 
     def test_returns_digested_call(self):
         lc = self._lazy()
-        assert isinstance(lc.to_digested_call(), DigestedCall)
+        assert isinstance(lc.detach(), DigestedCall)
 
     def test_field_equality_with_originating_digested_call(self):
-        """to_digested_call() reproduces every field of the DigestedCall it came from."""
+        """detach() reproduces every field of the DigestedCall it came from."""
         values = _mem()
         cache = _cache(values)
         call = _call(arguments={"x": 10, "y": 20}, result=42,
@@ -309,7 +309,7 @@ class TestLazyCallToDigestedCall:
                      module="mymod", version=3, code_digest="abc")
         dc = call.stash(values)
         lc = dc.fetch(cache)
-        dc2 = lc.to_digested_call()
+        dc2 = lc.detach()
 
         assert dc2.name == dc.name
         assert dc2.arguments == dc.arguments
@@ -319,38 +319,38 @@ class TestLazyCallToDigestedCall:
         assert dc2.version == dc.version
         assert dc2.code_digest == dc.code_digest
 
-    def test_round_trip_fetch_to_digested_call(self):
-        """fetch(cache).to_digested_call() == original DigestedCall (field-wise)."""
+    def test_round_trip_fetch_detach(self):
+        """fetch(cache).detach() == original DigestedCall (field-wise)."""
         values = _mem()
         cache = _cache(values)
         call = _call()
         dc = call.stash(values)
-        assert dc == dc.fetch(cache).to_digested_call()
+        assert dc == dc.fetch(cache).detach()
 
-    def test_to_digested_call_has_no_cache_reference(self):
+    def test_detach_has_no_cache_reference(self):
         """The returned DigestedCall carries no _cache field."""
         lc = self._lazy()
-        dc = lc.to_digested_call()
+        dc = lc.detach()
         assert not hasattr(dc, "_cache")
 
     def test_arguments_are_independent_copy(self):
         """Mutating the returned arguments dict does not affect the LazyCall."""
         lc = self._lazy()
-        dc = lc.to_digested_call()
+        dc = lc.detach()
         dc.arguments["injected"] = Digest("a" * 64)
         assert "injected" not in lc._arguments
 
     def test_metadata_is_independent_copy(self):
         """Mutating the returned metadata dict does not affect the LazyCall."""
         lc = self._lazy(metadata={"Runtime": {"elapsed": 1.0}})
-        dc = lc.to_digested_call()
+        dc = lc.detach()
         dc.metadata["injected"] = {}
         assert "injected" not in lc.metadata
 
     def test_lookup_key_preserved(self):
-        """to_digested_call() preserves the lookup key."""
+        """detach() preserves the lookup key."""
         values = _mem()
         cache = _cache(values)
         call = _call()
         lc = call.stash(values).fetch(cache)
-        assert lc.to_digested_call().to_lookup_key() == call.to_lookup_key()
+        assert lc.detach().to_lookup_key() == call.to_lookup_key()


### PR DESCRIPTION
Closes #586.

Promotes the `LazyCall`→`DigestedCall` conversion from `remote._strip_cache` (which read private `_arguments`/`_result` directly) into a public `LazyCall.to_digested_call()` method, so representation changes in `call.py` are caught at the source rather than silently breaking `remote.py`.

Generated with [Claude Code](https://claude.ai/code)