### PR TITLE
refactor: consolidate shrink boilerplate via Template Method pattern

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -455,10 +455,9 @@ class CacheWrapper(BaseCache):
         return self.cache.expand(key)
 
     def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
-        r = self.cache.shrink(*keys)
         if len(keys) == 1:
-            r = (r,)
-        return r
+            return (self.cache.shrink(keys[0]),)
+        return self.cache.shrink(*keys)
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         return self.cache.query(call)

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -107,7 +107,6 @@ class BaseCache(ABC):
     def shrink(self, key: Digest | str, /) -> Digest: ...
     @overload
     def shrink(self, key: Digest | str, /, *keys: Digest | str) -> "tuple[Digest, ...]": ...
-    @abstractmethod
     def shrink(self, *keys: Digest | str) -> "Digest | tuple[Digest, ...]":
         """
         Find the shortest substring(s) that unambiguously reference each call.
@@ -138,6 +137,14 @@ class BaseCache(ABC):
         Raises:
             :class:`AmbiguousDigestError`: if no shorter key is possible for any input
         """
+        if not keys:
+            raise TypeError("shrink() requires at least one key")
+        out = self._shrink(*keys)
+        return out[0] if len(keys) == 1 else out
+
+    @abstractmethod
+    def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
+        """Partition and shrink all keys; always returns a same-length tuple of short digests."""
         ...
 
     @abstractmethod
@@ -296,13 +303,7 @@ class Cache(BaseCache):
                 pass
         return _combine_expand(key, results)
 
-    @overload
-    def shrink(self, key: Digest | str, /) -> Digest: ...
-    @overload
-    def shrink(self, key: Digest | str, /, *keys: Digest | str) -> "tuple[Digest, ...]": ...
-    def shrink(self, *keys: Digest | str) -> "Digest | tuple[Digest, ...]":
-        if not keys:
-            raise TypeError("shrink() requires at least one key")
+    def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
         call_keys: list = []
         value_keys: list = []
         for k in keys:
@@ -321,8 +322,7 @@ class Cache(BaseCache):
                 r = (r,)
             for k, s in zip(ks, r):
                 results[k] = s
-        out = tuple(results[k] for k in keys)
-        return out[0] if len(keys) == 1 else out
+        return tuple(results[k] for k in keys)
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         """Query for cached calls that match a template and return decoded results.
@@ -454,12 +454,11 @@ class CacheWrapper(BaseCache):
     def expand(self, key: Digest | str) -> Digest:
         return self.cache.expand(key)
 
-    @overload
-    def shrink(self, key: Digest | str, /) -> Digest: ...
-    @overload
-    def shrink(self, key: Digest | str, /, *keys: Digest | str) -> "tuple[Digest, ...]": ...
-    def shrink(self, *keys: Digest | str) -> "Digest | tuple[Digest, ...]":
-        return self.cache.shrink(*keys)
+    def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
+        r = self.cache.shrink(*keys)
+        if len(keys) == 1:
+            r = (r,)
+        return r
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         return self.cache.query(call)
@@ -577,13 +576,7 @@ class CacheStack(BaseCache):
     def expand(self, key: Digest | str) -> Digest:
         return _combine_expand(key, self._collect(lambda c: c.expand(key)))
 
-    @overload
-    def shrink(self, key: Digest | str, /) -> Digest: ...
-    @overload
-    def shrink(self, key: Digest | str, /, *keys: Digest | str) -> "tuple[Digest, ...]": ...
-    def shrink(self, *keys: Digest | str) -> "Digest | tuple[Digest, ...]":
-        if not keys:
-            raise TypeError("shrink() requires at least one key")
+    def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
         per_key: dict = {k: [] for k in keys}
         for cache in self.stack:
             present = [k for k in keys if cache.contains(k)]
@@ -599,8 +592,7 @@ class CacheStack(BaseCache):
             if not per_key[k]:
                 raise KeyError(k)
             out_list.append(_combine_shrink(k, per_key[k]))
-        out = tuple(out_list)
-        return out[0] if len(keys) == 1 else out
+        return tuple(out_list)
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         """Aggregate query results across the stack, avoiding duplicates.

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -51,7 +51,7 @@ import sys
 import threading
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, Iterable, overload
+from typing import Any, Iterable
 
 from pyiron_snippets.import_alarm import ImportAlarm
 
@@ -742,16 +742,12 @@ class SshCache(BaseCache):
         self._ensure_handshake()
         return self._conn.call("expand", key)
 
-    @overload
-    def shrink(self, key: Digest | str, /) -> Digest: ...
-    @overload
-    def shrink(
-        self, key: Digest | str, /, *keys: Digest | str
-    ) -> "tuple[Digest, ...]": ...
-
-    def shrink(self, *keys: Digest | str) -> "Digest | tuple[Digest, ...]":
+    def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
         self._ensure_handshake()
-        return self._conn.call("shrink", *keys)
+        r = self._conn.call("shrink", *keys)
+        if len(keys) == 1:
+            r = (r,)
+        return r
 
     def _query(self, call: QueryCall) -> Iterable[LazyCall]:
         self._ensure_handshake()

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -744,10 +744,9 @@ class SshCache(BaseCache):
 
     def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
         self._ensure_handshake()
-        r = self._conn.call("shrink", *keys)
         if len(keys) == 1:
-            r = (r,)
-        return r
+            return (self._conn.call("shrink", keys[0]),)
+        return self._conn.call("shrink", *keys)
 
     def _query(self, call: QueryCall) -> Iterable[LazyCall]:
         self._ensure_handshake()

--- a/tests/unit/caches/test_expand_shrink.py
+++ b/tests/unit/caches/test_expand_shrink.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock
 import pytest
 
 from fleche.call import Call
-from fleche.caches import Cache, CacheStack
+from fleche.caches import Cache, CacheStack, ReadOnlyCache
 from fleche.digest import Digest
 from fleche.storage import AmbiguousDigestError, ValueMemory, CallMemory
 
@@ -242,3 +242,53 @@ def test_cache_stack_shrink_multiple_keys_skips_layers_without_key():
     assert out == (Digest("aaaa"), Digest("bbbb"))
     c1.shrink.assert_called_once_with("a" * 64)
     c2.shrink.assert_called_once_with("b" * 64)
+
+
+# ---------------------------------------------------------------------------
+# CacheWrapper._shrink (ReadOnlyCache as a representative concrete subclass)
+# ---------------------------------------------------------------------------
+
+def _make_call(name: str, x: int) -> Call:
+    return Call(name=name, arguments={"x": x}, result="r", module="m", version="1.0", metadata={})
+
+
+def test_cache_wrapper_shrink_single_key_returns_digest_not_nested_tuple():
+    """CacheWrapper._shrink with one key must return a flat Digest, not a nested tuple.
+
+    ty flags ``(r,)`` as potentially creating ``tuple[tuple[Digest, ...]]``
+    when ``self.cache.shrink(*keys)`` is inferred as returning
+    ``tuple[Digest, ...]``.  At runtime BaseCache.shrink returns a bare
+    Digest for one key, so the wrap is correct — this test pins that.
+    """
+    inner = Cache(ValueMemory({}), CallMemory({}))
+    key = inner.save(_make_call("f", 1))
+    wrapper = ReadOnlyCache(inner)
+
+    short = wrapper.shrink(key)
+
+    assert isinstance(short, Digest), f"expected Digest, got {type(short)}: {short!r}"
+    assert not isinstance(short, tuple), "shrink(single_key) must not return a nested tuple"
+    assert inner.expand(short) == key
+
+
+def test_cache_wrapper_shrink_multiple_keys_returns_flat_tuple_of_digests():
+    """CacheWrapper._shrink with multiple keys must return a flat tuple[Digest, ...],
+    not tuple[tuple[Digest, ...]] (which would happen if the wrapping logic were wrong)."""
+    inner = Cache(ValueMemory({}), CallMemory({}))
+    k1 = inner.save(_make_call("f", 1))
+    k2 = inner.save(_make_call("g", 2))
+    wrapper = ReadOnlyCache(inner)
+
+    result = wrapper.shrink(k1, k2)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    for element in result:
+        assert isinstance(element, Digest), (
+            f"expected each element to be a Digest, got {type(element)}: {element!r}"
+        )
+        assert not isinstance(element, tuple), (
+            "shrink result contains a nested tuple — CacheWrapper._shrink wrapping is broken"
+        )
+    assert inner.expand(result[0]) == k1
+    assert inner.expand(result[1]) == k2

--- a/tests/unit/config/test_cache_to_config.py
+++ b/tests/unit/config/test_cache_to_config.py
@@ -108,8 +108,8 @@ def test_cache_to_config_unknown_raises():
         def expand(self, key):
             raise KeyError(key)
 
-        def shrink(self, key):
-            raise KeyError(key)
+        def _shrink(self, *keys):
+            raise KeyError(keys[0])
 
         def _query(self, call):
             return iter([])


### PR DESCRIPTION
Implements the Template Method pattern for `shrink` across the `BaseCache` hierarchy, as suggested in #595.

`BaseCache.shrink` is now concrete and owns the empty-keys guard and single/tuple return-value unwrap. Subclasses implement the new abstract `_shrink(*keys) -> tuple[Digest, ...]` with only their partition logic.

Closes #595

Generated with [Claude Code](https://claude.ai/code)