### PR TITLE
feat(storage): add `intent` parameter to `_operation_context` (step 1 of #569)

### DIFF
--- a/src/fleche/storage/__init__.py
+++ b/src/fleche/storage/__init__.py
@@ -7,6 +7,7 @@ for backward compatibility with `from fleche.storage import ...` imports.
 from .base import (
     SaveError,
     AmbiguousDigestError,
+    Intent,
     KeyManagement,
     StorageBackend,
     ValueStorage,
@@ -26,6 +27,7 @@ from .thread_safe import SerializingMixin, PerKeyLockMixin
 __all__ = [
     "SaveError",
     "AmbiguousDigestError",
+    "Intent",
     "KeyManagement",
     "StorageBackend",
     "ValueStorage",

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -57,7 +57,7 @@ class KeyManagement(ABC):
     """
 
     @contextlib.contextmanager
-    def _operation_context(self, key: Digest | str):
+    def _operation_context(self, key: Digest | str, *, intent: str = "write"):
         """Context manager entered around every operation on ``key``.
 
         The base implementation is a no-op.  Override in a mixin to inject
@@ -68,13 +68,17 @@ class KeyManagement(ABC):
         resource (ignore the key) or per-key resources (e.g. a striped lock
         table or a key-specific file handle).
 
+        ``intent`` describes the kind of operation being performed.  Mixins
+        may use it to choose between exclusive and shared locks.  Currently
+        the only defined value is ``"write"`` (the default).
+
         **Composing multiple mixins**: use ``super()`` to chain so that every
         mixin in the MRO gets to wrap the operation::
 
             @contextlib.contextmanager
-            def _operation_context(self, key):
+            def _operation_context(self, key, *, intent="write"):
                 with self._lock:                   # this mixin's resource
-                    with super()._operation_context(key):
+                    with super()._operation_context(key, intent=intent):
                         yield
         """
         yield

--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 
 from abc import ABC, abstractmethod
+from enum import StrEnum
 from typing import Iterable, Any, Callable, Sequence, overload
 
 from ..digest import digest, Digest, DIGEST_LENGTH
@@ -17,6 +18,14 @@ class SaveError(Exception):
 
 class AmbiguousDigestError(ValueError):
     pass
+
+
+class Intent(StrEnum):
+    """Describes the kind of operation being performed on storage.
+
+    Mixins may use this to choose between exclusive and shared locks.
+    """
+    WRITE = "write"
 
 
 def _longest_common_prefix_length(s1: str, s2: str) -> int:
@@ -57,7 +66,7 @@ class KeyManagement(ABC):
     """
 
     @contextlib.contextmanager
-    def _operation_context(self, key: Digest | str, *, intent: str = "write"):
+    def _operation_context(self, key: Digest | str, *, intent: Intent = Intent.WRITE):
         """Context manager entered around every operation on ``key``.
 
         The base implementation is a no-op.  Override in a mixin to inject
@@ -70,13 +79,13 @@ class KeyManagement(ABC):
 
         ``intent`` describes the kind of operation being performed.  Mixins
         may use it to choose between exclusive and shared locks.  Currently
-        the only defined value is ``"write"`` (the default).
+        the only defined value is :attr:`Intent.WRITE` (the default).
 
         **Composing multiple mixins**: use ``super()`` to chain so that every
         mixin in the MRO gets to wrap the operation::
 
             @contextlib.contextmanager
-            def _operation_context(self, key, *, intent="write"):
+            def _operation_context(self, key, *, intent=Intent.WRITE):
                 with self._lock:                   # this mixin's resource
                     with super()._operation_context(key, intent=intent):
                         yield

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -214,9 +214,9 @@ class Sql(PerKeyLockMixin, CallStorage):
             self._local.session = None
 
     @contextlib.contextmanager
-    def _operation_context(self, key):
+    def _operation_context(self, key, *, intent: str = "write"):
         with self._session_context():
-            with super()._operation_context(key):
+            with super()._operation_context(key, intent=intent):
                 yield
 
     def _persist_call(self, call: DigestedCall, key: Digest) -> Digest:

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -5,7 +5,7 @@ import threading
 from typing import Iterable, Any, List
 from pathlib import Path
 from dataclasses import dataclass, field
-from .base import KeyManagement, CallStorage, _resolve_prefix
+from .base import Intent, KeyManagement, CallStorage, _resolve_prefix
 from .thread_safe import PerKeyLockMixin
 from ..call import DigestedCall, QueryCall
 from ..digest import Digest, DIGEST_LENGTH, digest
@@ -214,7 +214,7 @@ class Sql(PerKeyLockMixin, CallStorage):
             self._local.session = None
 
     @contextlib.contextmanager
-    def _operation_context(self, key, *, intent: str = "write"):
+    def _operation_context(self, key, *, intent: Intent = Intent.WRITE):
         with self._session_context():
             with super()._operation_context(key, intent=intent):
                 yield

--- a/src/fleche/storage/thread_safe.py
+++ b/src/fleche/storage/thread_safe.py
@@ -30,7 +30,7 @@ import threading
 import weakref
 from dataclasses import dataclass, field
 
-from .base import KeyManagement
+from .base import Intent, KeyManagement
 from ..digest import Digest
 
 
@@ -84,7 +84,7 @@ class SerializingMixin(KeyManagement):
     )
 
     @contextlib.contextmanager
-    def _operation_context(self, key, *, intent: str = "write"):
+    def _operation_context(self, key, *, intent: Intent = Intent.WRITE):
         with self._lock:
             with super()._operation_context(key, intent=intent):
                 yield
@@ -136,7 +136,7 @@ class PerKeyLockMixin(KeyManagement):
             return lock
 
     @contextlib.contextmanager
-    def _operation_context(self, key, *, intent: str = "write"):
+    def _operation_context(self, key, *, intent: Intent = Intent.WRITE):
         with self._get_key_lock(key):
             with super()._operation_context(key, intent=intent):
                 yield

--- a/src/fleche/storage/thread_safe.py
+++ b/src/fleche/storage/thread_safe.py
@@ -84,9 +84,9 @@ class SerializingMixin(KeyManagement):
     )
 
     @contextlib.contextmanager
-    def _operation_context(self, key):
+    def _operation_context(self, key, *, intent: str = "write"):
         with self._lock:
-            with super()._operation_context(key):
+            with super()._operation_context(key, intent=intent):
                 yield
 
 
@@ -136,8 +136,8 @@ class PerKeyLockMixin(KeyManagement):
             return lock
 
     @contextlib.contextmanager
-    def _operation_context(self, key):
+    def _operation_context(self, key, *, intent: str = "write"):
         with self._get_key_lock(key):
-            with super()._operation_context(key):
+            with super()._operation_context(key, intent=intent):
                 yield
 

--- a/tests/unit/storage/test_mixins.py
+++ b/tests/unit/storage/test_mixins.py
@@ -78,9 +78,9 @@ class _TrackingValueMemory(ValueMixin, MemoryBackend):
     _ctx_keys: list = field(default_factory=list, init=False, compare=False, repr=False)
 
     @contextlib.contextmanager
-    def _operation_context(self, key):
+    def _operation_context(self, key, *, intent="write"):
         self._ctx_keys.append(str(key))
-        with super()._operation_context(key):
+        with super()._operation_context(key, intent=intent):
             yield
 
 
@@ -89,9 +89,9 @@ class _TrackingCallMemory(CallMixin, MemoryBackend):
     _ctx_keys: list = field(default_factory=list, init=False, compare=False, repr=False)
 
     @contextlib.contextmanager
-    def _operation_context(self, key):
+    def _operation_context(self, key, *, intent="write"):
         self._ctx_keys.append(str(key))
-        with super()._operation_context(key):
+        with super()._operation_context(key, intent=intent):
             yield
 
 

--- a/tests/unit/storage/test_mixins.py
+++ b/tests/unit/storage/test_mixins.py
@@ -29,6 +29,7 @@ from fleche.digest import Digest, digest
 from fleche.storage.base import (
     AmbiguousDigestError,
     CallMixin,
+    Intent,
     StorageBackend,
     ValueMixin,
     _resolve_prefix,
@@ -78,7 +79,7 @@ class _TrackingValueMemory(ValueMixin, MemoryBackend):
     _ctx_keys: list = field(default_factory=list, init=False, compare=False, repr=False)
 
     @contextlib.contextmanager
-    def _operation_context(self, key, *, intent="write"):
+    def _operation_context(self, key, *, intent=Intent.WRITE):
         self._ctx_keys.append(str(key))
         with super()._operation_context(key, intent=intent):
             yield
@@ -89,7 +90,7 @@ class _TrackingCallMemory(CallMixin, MemoryBackend):
     _ctx_keys: list = field(default_factory=list, init=False, compare=False, repr=False)
 
     @contextlib.contextmanager
-    def _operation_context(self, key, *, intent="write"):
+    def _operation_context(self, key, *, intent=Intent.WRITE):
         self._ctx_keys.append(str(key))
         with super()._operation_context(key, intent=intent):
             yield

--- a/tests/unit/storage/test_operation_context.py
+++ b/tests/unit/storage/test_operation_context.py
@@ -17,9 +17,9 @@ def test_mixin_composition_chains_through_super():
 
     class TrackingMixin(SerializingMixin):
         @contextlib.contextmanager
-        def _operation_context(self, key):
+        def _operation_context(self, key, *, intent="write"):
             entered.append(key)
-            with super()._operation_context(key):
+            with super()._operation_context(key, intent=intent):
                 yield
 
     @dataclass(frozen=True)
@@ -47,9 +47,9 @@ def test_operation_context_wraps_evict_and_contains():
 
     class TrackingMixin(SerializingMixin):
         @contextlib.contextmanager
-        def _operation_context(self, key):
+        def _operation_context(self, key, *, intent="write"):
             called_with.append(("enter", str(key)[:4]))
-            with super()._operation_context(key):
+            with super()._operation_context(key, intent=intent):
                 yield
             called_with.append(("exit", str(key)[:4]))
 
@@ -67,3 +67,45 @@ def test_operation_context_wraps_evict_and_contains():
     called_with.clear()
     store.evict(key)
     assert any(e[0] == "enter" for e in called_with)
+
+
+def test_intent_default_is_write():
+    """The default intent passed to _operation_context is 'write'."""
+    intents_seen = []
+
+    class TrackingMixin(SerializingMixin):
+        @contextlib.contextmanager
+        def _operation_context(self, key, *, intent="write"):
+            intents_seen.append(intent)
+            with super()._operation_context(key, intent=intent):
+                yield
+
+    @dataclass(frozen=True)
+    class Tracked(TrackingMixin, _PlainValueMemory):
+        pass
+
+    store = Tracked(storage={})
+    store.save(1)
+    assert all(i == "write" for i in intents_seen)
+
+
+def test_intent_propagates_through_mixin_chain():
+    """intent is forwarded correctly through every layer in the MRO."""
+    collected = []
+
+    class OuterMixin(SerializingMixin):
+        @contextlib.contextmanager
+        def _operation_context(self, key, *, intent="write"):
+            collected.append(("outer", intent))
+            with super()._operation_context(key, intent=intent):
+                yield
+
+    @dataclass(frozen=True)
+    class Tracked(OuterMixin, _PlainValueMemory):
+        pass
+
+    store = Tracked(storage={})
+    with store._operation_context("k", intent="write"):
+        pass
+
+    assert collected == [("outer", "write")]

--- a/tests/unit/storage/test_operation_context.py
+++ b/tests/unit/storage/test_operation_context.py
@@ -3,7 +3,7 @@
 import contextlib
 from dataclasses import dataclass
 
-from fleche.storage import SerializingMixin, ValueMixin
+from fleche.storage import Intent, SerializingMixin, ValueMixin
 from fleche.storage.memory import MemoryBackend
 
 
@@ -17,7 +17,7 @@ def test_mixin_composition_chains_through_super():
 
     class TrackingMixin(SerializingMixin):
         @contextlib.contextmanager
-        def _operation_context(self, key, *, intent="write"):
+        def _operation_context(self, key, *, intent=Intent.WRITE):
             entered.append(key)
             with super()._operation_context(key, intent=intent):
                 yield
@@ -47,7 +47,7 @@ def test_operation_context_wraps_evict_and_contains():
 
     class TrackingMixin(SerializingMixin):
         @contextlib.contextmanager
-        def _operation_context(self, key, *, intent="write"):
+        def _operation_context(self, key, *, intent=Intent.WRITE):
             called_with.append(("enter", str(key)[:4]))
             with super()._operation_context(key, intent=intent):
                 yield
@@ -70,12 +70,12 @@ def test_operation_context_wraps_evict_and_contains():
 
 
 def test_intent_default_is_write():
-    """The default intent passed to _operation_context is 'write'."""
+    """The default intent passed to _operation_context is Intent.WRITE."""
     intents_seen = []
 
     class TrackingMixin(SerializingMixin):
         @contextlib.contextmanager
-        def _operation_context(self, key, *, intent="write"):
+        def _operation_context(self, key, *, intent=Intent.WRITE):
             intents_seen.append(intent)
             with super()._operation_context(key, intent=intent):
                 yield
@@ -86,7 +86,8 @@ def test_intent_default_is_write():
 
     store = Tracked(storage={})
     store.save(1)
-    assert all(i == "write" for i in intents_seen)
+    assert all(i == Intent.WRITE for i in intents_seen)
+    assert all(isinstance(i, Intent) for i in intents_seen)
 
 
 def test_intent_propagates_through_mixin_chain():
@@ -95,7 +96,7 @@ def test_intent_propagates_through_mixin_chain():
 
     class OuterMixin(SerializingMixin):
         @contextlib.contextmanager
-        def _operation_context(self, key, *, intent="write"):
+        def _operation_context(self, key, *, intent=Intent.WRITE):
             collected.append(("outer", intent))
             with super()._operation_context(key, intent=intent):
                 yield
@@ -105,7 +106,7 @@ def test_intent_propagates_through_mixin_chain():
         pass
 
     store = Tracked(storage={})
-    with store._operation_context("k", intent="write"):
+    with store._operation_context("k", intent=Intent.WRITE):
         pass
 
-    assert collected == [("outer", "write")]
+    assert collected == [("outer", Intent.WRITE)]


### PR DESCRIPTION
Adds `intent: str = "write"` (keyword-only) to `KeyManagement._operation_context` and all overriding implementations (`SerializingMixin`, `PerKeyLockMixin`, `Sql`).

This is step 1 of #569: pins the `intent` signature once at the storage layer. Currently the only defined value is "write", which is also the default, so all existing callers continue to work unchanged.

Generated with [Claude Code](https://claude.ai/code)