### PR TITLE
refactor(metadata): replace if/elif chain with @configurable decorator registry

### DIFF
--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -248,16 +248,10 @@ def load_default_metadata():
 
     meta_objects = []
     for name in meta_names:
-        if name == "Tags":
-            raise ValueError("Tags metadata cannot be configured from the config file.")
-        elif name == "Runtime":
-            meta_objects.append(metadata.Runtime())
-        elif name == "Environment":
-            meta_objects.append(metadata.Environment())
-        elif name == "Git":
-            meta_objects.append(metadata.Git())
-        else:
-            raise ValueError(f"Unknown metadata type in config: {name}")
+        cls = metadata.CONFIGURABLE.get(name)
+        if cls is None:
+            raise ValueError(f"Unknown or non-configurable metadata type in config: {name}")
+        meta_objects.append(cls())
 
     return tuple(meta_objects)
 

--- a/src/fleche/metadata.py
+++ b/src/fleche/metadata.py
@@ -65,16 +65,8 @@ class MetaData(ABC):
         """
         ...
 
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """
-        The unique name of this metadata type.
-
-        Returns:
-            str: The name of the metadata type.
-        """
-        ...
+    name: str
+    """The unique name of this metadata type."""
 
 
 CONFIGURABLE: dict[str, type["MetaData"]] = {}
@@ -87,12 +79,8 @@ def configurable(cls: type["MetaData"]) -> type["MetaData"]:
     ``CONFIGURABLE`` registry under ``cls.__name__``, making it selectable from
     the TOML ``[default] metadata = [...]`` list.  Classes that require
     constructor arguments (e.g. ``Tags``) must **not** be decorated.
-
-    ``__abstractmethods__`` is updated so that the class attribute set here
-    satisfies the abstract ``name`` property declared on ``MetaData``.
     """
     cls.name = cls.__name__.lower()
-    cls.__abstractmethods__ = cls.__abstractmethods__ - {"name"}
     CONFIGURABLE[cls.__name__] = cls
     return cls
 

--- a/src/fleche/metadata.py
+++ b/src/fleche/metadata.py
@@ -77,6 +77,27 @@ class MetaData(ABC):
         ...
 
 
+CONFIGURABLE: dict[str, type["MetaData"]] = {}
+
+
+def configurable(cls: type["MetaData"]) -> type["MetaData"]:
+    """Register a MetaData subclass as zero-arg configurable and set its name.
+
+    Sets ``cls.name`` to ``cls.__name__.lower()`` and adds the class to the
+    ``CONFIGURABLE`` registry under ``cls.__name__``, making it selectable from
+    the TOML ``[default] metadata = [...]`` list.  Classes that require
+    constructor arguments (e.g. ``Tags``) must **not** be decorated.
+
+    ``__abstractmethods__`` is updated so that the class attribute set here
+    satisfies the abstract ``name`` property declared on ``MetaData``.
+    """
+    cls.name = cls.__name__.lower()
+    cls.__abstractmethods__ = cls.__abstractmethods__ - {"name"}
+    CONFIGURABLE[cls.__name__] = cls
+    return cls
+
+
+@configurable
 class Runtime(MetaData):
     """Metadata type for capturing runtime information.
 
@@ -103,7 +124,6 @@ class Runtime(MetaData):
             'walltime': t - pre['timestart'],
         }
 
-    name: str = 'runtime'
     keys: dict[str, type] = {
             'timestart': float,
             'timestop': float,
@@ -111,6 +131,7 @@ class Runtime(MetaData):
     }
 
 
+@configurable
 class Environment(MetaData):
     """Metadata type for capturing the execution environment.
 
@@ -132,7 +153,6 @@ class Environment(MetaData):
             'python_version': platform.python_version(),
         }
 
-    name: str = 'environment'
     keys: dict[str, type] = {
             'hostname': str,
             'username': str,
@@ -156,6 +176,7 @@ def _git(*args: str) -> str | None:
     return result.stdout.strip()
 
 
+@configurable
 class Git(MetaData):
     """Metadata type for capturing the git state of the working directory.
 
@@ -183,7 +204,6 @@ class Git(MetaData):
             'dirty': bool(status) if status is not None else None,
         }
 
-    name: str = 'git'
     keys: dict[str, type] = {
             'root': str,
             'commit': str,

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -10,7 +10,7 @@ import pytest
 import fleche as fleche_pkg
 from fleche import fleche, cache, tags, project, meta
 from fleche.caches import Cache
-from fleche.metadata import Environment, Git, MetaData, Call
+from fleche.metadata import CONFIGURABLE, Environment, Git, MetaData, Runtime, Tags, Call, configurable
 from fleche.storage import ValueMemory, CallMemory
 
 
@@ -297,3 +297,29 @@ def test_metadata_default_methods():
 
     assert meta.pre(call) == {}
     assert meta.post({}, call) == {}
+
+
+def test_configurable_registry_contains_builtins():
+    assert CONFIGURABLE == {"Runtime": Runtime, "Environment": Environment, "Git": Git}
+
+
+def test_configurable_sets_name():
+    assert Runtime().name == "runtime"
+    assert Environment().name == "environment"
+    assert Git().name == "git"
+
+
+def test_configurable_decorator_registers_and_names():
+    @configurable
+    class MyMeta(MetaData):
+        keys: dict = {}
+
+    try:
+        assert MyMeta.name == "mymeta"
+        assert CONFIGURABLE.get("MyMeta") is MyMeta
+    finally:
+        CONFIGURABLE.pop("MyMeta", None)
+
+
+def test_tags_not_in_configurable():
+    assert Tags not in CONFIGURABLE.values()


### PR DESCRIPTION
Introduce a `configurable` class decorator in `metadata.py` that sets `cls.name` and registers the class in a `CONFIGURABLE` dict, replacing the closed if/elif chain in `config.load_default_metadata`.

Closes #593

Generated with [Claude Code](https://claude.ai/code)