### PR TITLE
docs: fix query.rst — use QueryCall, not Call, for cache().query()

### DIFF
--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -6,7 +6,7 @@ Overview
 Fleche lets you retrieve previously cached calls that "match" a template using the query method. You can query either:
 
 - From a function wrapper (recommended): ``myfunc.query(*args, metadata={...}, **kwargs)``
-- From the active cache directly via a Call template: ``cache().query(Call(...))``
+- From the active cache directly via a QueryCall template: ``cache().query(QueryCall(...))``
 
 When querying, any field in the template set to ``None`` acts as a wildcard. For arguments and result, values are compared using digest semantics (i.e., digest(template_value) == digest(stored_value)).
 


### PR DESCRIPTION
## Summary

- Line 9 of `docs/usage/query.rst` described the low-level query API as `cache().query(Call(...))`, but passing a `Call` object raises `AttributeError` at runtime.

## Root cause

`CallMixin.query()` (`src/fleche/storage/base.py`) iterates every stored key and calls `template.matches(call)` on each entry:

```python
def query(self, template: QueryCall) -> Iterable[DigestedCall]:
    for key in self.list():
        call = self.load(key)
        if template.matches(call):   # <-- only QueryCall has .matches()
            yield call
```

`Call` has no `.matches()` method — only `QueryCall` does. Passing a plain `Call` always raises:

```
AttributeError: 'Call' object has no attribute 'matches'
```

## Fix

Changed the example in the "Overview" bullet from `cache().query(Call(...))` to `cache().query(QueryCall(...))`, matching the actual type signature and the `QueryCall` example already shown later in the same page.

## Test plan

- [ ] Verify the corrected example runs without error using `QueryCall` from `fleche.call`
- [ ] Confirm `Call` still has no `.matches()` method in `src/fleche/call.py`

https://claude.ai/code/session_01EnWhGHkpo8xdgrXJbQuggw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnWhGHkpo8xdgrXJbQuggw)_