### PR TITLE
docs: fix configuration.rst — XDG fallback is unconditional, not conditional

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -4,9 +4,10 @@ Configuration
 ``fleche`` discovers configuration by walking the filesystem from the
 current working directory upward, collecting every ``fleche.toml`` it
 encounters.  The walk stops at ``$HOME`` (inclusive) or at the filesystem
-root, whichever comes first.  If ``$XDG_CONFIG_HOME`` is set,
-``$XDG_CONFIG_HOME/fleche/cache.toml`` is appended as a final
-lowest-priority layer.
+root, whichever comes first.  ``$XDG_CONFIG_HOME/fleche/cache.toml`` is
+then appended as a final lowest-priority layer, defaulting to
+``~/.config/fleche/cache.toml`` when ``$XDG_CONFIG_HOME`` is unset or
+empty (per the XDG base directory spec).
 
 All discovered files are **shallow-merged** at the top level: files closer
 to the current directory win, and a closer file's top-level table fully


### PR DESCRIPTION
## Summary

- `docs/storage/configuration.rst` lines 7-9 stated that `$XDG_CONFIG_HOME/fleche/cache.toml` is appended "If `$XDG_CONFIG_HOME` is set". The actual code always appends a config path in this position, falling back to `~/.config/fleche/cache.toml` when `$XDG_CONFIG_HOME` is unset — per the XDG base directory specification.

## Root cause

`src/fleche/config.py` `_collect_config_paths()` contains:

```python
xdg_base = os.environ.get("XDG_CONFIG_HOME") or (
    str(home / ".config") if home is not None else ""
)
```

The `or` fallback means `~/.config` is used when `$XDG_CONFIG_HOME` is absent or empty. The file `~/.config/fleche/cache.toml` is therefore always a candidate — not only when `$XDG_CONFIG_HOME` is explicitly set.

## Fix

Rewrote the sentence to accurately describe both cases:

> `$XDG_CONFIG_HOME/fleche/cache.toml` is then appended as a final lowest-priority layer, defaulting to `~/.config/fleche/cache.toml` when `$XDG_CONFIG_HOME` is unset or empty (per the XDG base directory spec).

## Test plan

- [ ] Unset `$XDG_CONFIG_HOME`, place a config at `~/.config/fleche/cache.toml`, and confirm fleche picks it up
- [ ] Set `$XDG_CONFIG_HOME=/tmp/xdg`, place a config at `/tmp/xdg/fleche/cache.toml`, and confirm fleche uses that path instead

https://claude.ai/code/session_01EnWhGHkpo8xdgrXJbQuggw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnWhGHkpo8xdgrXJbQuggw)_