### PR TITLE
docs: fix ssh_cache.rst diagram — update CLI command to post-PR#597 form

### DIFF
--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -114,11 +114,11 @@ One :class:`~fleche.remote.SshCache` owns exactly one
    call│    │return                      query / evict / info
        ▼    │
    ┌──────────────────────┐                ┌─────────────────────┐
-   │_SshConnection        │ (stdin) req ─▶ │ python -m           │
+   │_SshConnection        │──(stdin) req──>│ python -m           │
    │                      │                │   fleche remote     │
-   │ ssh host             │◀─(stdout) resp │   --serve           │
+   │ ssh host             │<─(stdout) resp─│   --serve           │
    │ python -m fleche     │                │                     │
-   │ remote --serve       │◀─(stderr) lines│   serve(...) loop   │
+   │ remote --serve       │<─(stderr) lines│   serve(...) loop   │
    └──────────────────────┘                └─────────────────────┘
        │
        │ stderr drained by a daemon thread

--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -113,14 +113,13 @@ One :class:`~fleche.remote.SshCache` owns exactly one
        │    ▲                            contains / expand / shrink /
    call│    │return                      query / evict / info
        ▼    │
-   ┌──────────────┐                        ┌─────────────────────┐
-   │_SshConnection│   (stdin) request   ─▶ │ python -m           │
-   │              │                        │   fleche.remote     │
-   │ ssh host     │ ◀─ (stdout) response   │   --serve           │
-   │ python -m    │                        │                     │
-   │ fleche.remote│ ◀─ (stderr) lines      │   serve(...) loop   │
-   │ --serve      │                        └─────────────────────┘
-   └──────────────┘
+   ┌──────────────────────┐                ┌─────────────────────┐
+   │_SshConnection        │ (stdin) req ─▶ │ python -m           │
+   │                      │                │   fleche remote     │
+   │ ssh host             │◀─(stdout) resp │   --serve           │
+   │ python -m fleche     │                │                     │
+   │ remote --serve       │◀─(stderr) lines│   serve(...) loop   │
+   └──────────────────────┘                └─────────────────────┘
        │
        │ stderr drained by a daemon thread
        ▼


### PR DESCRIPTION
## Summary

- The process layout diagram in `docs/dev/ssh_cache.rst` (both the client box and the server box) showed the old `python -m fleche.remote --serve` invocation (dotted module path). PR #597 introduced `src/fleche/__main__.py` as a CLI dispatcher, changing the correct invocation to `python -m fleche remote --serve` (space-separated subcommand).

## Root cause

After PR #597, `src/fleche/remote.py` `_build_command()` constructs:

```python
server_argv = [self._python, "-m", "fleche", "remote", "--serve"]
```

The diagram was not updated to match. The setup-commands section of the same file already had the correct `exec <python> -m fleche remote --serve` form, so only the ASCII process layout diagram was stale.

Running the old `python -m fleche.remote --serve` form on a server with PR #597 would raise a `runpy` double-import warning and may fail depending on how the module is structured.

## Fix

Updated the ASCII diagram to show `python -m fleche remote --serve` in both boxes (left: SSH client subprocess command; right: remote server process label). The left box was widened slightly to accommodate the longer command on two lines.

## Test plan

- [ ] Confirm `src/fleche/remote.py` `_build_command()` still uses `["-m", "fleche", "remote", "--serve"]`
- [ ] Confirm `src/fleche/__main__.py` handles the `remote --serve` subcommand

https://claude.ai/code/session_01EnWhGHkpo8xdgrXJbQuggw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnWhGHkpo8xdgrXJbQuggw)_