### PR TITLE
Add fast smoke-test set touching each optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ package-dir = {""  = "src"}
 version_file = "src/fleche/_version.py"
 fallback_version = "0.0.0"
 
+[tool.pytest.ini_options]
+markers = [
+    "smoke: minimal, fast tests touching each optional dependency end-to-end (run with `pytest -m smoke`) — intended as a pre-release sanity check of the packaged distribution.",
+]
+
 [project]
 name = "fleche"
 dynamic = ["version"]

--- a/tests/smoke/test_optional_deps.py
+++ b/tests/smoke/test_optional_deps.py
@@ -124,16 +124,3 @@ def test_attrs():
         assert norm(Point(1, 2)) == 3
 
     assert calls == [Point(1, 2)], "attrs arg should hash to a cache hit"
-
-
-def test_executorlib():
-    """executorlib's executor accepts and runs a fleche-decorated function."""
-    pytest.importorskip("executorlib")
-    from executorlib import SingleNodeExecutor
-
-    @fleche()
-    def double(x):
-        return x * 2
-
-    with SingleNodeExecutor() as executor:
-        assert executor.submit(double, 21).result() == 42

--- a/tests/smoke/test_optional_deps.py
+++ b/tests/smoke/test_optional_deps.py
@@ -1,0 +1,139 @@
+"""Smoke tests touching each optional dependency.
+
+This is a deliberately tiny, fast test set whose sole purpose is to confirm
+that every *optional* dependency is importable **and** minimally functional
+end-to-end — i.e. that a value can make a full round-trip through the backend
+(or code path) that the dependency powers.  It is intended as a pre-release
+sanity check for the packaged (e.g. conda) distribution, where you install the
+package together with all of its extras and run::
+
+    pytest -m smoke
+
+Each test is marked ``smoke`` so the whole set can be selected with the marker.
+Each dependency is loaded with :func:`pytest.importorskip`, so the set runs
+against whatever happens to be installed and *skips* (rather than errors) on a
+genuinely absent dependency — when run in an environment with all extras
+present, every test should execute, and a dependency that is installed but
+broken will fail loudly.
+"""
+
+import pytest
+
+from fleche import fleche, cache
+from fleche.caches import Cache
+from fleche.storage import ValueMemory, CallMemory
+
+pytestmark = pytest.mark.smoke
+
+
+def _assert_roundtrip(c):
+    """Run a decorated function twice through cache *c*; assert it round-trips.
+
+    The function records every real execution in a list; a working cache means
+    the second invocation is served from storage and the body does not run
+    again, while still returning the correct value.
+    """
+    calls = []
+
+    @fleche()
+    def add(x, y):
+        calls.append((x, y))
+        return x + y
+
+    with cache(c):
+        assert add(2, 3) == 5  # miss -> computed + stored
+        assert add(2, 3) == 5  # hit  -> loaded from backend
+
+    assert calls == [(2, 3)], "second call should have been served from cache"
+
+
+def test_cloudpickle(tmp_path):
+    """cloudpickle-serialised file backend round-trips a value."""
+    pytest.importorskip("cloudpickle")
+    from fleche.storage import ValuePickleFile, CallPickleFile
+
+    _assert_roundtrip(
+        Cache(
+            ValuePickleFile.with_cloudpickle(root=tmp_path / "values"),
+            CallPickleFile.with_cloudpickle(root=tmp_path / "calls"),
+        )
+    )
+
+
+def test_dill(tmp_path):
+    """dill-serialised file backend round-trips a value."""
+    pytest.importorskip("dill")
+    from fleche.storage import ValuePickleFile, CallPickleFile
+
+    _assert_roundtrip(
+        Cache(
+            ValuePickleFile.with_dill(root=tmp_path / "values"),
+            CallPickleFile.with_dill(root=tmp_path / "calls"),
+        )
+    )
+
+
+def test_sqlalchemy(tmp_path):
+    """SQLAlchemy calls backend round-trips a call record."""
+    pytest.importorskip("sqlalchemy")
+    from fleche.storage import Sql
+
+    # Sql stores call records only; values live in memory for this round-trip.
+    _assert_roundtrip(
+        Cache(ValueMemory({}), Sql(f"sqlite:///{tmp_path / 'calls.db'}"))
+    )
+
+
+def test_bagofholding(tmp_path):
+    """bagofholding (HDF5) backend round-trips a value."""
+    pytest.importorskip("bagofholding")
+    from fleche.storage import ValueBagOfHoldingH5File, CallBagOfHoldingH5File
+
+    _assert_roundtrip(
+        Cache(
+            ValueBagOfHoldingH5File(root=tmp_path / "values"),
+            CallBagOfHoldingH5File(root=tmp_path / "calls"),
+        )
+    )
+
+
+def test_attrs():
+    """attrs instances are digestible and usable as cache-key arguments."""
+    pytest.importorskip("attr")
+    import attrs
+
+    from fleche.digest import digest
+
+    @attrs.define(frozen=True)
+    class Point:
+        x: int
+        y: int
+
+    # The attrs-class digest path must produce a stable key.
+    assert digest(Point(1, 2)) == digest(Point(1, 2))
+
+    calls = []
+
+    @fleche()
+    def norm(p):
+        calls.append(p)
+        return p.x + p.y
+
+    with cache(Cache(ValueMemory({}), CallMemory({}))):
+        assert norm(Point(1, 2)) == 3
+        assert norm(Point(1, 2)) == 3
+
+    assert calls == [Point(1, 2)], "attrs arg should hash to a cache hit"
+
+
+def test_executorlib():
+    """executorlib's executor accepts and runs a fleche-decorated function."""
+    pytest.importorskip("executorlib")
+    from executorlib import SingleNodeExecutor
+
+    @fleche()
+    def double(x):
+        return x * 2
+
+    with SingleNodeExecutor() as executor:
+        assert executor.submit(double, 21).result() == 42


### PR DESCRIPTION
## Summary

Adds a tiny, fast test set that touches each **optional** dependency end-to-end, intended as a pre-release sanity check for the packaged (e.g. conda) distribution.

- New `tests/smoke/test_optional_deps.py` with one minimal test per optional dependency:
  - **cloudpickle** — value round-trips through the cloudpickle file backend
  - **dill** — value round-trips through the dill file backend
  - **sqlalchemy** — call record round-trips through the `Sql` calls backend
  - **bagofholding** — value round-trips through the HDF5 backend
  - **attrs** — attrs instances are digestible and usable as cache-key arguments
- Each test drives a real `@fleche` + `cache()` round-trip and asserts the second call is served from the backend (the body does not re-run), so it verifies the dependency is genuinely *functional*, not merely importable.
- Registers a `smoke` pytest marker in `pyproject.toml` so the whole set is selectable with `pytest -m smoke`.
- Tests use `pytest.importorskip`, so the set runs against whatever is installed and skips genuinely-absent deps; in a full-extras environment every test executes, and an installed-but-broken dependency fails loudly.

`executorlib` is intentionally **not** covered — it is not advertised in the conda package.

## Usage

```bash
pytest -m smoke
```

## Test plan

- `pip install -e ".[tests]"` → `pytest -m smoke` → **5 passed in ~0.8s**.
- Genuinely-absent deps **skip** rather than error.
- Marker is registered (no `PytestUnknownMarkWarning`).

https://claude.ai/code/session_01Gf3XS1haG6Jb9ot5CEukj5