### PR TITLE
docs: require Conventional Commits in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,16 @@ issue or PR.
 
 When you cannot complete a task or question because you are missing dependencies fail early and report the errors.
 
+## Commit messages
+
+Always write commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+format (`<type>[optional scope]: <description>`, e.g. `feat:`, `fix:`, `docs:`,
+`test:`, `chore:`, `refactor:`). This repo's releases are driven by
+**release-please**, which derives version bumps and changelog entries from the
+conventional-commit history on `main` — non-conforming messages are ignored by
+the release tooling. Use `!` after the type/scope (or a `BREAKING CHANGE:`
+footer) for breaking changes.
+
 ## Commit attribution
 
 When running inside a GitHub Action, the workflow may be authenticated with a


### PR DESCRIPTION
## Summary

Adds a **Commit messages** section to `AGENTS.md` instructing agents to always use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.

This makes explicit what the repo already depends on: releases are driven by **release-please**, which derives version bumps and changelog entries from conventional-commit history on `main`. Non-conforming messages are silently ignored by the release tooling, so codifying the convention keeps the changelog and version bumps accurate.

The section covers the `<type>[scope]: <description>` shape, common types (`feat`, `fix`, `docs`, `test`, `chore`, `refactor`), and how to signal breaking changes (`!` or a `BREAKING CHANGE:` footer).

## Test plan

Docs-only change — no code affected.

https://claude.ai/code/session_01Gf3XS1haG6Jb9ot5CEukj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gf3XS1haG6Jb9ot5CEukj5)_