### PR TITLE
ci: restore standalone pypi-publish workflow for manual releases

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,25 @@
+on:
+  release:
+    types: [published]
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fleche
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    # retrieve your distributions here
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build
+      shell: bash
+      run: |
+        pip install build
+        python -m build --sdist
+    - name: pypi-publish
+      uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
## Summary

Restores the standalone `.github/workflows/pypi-publish.yml` workflow that was folded into `release-please.yml` in 638bc76 ("ci: chain pypi publish to release-please job"), so **manual** releases are easy again: publishing a GitHub Release builds the sdist and uploads it to PyPI via trusted publishing.

The restored workflow is identical to the original — it triggers on `release: published` and uses PyPI trusted publishing (`id-token: write`, `pypi` environment).

## Why this doesn't double-publish

`release-please` is left **completely unchanged**:

- It creates releases with `GITHUB_TOKEN`, which (per 638bc76's own commit message) does **not** fire the `release.published` event — so the restored workflow won't trigger on release-please's automated releases.
- release-please continues to publish those automated releases via its own chained `publish` job in `release-please.yml`.

The two paths are mutually exclusive by trigger:

| Path | Trigger | Publisher |
|------|---------|-----------|
| Automated (release-please) | push to `main` + `release_created` | `publish` job in `release-please.yml` |
| Manual (publish a GitHub Release) | `release: published` | restored `pypi-publish.yml` |

## Test plan

- CI-config-only change.
- Manual release flow: create/publish a GitHub Release for a tag → `pypi-publish.yml` builds the tagged sdist and uploads to PyPI.

https://claude.ai/code/session_01Gf3XS1haG6Jb9ot5CEukj5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gf3XS1haG6Jb9ot5CEukj5)_