### PR TITLE
docs: add conda-forge installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ A persistent caching solution for arbitrary Python functions - like `lru_cache` 
 pip install fleche
 ```
 
+### With conda
+
+`fleche` is available on [conda-forge](https://conda-forge.org/). Two packages are
+published:
+
+- **`fleche-base`** — the core library only (no optional dependencies)
+- **`fleche`** — the full install, which also pulls in the optional dependencies
+
+```bash
+# Core library only
+conda install -c conda-forge fleche-base
+
+# Full install with all optional dependencies
+conda install -c conda-forge fleche
+```
+
 ### With Optional Dependencies
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,12 +62,18 @@ pip install fleche[bagofholding]
 # For SshCache (sharing caches across machines over SSH) — requires cloudpickle
 pip install fleche[ssh]
 
+# For running cached calls through executorlib executors
+pip install fleche[executorlib]
+
 # For documentation
 pip install fleche[docs]
 
 # For development and testing
 pip install fleche[tests]
 ```
+
+See the [Optional dependencies](https://fleche.readthedocs.io/en/latest/installation.html#optional-dependencies)
+section of the docs for a full table of extras and the features they enable.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ published:
 
 - **`fleche-base`** — the core library only (no optional dependencies)
 - **`fleche`** — the full install, which also pulls in the optional dependencies
+  (`cloudpickle`, `dill`, `sqlalchemy`, and `bagofholding`), enabling the SQL,
+  SSH, alternate-serialization, and Bagofholding features out of the box
 
 ```bash
 # Core library only

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,9 @@ Installing with conda
 packages are published:
 
 * ``fleche-base`` -- the core library only (no optional dependencies).
-* ``fleche`` -- the full install, which also pulls in the optional dependencies.
+* ``fleche`` -- the full install, which also pulls in the optional dependencies
+  (``cloudpickle``, ``dill``, ``sqlalchemy`` and ``bagofholding``), enabling the
+  SQL, SSH, alternate-serialization and Bagofholding features out of the box.
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,6 +27,60 @@ packages are published:
    # Full install with all optional dependencies
    conda install -c conda-forge fleche
 
+Optional dependencies
+---------------------
+
+The core install is deliberately lean. Extra features are gated behind optional
+dependencies, exposed as pip *extras*. Install one or more by listing them in
+brackets, e.g. ``pip install "fleche[sqlalchemy,ssh]"``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 30 52
+
+   * - Extra
+     - Install
+     - Enables
+   * - ``cloudpickle``
+     - ``pip install "fleche[cloudpickle]"``
+     - The ``cloudpickle`` serializer for the file backend
+       (``PickleFileBackend.with_cloudpickle``); also the wire protocol used by
+       SSH caches.
+   * - ``dill``
+     - ``pip install "fleche[dill]"``
+     - The ``dill`` serializer for the file backend
+       (``PickleFileBackend.with_dill``).
+   * - ``sqlalchemy``
+     - ``pip install "fleche[sqlalchemy]"``
+     - The SQL call-storage backend (``type = "sql"``) via SQLAlchemy --
+       SQLite, PostgreSQL, MySQL and any other SQLAlchemy-supported database.
+   * - ``bagofholding``
+     - ``pip install "fleche[bagofholding]"``
+     - The HDF5 storage backend (``type = "bagofholding_hdf"``).
+   * - ``ssh``
+     - ``pip install "fleche[ssh]"``
+     - :class:`~fleche.remote.SshCache`, which forwards a whole cache to a
+       remote host over SSH. Pulls in ``cloudpickle`` (its wire protocol), so
+       it is required rather than optional.
+   * - ``executorlib``
+     - ``pip install "fleche[executorlib]"``
+     - Running cached calls through `executorlib
+       <https://executorlib.readthedocs.io/>`_ executors for cluster/parallel
+       execution (see :doc:`parallel_execution`).
+   * - ``docs``
+     - ``pip install "fleche[docs]"``
+     - The packages needed to build this documentation (see below).
+   * - ``tests``
+     - ``pip install "fleche[tests]"``
+     - The full test suite plus every optional backend it exercises.
+
+.. note::
+
+   The conda-forge ``fleche`` metapackage covers the ``cloudpickle``, ``dill``,
+   ``sqlalchemy``, ``bagofholding`` and ``ssh`` features in one install. The
+   ``executorlib``, ``docs`` and ``tests`` extras are pip-only -- install
+   ``executorlib`` from conda-forge separately if you need it.
+
 Installing documentation (optional)
 -----------------------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,6 +8,23 @@ Normal installation
 
    pip install fleche
 
+Installing with conda
+---------------------
+
+``fleche`` is also available on `conda-forge <https://conda-forge.org/>`_. Two
+packages are published:
+
+* ``fleche-base`` -- the core library only (no optional dependencies).
+* ``fleche`` -- the full install, which also pulls in the optional dependencies.
+
+.. code-block:: bash
+
+   # Core library only
+   conda install -c conda-forge fleche-base
+
+   # Full install with all optional dependencies
+   conda install -c conda-forge fleche
+
 Installing documentation (optional)
 -----------------------------------
 


### PR DESCRIPTION
## Summary

Now that the `fleche` and `fleche-base` conda packages are published on conda-forge, this updates the docs to point users there.

- **`fleche-base`** — core library only (no optional dependencies)
- **`fleche`** — full install, which also pulls in the optional dependencies

## Changes

- `README.md`: new "With conda" subsection under Installation
- `docs/installation.rst`: new "Installing with conda" section

Both show:
```bash
# Core library only
conda install -c conda-forge fleche-base

# Full install with all optional dependencies
conda install -c conda-forge fleche
```

https://claude.ai/code/session_01BGe3o5E26TpaXz9S9sJaHh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGe3o5E26TpaXz9S9sJaHh)_