### PR TITLE
perf: avoid double H5Bag file open on load

### DIFF
--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -39,9 +39,13 @@ class BagOfHoldingH5FileBackend(FileStorage):
 
     def _from_file(self, path: Path) -> Any:
         try:
+            # _skip_load=True skips the constructor's _load_existing_bag_info() call,
+            # which would otherwise open and close the file just to read bag metadata
+            # before load() opens it a second time to read the actual payload.
+            bag = H5Bag(path, _skip_load=True)
             if self.version_validator is not None:
-                return H5Bag(path).load(version_validator=self.version_validator)
-            return H5Bag(path).load()
+                return bag.load(version_validator=self.version_validator)
+            return bag.load()
         except FileNotFoundError:
             raise KeyError(path) from None
         except OSError as e:
@@ -58,7 +62,7 @@ class BagOfHoldingH5FileBackend(FileStorage):
             path = self._path(key)
             with self._operation_context(key):
                 try:
-                    value = H5Bag(path).load(version_validator=version_validator)
+                    value = H5Bag(path, _skip_load=True).load(version_validator=version_validator)
                     H5Bag.save(value, path)
                 except OSError as e:
                     logger.warning("Failed to rebag %s: %s", key, e)

--- a/tests/unit/storage/test_bagofholding_file.py
+++ b/tests/unit/storage/test_bagofholding_file.py
@@ -106,6 +106,42 @@ def test_rebag_skips_oserror(tmp_path, monkeypatch, caplog):
     assert "Failed to rebag" in caplog.text
 
 
+def test_from_file_passes_skip_load_to_h5bag(tmp_path, monkeypatch):
+    """_from_file must pass _skip_load=True so the file is opened only once per get."""
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.return_value = 7
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    key = Digest("skip_load_key")
+    s.get(key)
+
+    _, kwargs = mock_h5bag.call_args
+    assert kwargs.get("_skip_load") is True
+
+
+def test_rebag_passes_skip_load_to_h5bag(tmp_path, monkeypatch):
+    """rebag must pass _skip_load=True so the file is opened only once per entry."""
+    pytest.importorskip("bagofholding")
+    import fleche.storage.bagofholding_file as boh_mod
+
+    mock_h5bag = MagicMock()
+    mock_h5bag.return_value.load.return_value = 1
+    monkeypatch.setattr(boh_mod, "H5Bag", mock_h5bag)
+
+    s = BagOfHoldingH5FileBackend(tmp_path)
+    key = Digest("rebag_skip_load_key")
+    s._path(key).write_bytes(b"dummy")
+
+    s.rebag()
+
+    _, kwargs = mock_h5bag.call_args
+    assert kwargs.get("_skip_load") is True
+
+
 def test_rebag_default_validator_is_none(tmp_path, monkeypatch):
     pytest.importorskip("bagofholding")
     import fleche.storage.bagofholding_file as boh_mod


### PR DESCRIPTION
## Summary

- `H5Bag.__init__` eagerly calls `_unpack_bag_info()` when the file already exists, opening and closing the HDF5 file to read bag metadata. The subsequent `H5Bag.load()` then opens it a second time to read the actual payload — two `openat` syscalls per load where one would do.
- Fix: pass `_skip_load=True` in `_from_file` and `rebag`, available since bagofholding 0.1.12, which skips the constructor's metadata read. The load call itself validates the bag info, so no correctness is lost.

Closes #527 (hot-spot #3).

## Benchmark (1000-element float64 numpy array, 200 reps)

| | µs/load |
|---|---|
| `H5Bag(_skip_load=False)` (old) | 826 |
| `H5Bag(_skip_load=True)` (new) | 531 |
| `ValueBagOfHoldingH5File` via storage (branch) | 755 |
| `PickleFile` reference | 105 |

The fix gives ~1.56× speedup on the raw H5Bag call and narrows the gap to PickleFile from 7.9× to 5.1×. The remaining gap is intrinsic HDF5 format overhead, unaffected by this change.

## Test plan

- [ ] Existing storage tests pass
- [ ] Strace confirms single `O_RDONLY` per load (see PR comment)