### PR TITLE
test: cover python -m fleche CLI dispatcher (0% → 81%)

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,55 @@
+"""Unit tests for the ``python -m fleche`` CLI dispatcher in :mod:`fleche.__main__`.
+
+The integration tests in ``tests/integration/test_remote.py`` exercise the
+dispatcher end-to-end via a real subprocess, but coverage of ``__main__.py``
+itself does not propagate out of that subprocess.  These tests drive
+``_main`` in-process so the argument parsing and branch dispatching are
+recorded by the parent coverage run.
+"""
+
+import pytest
+
+import fleche.remote
+from fleche.__main__ import _main
+
+
+def test_main_serve_dispatches_to_run_server_with_default_cache(monkeypatch):
+    """Without ``--cache``, the dispatcher forwards ``cache_name=None`` and
+    returns the server's exit code."""
+    received = []
+    monkeypatch.setattr(
+        fleche.remote, "_run_server", lambda cache_name: received.append(cache_name) or 0
+    )
+
+    rc = _main(["remote", "--serve"])
+
+    assert rc == 0
+    assert received == [None]
+
+
+def test_main_serve_forwards_named_cache(monkeypatch):
+    """``--cache NAME`` is parsed and threaded through to ``_run_server``."""
+    received = []
+    monkeypatch.setattr(
+        fleche.remote, "_run_server", lambda cache_name: received.append(cache_name) or 0
+    )
+
+    rc = _main(["remote", "--serve", "--cache", "mycache"])
+
+    assert rc == 0
+    assert received == ["mycache"]
+
+
+def test_main_remote_without_serve_errors():
+    """``remote`` without ``--serve`` exits with the argparse error code (2)
+    rather than silently no-oping."""
+    with pytest.raises(SystemExit) as excinfo:
+        _main(["remote"])
+    assert excinfo.value.code == 2
+
+
+def test_main_missing_subcommand_errors():
+    """A bare invocation with no subcommand fails parsing (required=True)."""
+    with pytest.raises(SystemExit) as excinfo:
+        _main([])
+    assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary

Coverage audit on `main` flagged `src/fleche/__main__.py` as the lowest-covered module — fully untested (0% line, 0% branch). The integration tests in `tests/integration/test_remote.py` invoke `python -m fleche remote --serve` as a subprocess so they exercise the dispatcher in production form, but subprocess coverage doesn't propagate to the parent run, leaving the CLI parser and dispatch code unmeasured.

This PR adds `tests/unit/test_main.py` with four orthogonal in-process tests that call `_main(argv)` directly:

1. **`test_main_serve_dispatches_to_run_server_with_default_cache`** — covers the happy path (`remote --serve`); monkeypatches `fleche.remote._run_server` to verify it receives `cache_name=None` and that its return code is propagated.
2. **`test_main_serve_forwards_named_cache`** — exercises the `--cache NAME` branch by asserting the parsed name is threaded through.
3. **`test_main_remote_without_serve_errors`** — covers the explicit `parser.error("nothing to do…")` branch (`SystemExit(2)`).
4. **`test_main_missing_subcommand_errors`** — covers argparse's `required=True` subparser path on a bare `[]` invocation.

Each test exercises one decision point, so dropping any one of them leaves a distinct branch uncovered.

## Coverage report

Baseline (`coverage run --source=src/fleche --branch -m pytest tests/`) — only the modules at or below 90% line/branch coverage:

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__main__.py                       21     21      6      0     0%
src/fleche/__init__.py                       13      3      2      1    73%
src/fleche/remote.py                        376     77     98      9    78%
src/fleche/_attrs.py                         12      2      0      0    83%
...
TOTAL                                      2693    173    802     49    93%
```

After this PR (running just the new file):

```
Name                     Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------
src/fleche/__main__.py      21      3      6      2    81%   52-53, 57
```

`__main__.py` goes from **0% → 81%**. The three residual lines are:
- **52-53** — `parser.error(f"unknown command: {args.command!r}")`. Dead code: `add_subparsers(required=True)` means argparse rejects unknown commands before this branch can be reached. Could be removed in a follow-up, but I kept it as defensive scaffolding (the file's docstring says "Register additional subcommands by adding a parser…and a branch in `_main`", implying the maintainer intends the branch to remain).
- **57** — `if __name__ == "__main__": raise SystemExit(_main(sys.argv[1:]))`. Only fires when the module is invoked via `runpy`, which would require a subprocess — that's exactly what the existing integration tests already do (without parent-process coverage).

## Test plan

- [x] `pytest tests/unit/test_main.py -v` — 4 passed
- [x] Full suite still passes (`pytest tests/` ran clean on baseline; the new file is additive, no edits to existing tests/code)
- [x] `coverage report --include="src/fleche/__main__.py"` after the new tests reports 81% line + branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01HaB7qPdCF2HcNxLw6XtfVc)_