### PR TITLE
feat(cache): BaseCache(OperationContext) + PerKeyLockMixin on Cache (steps 4-5 of #569)

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -264,9 +264,6 @@ def _combine_shrink(key: "Digest | str", results: "Iterable[Digest]") -> "Digest
 class Cache(PerKeyLockMixin, BaseCache):
     values: storage.ValueStorage
     calls: storage.CallStorage
-    # Identity hash: values/calls storages may carry unhashable dict fields
-    # (e.g. MemoryBackend.storage), mirroring ValueMemory/CallMemory convention.
-    __hash__ = object.__hash__
 
     def load_value(self, key):
         with self._operation_context(key):

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -10,8 +10,9 @@ import pandas as pd
 from . import digest as _digest
 from .digest import Digest  # type hint convenience
 from . import storage
-from .storage.base import _longest_common_prefix_length
+from .storage.base import _longest_common_prefix_length, OperationContext
 from .storage.destructuring import HasChildDigests
+from .storage.thread_safe import PerKeyLockMixin
 from .call import Call, DigestedCall, LazyCall, QueryCall
 from . import call
 from . import query
@@ -30,7 +31,7 @@ DigestedIterable = storage.destructuring.DigestedIterable
 DigestedDict = storage.destructuring.DigestedDict
 
 
-class BaseCache(ABC):
+class BaseCache(OperationContext):
 
     @abstractmethod
     def save(self, call: Call) -> str:
@@ -260,34 +261,43 @@ def _combine_shrink(key: "Digest | str", results: "Iterable[Digest]") -> "Digest
 
 
 @dataclass(frozen=True)
-class Cache(BaseCache):
+class Cache(PerKeyLockMixin, BaseCache):
     values: storage.ValueStorage
     calls: storage.CallStorage
+    # Identity hash: values/calls storages may carry unhashable dict fields
+    # (e.g. MemoryBackend.storage), mirroring ValueMemory/CallMemory convention.
+    __hash__ = object.__hash__
 
     def load_value(self, key):
-        return self.values.load(key)
+        with self._operation_context(key):
+            return self.values.load(key)
 
     def save(self, call: Call) -> str:
-        try:
-            digested = call.stash(self.values)
-        except storage.SaveError as e:
-            raise Rejected(e)
-        return self.calls.save(digested)
+        key = call.to_lookup_key()
+        with self._operation_context(key):
+            try:
+                digested = call.stash(self.values)
+            except storage.SaveError as e:
+                raise Rejected(e)
+            return self.calls.save(digested)
 
     def load(self, key: str) -> LazyCall:
-        return self.calls.load(key).fetch(self)
+        with self._operation_context(key):
+            return self.calls.load(key).fetch(self)
 
     def contains(self, key: str) -> bool:
-        return self.calls.contains(key)
+        with self._operation_context(key):
+            return self.calls.contains(key)
 
     def expand(self, key: Digest | str) -> Digest:
-        results = []
-        for sub in (self.calls, self.values):
-            try:
-                results.append(sub.expand(key))
-            except KeyError:
-                pass
-        return _combine_expand(key, results)
+        with self._operation_context(key):
+            results = []
+            for sub in (self.calls, self.values):
+                try:
+                    results.append(sub.expand(key))
+                except KeyError:
+                    pass
+            return _combine_expand(key, results)
 
     def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
         call_keys: list = []
@@ -351,7 +361,8 @@ class Cache(BaseCache):
                 )
 
     def evict(self, key: str | Digest) -> None:
-        self.calls.evict(key)
+        with self._operation_context(key):
+            self.calls.evict(key)
 
     def redigest(self) -> None:
         """Ensures consistent cache keys in case digest function changed.

--- a/tests/unit/caches/test_gc.py
+++ b/tests/unit/caches/test_gc.py
@@ -19,6 +19,10 @@ class FlatValueMemory(ValueMixin, MemoryBackend):
     :class:`fleche.storage.destructuring.HasChildDigests`.  Used to exercise
     the GC path that walks only direct call references.
     """
+    # @dataclass(frozen=True) regenerates __hash__ from fields, including the
+    # inherited storage: dict, which is unhashable. Mirror MemoryBackend's
+    # convention to keep identity-based hashing.
+    __hash__ = object.__hash__
 
 
 @pytest.fixture(params=["destructuring", "flat"])

--- a/tests/unit/caches/test_gc.py
+++ b/tests/unit/caches/test_gc.py
@@ -1,7 +1,5 @@
 """Tests for Cache.gc() — brute-force reachability-based value eviction."""
 
-from dataclasses import dataclass
-
 import pytest
 
 from fleche.call import Call
@@ -11,7 +9,6 @@ from fleche.storage.base import ValueMixin
 from fleche.storage.memory import CallMemory, MemoryBackend, ValueMemory
 
 
-@dataclass(frozen=True)
 class FlatValueMemory(ValueMixin, MemoryBackend):
     """Memory-backed value storage without destructuring.
 
@@ -19,10 +16,6 @@ class FlatValueMemory(ValueMixin, MemoryBackend):
     :class:`fleche.storage.destructuring.HasChildDigests`.  Used to exercise
     the GC path that walks only direct call references.
     """
-    # @dataclass(frozen=True) regenerates __hash__ from fields, including the
-    # inherited storage: dict, which is unhashable. Mirror MemoryBackend's
-    # convention to keep identity-based hashing.
-    __hash__ = object.__hash__
 
 
 @pytest.fixture(params=["destructuring", "flat"])

--- a/tests/unit/caches/test_operation_context_cache.py
+++ b/tests/unit/caches/test_operation_context_cache.py
@@ -1,0 +1,215 @@
+"""Tests for _operation_context wiring on Cache and BaseCache(OperationContext)."""
+
+import contextlib
+import threading
+from dataclasses import dataclass
+
+from fleche.call import Call, QueryCall
+from fleche.caches import BaseCache, Cache
+from fleche.storage.base import Intent, OperationContext
+from fleche.storage.memory import ValueMemory, CallMemory
+from fleche.storage.thread_safe import PerKeyLockMixin
+
+
+def make_call(name: str, x: int, result: int) -> Call:
+    return Call(name=name, arguments={"x": x}, result=result, module="test", version=1, metadata={})
+
+
+def make_cache() -> Cache:
+    return Cache(values=ValueMemory({}), calls=CallMemory({}))
+
+
+# ---------------------------------------------------------------------------
+# Inheritance checks
+# ---------------------------------------------------------------------------
+
+def test_basecache_inherits_operation_context():
+    assert issubclass(BaseCache, OperationContext)
+
+
+def test_cache_inherits_perkey_lock_mixin():
+    assert issubclass(Cache, PerKeyLockMixin)
+
+
+def test_cache_instance_is_operation_context():
+    c = make_cache()
+    assert isinstance(c, OperationContext)
+
+
+def test_cache_instance_is_perkey_lock_mixin():
+    c = make_cache()
+    assert isinstance(c, PerKeyLockMixin)
+
+
+# ---------------------------------------------------------------------------
+# Per-key methods enter _operation_context
+# ---------------------------------------------------------------------------
+
+def _make_tracking_cache():
+    """Return a Cache subclass that records every (method, key, intent) context entry."""
+    entered = []
+
+    class TrackingCache(Cache):
+        @contextlib.contextmanager
+        def _operation_context(self, key, *, intent=Intent.WRITE):
+            entered.append((str(key)[:8], intent))
+            with super()._operation_context(key, intent=intent):
+                yield
+
+    return TrackingCache(values=ValueMemory({}), calls=CallMemory({})), entered
+
+
+def test_save_enters_operation_context():
+    cache, entered = _make_tracking_cache()
+    c = make_call("f", 1, 2)
+    cache.save(c)
+    assert len(entered) >= 1
+
+
+def test_load_enters_operation_context():
+    cache, entered = _make_tracking_cache()
+    c = make_call("f", 1, 2)
+    key = cache.save(c)
+    entered.clear()
+    cache.load(key)
+    assert len(entered) >= 1
+
+
+def test_load_value_enters_operation_context():
+    cache, entered = _make_tracking_cache()
+    c = make_call("f", 1, 2)
+    call_key = cache.save(c)
+    # get the value digest for the result (stored separately from call records)
+    dc = cache.calls.load(call_key)
+    value_key = dc.result
+    entered.clear()
+    cache.load_value(value_key)
+    assert len(entered) >= 1
+
+
+def test_evict_enters_operation_context():
+    cache, entered = _make_tracking_cache()
+    c = make_call("f", 1, 2)
+    key = cache.save(c)
+    entered.clear()
+    cache.evict(key)
+    assert len(entered) >= 1
+
+
+def test_contains_enters_operation_context():
+    cache, entered = _make_tracking_cache()
+    c = make_call("f", 1, 2)
+    key = cache.save(c)
+    entered.clear()
+    cache.contains(key)
+    assert len(entered) >= 1
+
+
+def test_expand_enters_operation_context():
+    cache, entered = _make_tracking_cache()
+    c = make_call("f", 1, 2)
+    key = cache.save(c)
+    entered.clear()
+    cache.expand(str(key)[:8])
+    assert len(entered) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Thread safety: concurrent save/load via per-key locking
+# ---------------------------------------------------------------------------
+
+def test_concurrent_saves_are_thread_safe():
+    """Multiple threads saving distinct calls must not corrupt the cache."""
+    cache = make_cache()
+    errors = []
+    saved_keys = []
+    lock = threading.Lock()
+
+    def worker(tid: int):
+        try:
+            for i in range(20):
+                c = make_call(f"f{tid}", i, tid * 100 + i)
+                key = cache.save(c)
+                with lock:
+                    saved_keys.append(key)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(tid,)) for tid in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Exceptions during concurrent saves: {errors}"
+    # Every saved key should be loadable
+    for key in saved_keys:
+        assert cache.contains(key), f"Key {key[:8]}… missing after concurrent saves"
+
+
+def test_concurrent_save_load_round_trip():
+    """Concurrent saves and loads on the same cache produce no data races."""
+    cache = make_cache()
+    errors = []
+    saved: list[tuple] = []
+    lock = threading.Lock()
+
+    def saver(tid: int):
+        try:
+            for i in range(10):
+                c = make_call("g", tid * 100 + i, i)
+                key = cache.save(c)
+                with lock:
+                    saved.append((key, i))
+        except Exception as e:
+            errors.append(e)
+
+    def loader():
+        try:
+            for _ in range(30):
+                with lock:
+                    snap = list(saved)
+                for key, _ in snap:
+                    try:
+                        cache.load(key)
+                    except KeyError:
+                        pass
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=saver, args=(tid,)) for tid in range(4)]
+    threads += [threading.Thread(target=loader) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Exceptions during concurrent save/load: {errors}"
+
+
+def test_per_key_lock_allows_parallel_ops_on_different_keys():
+    """Two threads operating on different keys must not block each other."""
+    cache = make_cache()
+
+    # Pre-populate two calls with known keys
+    c1 = make_call("h", 1, 10)
+    c2 = make_call("h", 2, 20)
+    key1 = cache.save(c1)
+    key2 = cache.save(c2)
+
+    barrier = threading.Barrier(2)
+    results = {}
+
+    def load_key(key, name):
+        barrier.wait()  # ensure both start at the same time
+        results[name] = cache.load(key).result
+
+    t1 = threading.Thread(target=load_key, args=(key1, "t1"))
+    t2 = threading.Thread(target=load_key, args=(key2, "t2"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert results.get("t1") == 10
+    assert results.get("t2") == 20

--- a/tests/unit/caches/test_operation_context_cache.py
+++ b/tests/unit/caches/test_operation_context_cache.py
@@ -2,9 +2,10 @@
 
 import contextlib
 import threading
-from dataclasses import dataclass
 
-from fleche.call import Call, QueryCall
+import pytest
+
+from fleche.call import Call
 from fleche.caches import BaseCache, Cache
 from fleche.storage.base import Intent, OperationContext
 from fleche.storage.memory import ValueMemory, CallMemory
@@ -15,8 +16,23 @@ def make_call(name: str, x: int, result: int) -> Call:
     return Call(name=name, arguments={"x": x}, result=result, module="test", version=1, metadata={})
 
 
-def make_cache() -> Cache:
-    return Cache(values=ValueMemory({}), calls=CallMemory({}))
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tracking_cache():
+    """Cache subclass that records every (key_prefix, intent) _operation_context entry."""
+    entered = []
+
+    class TrackingCache(Cache):
+        @contextlib.contextmanager
+        def _operation_context(self, key, *, intent=Intent.WRITE):
+            entered.append((str(key)[:8], intent))
+            with super()._operation_context(key, intent=intent):
+                yield
+
+    return TrackingCache(values=ValueMemory({}), calls=CallMemory({})), entered
 
 
 # ---------------------------------------------------------------------------
@@ -31,43 +47,27 @@ def test_cache_inherits_perkey_lock_mixin():
     assert issubclass(Cache, PerKeyLockMixin)
 
 
-def test_cache_instance_is_operation_context():
-    c = make_cache()
-    assert isinstance(c, OperationContext)
+def test_cache_instance_is_operation_context(clean_cache):
+    assert isinstance(clean_cache, OperationContext)
 
 
-def test_cache_instance_is_perkey_lock_mixin():
-    c = make_cache()
-    assert isinstance(c, PerKeyLockMixin)
+def test_cache_instance_is_perkey_lock_mixin(clean_cache):
+    assert isinstance(clean_cache, PerKeyLockMixin)
 
 
 # ---------------------------------------------------------------------------
 # Per-key methods enter _operation_context
 # ---------------------------------------------------------------------------
 
-def _make_tracking_cache():
-    """Return a Cache subclass that records every (method, key, intent) context entry."""
-    entered = []
-
-    class TrackingCache(Cache):
-        @contextlib.contextmanager
-        def _operation_context(self, key, *, intent=Intent.WRITE):
-            entered.append((str(key)[:8], intent))
-            with super()._operation_context(key, intent=intent):
-                yield
-
-    return TrackingCache(values=ValueMemory({}), calls=CallMemory({})), entered
-
-
-def test_save_enters_operation_context():
-    cache, entered = _make_tracking_cache()
+def test_save_enters_operation_context(tracking_cache):
+    cache, entered = tracking_cache
     c = make_call("f", 1, 2)
     cache.save(c)
     assert len(entered) >= 1
 
 
-def test_load_enters_operation_context():
-    cache, entered = _make_tracking_cache()
+def test_load_enters_operation_context(tracking_cache):
+    cache, entered = tracking_cache
     c = make_call("f", 1, 2)
     key = cache.save(c)
     entered.clear()
@@ -75,8 +75,8 @@ def test_load_enters_operation_context():
     assert len(entered) >= 1
 
 
-def test_load_value_enters_operation_context():
-    cache, entered = _make_tracking_cache()
+def test_load_value_enters_operation_context(tracking_cache):
+    cache, entered = tracking_cache
     c = make_call("f", 1, 2)
     call_key = cache.save(c)
     # get the value digest for the result (stored separately from call records)
@@ -87,8 +87,8 @@ def test_load_value_enters_operation_context():
     assert len(entered) >= 1
 
 
-def test_evict_enters_operation_context():
-    cache, entered = _make_tracking_cache()
+def test_evict_enters_operation_context(tracking_cache):
+    cache, entered = tracking_cache
     c = make_call("f", 1, 2)
     key = cache.save(c)
     entered.clear()
@@ -96,8 +96,8 @@ def test_evict_enters_operation_context():
     assert len(entered) >= 1
 
 
-def test_contains_enters_operation_context():
-    cache, entered = _make_tracking_cache()
+def test_contains_enters_operation_context(tracking_cache):
+    cache, entered = tracking_cache
     c = make_call("f", 1, 2)
     key = cache.save(c)
     entered.clear()
@@ -105,8 +105,8 @@ def test_contains_enters_operation_context():
     assert len(entered) >= 1
 
 
-def test_expand_enters_operation_context():
-    cache, entered = _make_tracking_cache()
+def test_expand_enters_operation_context(tracking_cache):
+    cache, entered = tracking_cache
     c = make_call("f", 1, 2)
     key = cache.save(c)
     entered.clear()
@@ -118,9 +118,8 @@ def test_expand_enters_operation_context():
 # Thread safety: concurrent save/load via per-key locking
 # ---------------------------------------------------------------------------
 
-def test_concurrent_saves_are_thread_safe():
+def test_concurrent_saves_are_thread_safe(clean_cache):
     """Multiple threads saving distinct calls must not corrupt the cache."""
-    cache = make_cache()
     errors = []
     saved_keys = []
     lock = threading.Lock()
@@ -129,7 +128,7 @@ def test_concurrent_saves_are_thread_safe():
         try:
             for i in range(20):
                 c = make_call(f"f{tid}", i, tid * 100 + i)
-                key = cache.save(c)
+                key = clean_cache.save(c)
                 with lock:
                     saved_keys.append(key)
         except Exception as e:
@@ -144,12 +143,11 @@ def test_concurrent_saves_are_thread_safe():
     assert not errors, f"Exceptions during concurrent saves: {errors}"
     # Every saved key should be loadable
     for key in saved_keys:
-        assert cache.contains(key), f"Key {key[:8]}… missing after concurrent saves"
+        assert clean_cache.contains(key), f"Key {key[:8]}… missing after concurrent saves"
 
 
-def test_concurrent_save_load_round_trip():
+def test_concurrent_save_load_round_trip(clean_cache):
     """Concurrent saves and loads on the same cache produce no data races."""
-    cache = make_cache()
     errors = []
     saved: list[tuple] = []
     lock = threading.Lock()
@@ -158,7 +156,7 @@ def test_concurrent_save_load_round_trip():
         try:
             for i in range(10):
                 c = make_call("g", tid * 100 + i, i)
-                key = cache.save(c)
+                key = clean_cache.save(c)
                 with lock:
                     saved.append((key, i))
         except Exception as e:
@@ -171,7 +169,7 @@ def test_concurrent_save_load_round_trip():
                     snap = list(saved)
                 for key, _ in snap:
                     try:
-                        cache.load(key)
+                        clean_cache.load(key)
                     except KeyError:
                         pass
         except Exception as e:
@@ -188,28 +186,58 @@ def test_concurrent_save_load_round_trip():
 
 
 def test_per_key_lock_allows_parallel_ops_on_different_keys():
-    """Two threads operating on different keys must not block each other."""
-    cache = make_cache()
+    """Holding one key's lock must not block a concurrent op on a different key.
 
-    # Pre-populate two calls with known keys
+    A ``HoldingCache`` subclass artificially holds key1's per-key lock until
+    signalled.  While that lock is held, a second thread loads key2.  If the
+    locks are truly per-key, key2's thread completes immediately; if they
+    share a single global lock, key2's thread would be stuck until key1 is
+    released (and the ``t2.join(timeout=2)`` assertion would fail).
+    """
+    t1_holding = threading.Event()
+    t1_can_release = threading.Event()
+    errors = []
+    _key1 = [None]  # mutable cell so the method closure sees the late-bound value
+
+    class HoldingCache(Cache):
+        @contextlib.contextmanager
+        def _operation_context(self, key, *, intent=Intent.WRITE):
+            with super()._operation_context(key, intent=intent):
+                # Inside the per-key lock for `key`.  Hold it for key1 only.
+                if _key1[0] is not None and str(key) == _key1[0]:
+                    t1_holding.set()
+                    t1_can_release.wait(timeout=5)
+                yield
+
+    cache = HoldingCache(values=ValueMemory({}), calls=CallMemory({}))
     c1 = make_call("h", 1, 10)
     c2 = make_call("h", 2, 20)
-    key1 = cache.save(c1)
+    key1 = cache.save(c1)  # _key1[0] is None during setup — no hold
     key2 = cache.save(c2)
+    _key1[0] = key1        # arm: subsequent loads of key1 will hold the lock
 
-    barrier = threading.Barrier(2)
-    results = {}
+    def t1_worker():
+        try:
+            cache.load(key1)
+        except Exception as e:
+            errors.append(e)
 
-    def load_key(key, name):
-        barrier.wait()  # ensure both start at the same time
-        results[name] = cache.load(key).result
+    def t2_worker():
+        try:
+            cache.load(key2)
+        except Exception as e:
+            errors.append(e)
 
-    t1 = threading.Thread(target=load_key, args=(key1, "t1"))
-    t2 = threading.Thread(target=load_key, args=(key2, "t2"))
+    t1 = threading.Thread(target=t1_worker)
     t1.start()
-    t2.start()
-    t1.join(timeout=5)
-    t2.join(timeout=5)
+    assert t1_holding.wait(timeout=5), "t1 never acquired key1 lock"
 
-    assert results.get("t1") == 10
-    assert results.get("t2") == 20
+    # While t1 holds key1's lock, t2 should complete key2 without blocking.
+    t2 = threading.Thread(target=t2_worker)
+    t2.start()
+    t2.join(timeout=2)
+    assert not t2.is_alive(), "t2 was blocked by t1's key1 lock (per-key locking broken)"
+
+    t1_can_release.set()
+    t1.join(timeout=5)
+    assert not errors


### PR DESCRIPTION
Implements steps 4 and 5 of #569.

**Step 4**: `BaseCache` now inherits from `OperationContext`, giving the cache layer the same `_operation_context` hook that the storage layer already has. Per-key methods on `Cache` (`save`, `load`, `load_value`, `evict`, `contains`, `expand`) each enter the hook around their work; `save` derives the key via `call.to_lookup_key()` before entering, mirroring `CallMixin.save`.

**Step 5**: `PerKeyLockMixin` is applied directly to `Cache` (`Cache(PerKeyLockMixin, BaseCache)` --- no separate `PerKeyLockCache` class. `Cache` adopts `__hash__ = object.__hash__` so that storage backends with unhashable dict fields (e.g. `ValueMemory`) do not break the `WeakKeyDictionary` in `PerKeyLockMixin`.

Whole-cache ops (`gc`, `redigest`, `_query`) are intentionally left unwired; they will get `intent="scan"` once that `Intent` value lands.

Closes steps 4-5 of #569.

Generated with [Claude Code](https://claude.ai/code))