### PR TITLE
ci: pin Claude action to Opus with high reasoning effort

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-sonnet-4-6
+            --model opus --effort high
             --allowedTools "WebFetch(*)" "Bash(git *)" "Bash(python *)" "Bash(pip install *)" "Bash(pytest *)" "Bash(gh *)" "mcp__github__*"
           additional_permissions: |
             actions: read


### PR DESCRIPTION
Mirrors [eisenforschung/landau#195](https://github.com/eisenforschung/landau/pull/195) for this repo.

Updates the Claude GitHub action's `claude_args` to:
- Switch the model from `claude-sonnet-4-6` to the `opus` alias (resolves to the latest Opus model on the Anthropic API).
- Set `--effort high` to use high reasoning effort.

The `--allowedTools` and `additional_permissions` configuration is unchanged.

https://claude.ai/code/session_01Vz1imn3cy9CzX4rPKJyr7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vz1imn3cy9CzX4rPKJyr7v)_