### PR TITLE
fix(wrapper): narrow _in_flight to the cache-write gap, not full computation

### DIFF
--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -214,13 +214,10 @@ def make_wrapper(func, policy, meta, isolate, get_call):
 
         # A done-callback for the same key may be mid-save right now (the
         # CPython gap between condition.notify_all() and _invoke_callbacks()).
-        # If so, the future is already resolved — .result() returns immediately.
+        # If so, the future is already resolved — .result() returns immediately
+        # and the future's result is exactly the function result.
         if (f := _in_flight.get(key)) is not None:
-            f.result()
-            try:
-                return cache.load(key).result
-            except KeyError:
-                return f.result()
+            return f.result()
 
         def _run_and_cache():
             active_meta = state._METADATA.get() + tuple(meta)

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from pathlib import Path
 from functools import wraps, partial
 from types import SimpleNamespace
@@ -169,6 +170,13 @@ def make_rerun(func, wrapper):
 
 def make_wrapper(func, policy, meta, isolate, get_call):
     """Build the cached wrapper returned by :func:`fleche`."""
+    # Tracks futures whose done-callback is currently executing the cache write.
+    # Populated at the start of _cache() and removed in its finally clause, so
+    # the entry only exists during the narrow window between Future.set_result()
+    # releasing the condition lock and cache.save() completing.
+    _in_flight: dict[str, Future] = {}
+    _in_flight_lock = threading.Lock()
+
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> _T:
         cache: BaseCache = state._CACHE.get()
@@ -204,6 +212,16 @@ def make_wrapper(func, policy, meta, isolate, get_call):
         except KeyError:
             logger.debug("Cache miss for %s with key %s", call.name, key)
 
+        # A done-callback for the same key may be mid-save right now (the
+        # CPython gap between condition.notify_all() and _invoke_callbacks()).
+        # If so, the future is already resolved — .result() returns immediately.
+        if (f := _in_flight.get(key)) is not None:
+            f.result()
+            try:
+                return cache.load(key).result
+            except KeyError:
+                return f.result()
+
         def _run_and_cache():
             active_meta = state._METADATA.get() + tuple(meta)
             metadata: Dict[str, Any] = defaultdict(dict)
@@ -212,25 +230,33 @@ def make_wrapper(func, policy, meta, isolate, get_call):
 
             result: _T = func(*args, **kwargs)
 
-            def _cache(future = None):
-                if future is None:
-                    call.result = result
-                else:
-                    call.result = future.result()
-                if call.result is None:
-                    logger.warning("Function returned None, not caching")
-                    return None
-                for m in active_meta:
-                    metadata[m.name] |= m.post(
-                        metadata[m.name], replace(call, metadata={})
-                    )
+            def _cache(future=None):
+                if future is not None:
+                    with _in_flight_lock:
+                        _in_flight[key] = future
                 try:
-                    call.metadata = metadata
-                    logger.debug("Saving result for %s with key %s", call.name, key)
-                    cache.save(call)
-                except Rejected as e:
-                    logger.warning("Cache rejected save: %s", e.args)
-                return call.result
+                    if future is None:
+                        call.result = result
+                    else:
+                        call.result = future.result()
+                    if call.result is None:
+                        logger.warning("Function returned None, not caching")
+                        return None
+                    for m in active_meta:
+                        metadata[m.name] |= m.post(
+                            metadata[m.name], replace(call, metadata={})
+                        )
+                    try:
+                        call.metadata = metadata
+                        logger.debug("Saving result for %s with key %s", call.name, key)
+                        cache.save(call)
+                    except Rejected as e:
+                        logger.warning("Cache rejected save: %s", e.args)
+                    return call.result
+                finally:
+                    if future is not None:
+                        with _in_flight_lock:
+                            _in_flight.pop(key, None)
 
             if not isinstance(result, Future):
                 return _cache()

--- a/tests/regression/test_issue_485.py
+++ b/tests/regression/test_issue_485.py
@@ -1,0 +1,111 @@
+"""
+Regression test for issue #485: narrow _in_flight to cover only the cache-write gap.
+
+CPython's Future.set_result() releases the condition lock before calling
+_invoke_callbacks().  This means a thread blocked on future.result() can be
+unblocked while the done-callback that saves to the cache has not yet run.
+
+The fix: _in_flight[key] is populated at the START of _cache() (before
+cache.save) and removed in its finally clause.  A concurrent compute() call
+that arrives during that window finds the future in _in_flight, calls
+.result() (which returns immediately — the future is already resolved), and
+returns the value without triggering a second function invocation.
+"""
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from unittest.mock import patch
+
+from fleche import fleche
+from fleche.caches import Cache
+from fleche.state import cache
+from fleche.storage import ValueMemory, CallMemory
+
+
+def _make_cache():
+    return Cache(ValueMemory({}), CallMemory({}))
+
+
+def _wait_for_cache(fn, *args, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while not fn.contains(*args):
+        assert time.monotonic() < deadline, f"cache never populated for args {args}"
+        time.sleep(0.001)
+
+
+def test_in_flight_covers_cache_write_gap():
+    """
+    _in_flight[key] is set before cache.save so a second compute() call that
+    arrives while the save is in progress gets the value without re-executing
+    the function.
+
+    Threading.Barrier is used to hold the done-callback at the start of
+    cache.save.  While it is paused, a second compute() call is made; it
+    should find the key in _in_flight and return without incrementing
+    call_count.  Releasing the barrier lets save complete, and the cache
+    should contain exactly one entry.
+    """
+    barrier = threading.Barrier(2)
+    save_started = threading.Event()
+    save_count = [0]
+    call_count = [0]
+    ready = threading.Event()
+
+    real_save = Cache.save
+
+    def slow_save(self_cache, call):
+        save_started.set()
+        barrier.wait()
+        save_count[0] += 1
+        return real_save(self_cache, call)
+
+    executor = ThreadPoolExecutor(max_workers=1)
+
+    try:
+        with patch.object(Cache, "save", slow_save):
+            c = _make_cache()
+
+            @fleche
+            def compute(x):
+                call_count[0] += 1
+                def work():
+                    # Hold the worker until the main thread has registered the
+                    # done-callback, ensuring the callback runs in the worker
+                    # thread (not synchronously in the calling thread).
+                    ready.wait()
+                    return x * 2
+                return executor.submit(work)
+
+            with cache(c):
+                future = compute(5)
+
+                # Allow the worker to resolve the future; the done-callback
+                # (_cache) is already registered and will run in the worker
+                # thread via _invoke_callbacks().
+                ready.set()
+
+                assert future.result() == 10
+                assert call_count[0] == 1
+
+                # Wait until the callback has entered slow_save (meaning
+                # _in_flight[key] is now set but cache.save has not yet run).
+                assert save_started.wait(timeout=2.0), "callback never reached slow_save"
+
+                # A second compute(5) during the save window should find the
+                # key in _in_flight and return the value without calling func.
+                second = compute(5)
+                assert second == 10
+                assert call_count[0] == 1, "_in_flight check did not prevent second invocation"
+
+                # Release the callback to complete the save.
+                barrier.wait()
+
+                _wait_for_cache(compute, 5)
+                assert save_count[0] == 1, f"cache.save called {save_count[0]} times, expected 1"
+
+                # Third call: plain cache hit.
+                third = compute(5)
+                assert third == 10
+                assert call_count[0] == 1
+    finally:
+        executor.shutdown(wait=True)

--- a/tests/regression/test_issue_485.py
+++ b/tests/regression/test_issue_485.py
@@ -42,8 +42,10 @@ def test_in_flight_covers_cache_write_gap():
     Threading.Barrier is used to hold the done-callback at the start of
     cache.save.  While it is paused, a second compute() call is made; it
     should find the key in _in_flight and return without incrementing
-    call_count.  Releasing the barrier lets save complete, and the cache
-    should contain exactly one entry.
+    call_count.  Both calls use the same key, so the cache count alone can't
+    distinguish the fix from the bug; instead we assert on call metadata --
+    the function is invoked exactly once (call_count) and cache.save runs
+    exactly once (save_count).
     """
     barrier = threading.Barrier(2)
     save_started = threading.Event()


### PR DESCRIPTION
Closes #485

## Summary

- `_in_flight[key]` is now populated inside `_cache()` (the done-callback), before `cache.save()`, not while the computation is still running
- `_in_flight` is removed in a `finally` clause after `save()` completes
- Lock management lives entirely in `_cache()`; wrapper body does a lockless `dict.get` read
- Adds `tests/regression/test_issue_485.py` with a `threading.Barrier`-based regression test

Generated with [Claude Code](https://claude.ai/code)