### PR TITLE
ci: add Haiku performance-triage workflow for PRs

### DIFF
--- a/.github/workflows/perf-triage.yml
+++ b/.github/workflows/perf-triage.yml
@@ -1,0 +1,87 @@
+name: Performance Triage
+
+# Runs on every new pull request and asks Claude Haiku to judge — from the PR
+# description and the change diff — whether the change is performance-critical
+# (i.e. touches a hot path the benchmark suite measures: digesting, storage
+# backends, cache/query traversal, the call/wrapper hot loop).
+#
+# If Haiku decides it is, it adds the `benchmark` label to the PR. That label is
+# the existing trigger for `benchmarks.yml` (it runs on the `labeled` event and
+# gates on `contains(...labels..., 'benchmark')`), so labelling here transparently
+# kicks off the full benchmark + delta-vs-baseline comparison without duplicating
+# that logic. If Haiku decides it is not, it does nothing.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+# Don't pile up triage runs if a PR is rapidly reopened / edited.
+concurrency:
+  group: perf-triage-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    # Skip drafts and PRs that already carry the label (nothing to decide).
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'benchmark')
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Triage performance impact with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-haiku-4-5
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+          prompt: |
+            You are triaging a pull request to decide whether it is
+            **performance-critical** and therefore warrants running the benchmark
+            suite. Be decisive and terse — do not post any PR comment.
+
+            Context:
+            - Repo: ${{ github.repository }}
+            - PR number: ${{ github.event.pull_request.number }}
+
+            fleche is a persistent function-cache library. Its benchmark suite
+            (`benchmarks/`) measures three hot paths only:
+              1. **Digesting** — `src/fleche/digest.py`, `src/fleche/call.py`
+                 (SHA256 content hashing of arguments/results; the hottest path).
+              2. **Storage backends** — `src/fleche/storage/**` (put/get/save/load,
+                 serialization, locking, SQL/file/memory/bagofholding backends).
+              3. **End-to-end caching** — `src/fleche/wrapper.py`, `caches.py`,
+                 `query.py`, `state.py` (the decorator call loop, cache lookup,
+                 query traversal).
+
+            Do the following:
+            1. Read the PR title and description:
+               `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body`
+            2. Read the change diff:
+               `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}`
+               (If the diff is very large, focus on changes under `src/fleche/`.)
+            3. Decide: is this change **performance-critical**? Treat it as YES if
+               it modifies runtime behaviour of any hot path above — algorithmic
+               changes, the digest/hash function, serialization, locking, the
+               cache lookup/save loop, or anything the PR text itself flags as a
+               perf change (mentions speed, latency, throughput, hot path,
+               optimization, `hash_version`, blake2b, etc.). Treat it as NO for
+               docs-only, test-only, CI/workflow, comment, typing-only, or changes
+               confined to non-runtime files (`benchmarks/`, `docs/`, `tests/`,
+               `*.md`, `.github/`).
+            4. If and only if your decision is YES, add the label that triggers the
+               benchmark workflow:
+               `gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label benchmark`
+               (If the label does not exist, create it first:
+               `gh label create benchmark --repo ${{ github.repository }} --color FFA500 --description "Run the benchmark suite on this PR" || true`)
+            5. Finish by printing a single line: either
+               `DECISION: performance-critical — benchmark label added` or
+               `DECISION: not performance-critical — no action`, followed by one
+               short sentence of justification.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/perf-triage.yml
+++ b/.github/workflows/perf-triage.yml
@@ -60,13 +60,23 @@ jobs:
                  `query.py`, `state.py` (the decorator call loop, cache lookup,
                  query traversal).
 
-            Do the following:
+            Do the following. Fetch input lazily — triage by filename first and
+            only pull the full diff when the changed paths could plausibly touch a
+            hot path. This keeps the model input small on the common (docs/test/CI)
+            cases instead of loading a large diff every run.
             1. Read the PR title and description:
                `gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body`
-            2. Read the change diff:
-               `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}`
-               (If the diff is very large, focus on changes under `src/fleche/`.)
-            3. Decide: is this change **performance-critical**? Treat it as YES if
+            2. List the changed files first (cheap):
+               `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --name-only`
+               - If **every** changed path is confined to non-runtime files
+                 (`docs/`, `tests/`, `benchmarks/`, `.github/`, `*.md`), decide NO
+                 immediately and skip to step 5 — do NOT fetch the full diff.
+               - Otherwise continue to step 3.
+            3. Only now pull the hunks, and focus on the runtime code. Prefer
+               restricting the diff to the source tree, e.g.
+               `gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} -- 'src/fleche/**'`
+               (fall back to the unfiltered diff only if that yields nothing).
+               Decide: is this change **performance-critical**? Treat it as YES if
                it modifies runtime behaviour of any hot path above — algorithmic
                changes, the digest/hash function, serialization, locking, the
                cache lookup/save loop, or anything the PR text itself flags as a

--- a/.github/workflows/perf-triage.yml
+++ b/.github/workflows/perf-triage.yml
@@ -28,6 +28,7 @@ jobs:
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'benchmark')
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
     steps:

--- a/.github/workflows/perf-triage.yml
+++ b/.github/workflows/perf-triage.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Triage performance impact with Claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## What

Adds a new workflow, `.github/workflows/perf-triage.yml`, that runs on every new pull request (`opened` / `reopened` / `ready_for_review`) and uses **Claude Haiku** to decide — from the PR's OP text (title + body) and the change diff — whether the change is **performance-critical**. If so, it triggers the benchmark suite.

## How it triggers benchmarks

Rather than duplicate any benchmark logic, the triage job reuses the existing pipeline. The current `benchmarks.yml` already runs on the `labeled` event and gates on:

```yaml
if: contains(github.event.pull_request.labels.*.name, 'benchmark')
```

So when Haiku judges a PR performance-critical, it simply runs `gh pr edit --add-label benchmark`. Adding that label fires `benchmarks.yml`, which runs the suite and posts the delta-vs-baseline comparison as it does today. One source of truth, no copied steps.

## Decision criteria given to Haiku

Grounded in what `benchmarks/` actually measures — the three hot paths:

1. **Digesting** — `digest.py`, `call.py` (SHA256 content hashing; hottest path)
2. **Storage backends** — `storage/**` (put/get/save/load, serialization, locking)
3. **End-to-end caching** — `wrapper.py`, `caches.py`, `query.py`, `state.py`

Algorithmic / hash-function / serialization / lock / cache-loop changes (or anything the PR text flags as perf-related) → YES. Docs/test/CI/typing-only changes → NO.

## Design note: how the PR text + diff reach Haiku

The triage job has Haiku **fetch its input agentically** (via `gh pr view` / `gh pr diff` through the Bash tool) rather than pre-injecting the body and diff verbatim into the prompt. Considered both:

- **Pre-injecting verbatim** is more deterministic and lets you size-cap in a prep step, but it forces the *entire* diff into the prompt on every run, and plumbing a multi-KB multiline diff through a YAML `prompt:` string is awkward and is the classic GitHub Actions injection footgun (a crafted PR body could break the YAML / inject instructions).
- **Agentic fetch** sidesteps that marshalling entirely and lets the model load input lazily.

To get the cost control of pre-injection without its liabilities, the prompt instructs Haiku to **triage by filename first**: read the changed paths (`gh pr diff --name-only`), short-circuit to NO when everything is confined to non-runtime paths (`docs/`, `tests/`, `benchmarks/`, `.github/`, `*.md`) without ever fetching the hunks, and only then pull the diff — scoped to `src/fleche/**` — for the cases that could plausibly touch a hot path. So the common cheap PRs cost a filename listing, not a full diff load.

## Notes

- Skips drafts and PRs that already carry the `benchmark` label (nothing to decide).
- `concurrency` group cancels superseded triage runs.
- Uses the same `claude_code_oauth_token` secret and `claude-code-action@v1` pattern as the existing `claude.yaml` / CI-failure-summary workflows; `id-token: write` is granted (the action needs OIDC); model pinned to `claude-haiku-4-5` like the CI-failure summarizer; `actions/checkout@v6`.
- Minimal tool allowlist: `gh pr view/diff/edit` plus `gh label list/create`.
- Creates the `benchmark` label on the fly if it doesn't exist yet.

https://claude.ai/code/session_018CZQJgbVQjXzBtHFFSQNZw