### PR TITLE
fix(caches): serialize CacheStack.load() auto-transfer to base cache

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -557,9 +557,11 @@ class CacheStack(PerKeyLockMixin, BaseCache):
         """Transfer a hit from a higher cache into the base cache.
 
         Serialized per key so that concurrent loads of the same missing key do
-        not all run the base cache's non-atomic check-evict-save at once.  The
-        double-checked :meth:`~BaseCache.contains` lets every waiter past the
-        first skip the redundant save once the key has been back-filled.
+        not all run the base cache's non-atomic check-evict-save at once.  All
+        concurrent loaders block on the per-key :meth:`_operation_context` lock;
+        the first one past the lock does the transfer, and every later waiter
+        finds the key already present via :meth:`~BaseCache.contains` and returns
+        without repeating the save.
         """
         with self._operation_context(key):
             if self.stack[0].contains(key):

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -515,11 +515,14 @@ class RefreshingCache(CacheWrapper):
 
 
 @dataclass(frozen=True)
-class CacheStack(BaseCache):
+class CacheStack(PerKeyLockMixin, BaseCache):
     """A combination of caches with a shared traversal policy.
 
     Saving always targets the lowest level (``stack[0]``); loading traverses
-    from ``stack[0]`` upward and back-fills any hit into ``stack[0]``.
+    from ``stack[0]`` upward and back-fills any hit into ``stack[0]``.  The
+    back-fill is serialized per key (via :class:`PerKeyLockMixin`) so that
+    concurrent loads of the same missing key do not all run the base cache's
+    non-atomic check-evict-save at once.
 
     All multi-cache fan-out is handled by three private traversal helpers,
     each implementing one of the recurring patterns across the stack:
@@ -544,15 +547,28 @@ class CacheStack(BaseCache):
             try:
                 lc = cache.load(key)
                 if i > 0:
-                    try:
-                        self.save(lc.fetch())
-                        logger.info("Transferred hit for %s from higher cache to base cache", key)
-                    except Rejected as e:
-                        logger.warning("Failed to transfer hit for %s to base cache: %s", key, e)
+                    self._backfill(key, lc)
                 return lc
             except KeyError:
                 continue
         raise KeyError(key)
+
+    def _backfill(self, key, lc: LazyCall) -> None:
+        """Transfer a hit from a higher cache into the base cache.
+
+        Serialized per key so that concurrent loads of the same missing key do
+        not all run the base cache's non-atomic check-evict-save at once.  The
+        double-checked :meth:`~BaseCache.contains` lets every waiter past the
+        first skip the redundant save once the key has been back-filled.
+        """
+        with self._operation_context(key):
+            if self.stack[0].contains(key):
+                return
+            try:
+                self.save(lc.fetch())
+                logger.info("Transferred hit for %s from higher cache to base cache", key)
+            except Rejected as e:
+                logger.warning("Failed to transfer hit for %s to base cache: %s", key, e)
 
     def load_value(self, key):
         return self._first_hit(lambda c: c.load_value(key))

--- a/tests/regression/test_issue_217.py
+++ b/tests/regression/test_issue_217.py
@@ -1,0 +1,65 @@
+"""Regression test for issue #217.
+
+``CacheStack.load()`` back-fills a hit from a higher cache into the base
+cache.  Before the fix this transfer was unprotected: multiple threads loading
+the same key would all miss the base, all hit the higher cache, and all call
+``self.save(...)`` on the base concurrently — running the base's non-atomic
+check-evict-save many times over.
+
+The fix serializes the back-fill per key and double-checks ``contains`` under
+the lock, so the transfer happens exactly once no matter how many threads race.
+"""
+
+import threading
+import time
+from dataclasses import dataclass
+
+from fleche.caches import Cache, CacheStack
+from fleche.call import Call
+from fleche.storage import ValueMemory, CallMemory
+
+
+def test_concurrent_backfill_transfers_once():
+    save_calls: list[int] = []
+    barrier = threading.Barrier(8)
+
+    @dataclass(frozen=True)
+    class CountingCache(Cache):
+        """Base cache that records every save and widens the race window."""
+
+        def save(self, call: Call) -> str:
+            save_calls.append(1)
+            # Sleep while holding the per-key back-fill lock so that, without
+            # serialization, all eight threads would pile into save() at once.
+            time.sleep(0.05)
+            return super().save(call)
+
+    base = CountingCache(ValueMemory({}), CallMemory({}))
+    top = Cache(ValueMemory({}), CallMemory({}))
+
+    call = Call(name="compute", arguments={"x": 42}, result=84)
+    key = top.save(call)
+
+    stack = CacheStack((base, top))
+
+    results: list[object] = []
+    results_lock = threading.Lock()
+
+    def worker():
+        barrier.wait()
+        lc = stack.load(key)
+        with results_lock:
+            results.append(lc.result)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Every thread observed the correct result ...
+    assert results == [84] * 8
+    # ... but the back-fill ran exactly once despite the concurrent race.
+    assert len(save_calls) == 1
+    # ... and the key is now present in the base cache.
+    assert base.contains(key)


### PR DESCRIPTION
Serializes the per-key back-fill in `CacheStack.load()` so concurrent loads of the same missing key transfer the hit into the base cache exactly once, instead of all racing into the base's non-atomic check-evict-save.

Closes #217

Generated with [Claude Code](https://claude.ai/code)