### PR TITLE
fix(benchmarks): restore __hash__ on raw Memory subclasses

### DIFF
--- a/benchmarks/benchmark_integration.py
+++ b/benchmarks/benchmark_integration.py
@@ -26,11 +26,13 @@ from fleche.storage.memory import MemoryBackend
 
 
 @dataclass(frozen=True)
-class ValueMemoryRaw(DestructuringMixin, ValueMixin, MemoryBackend): ...
+class ValueMemoryRaw(DestructuringMixin, ValueMixin, MemoryBackend):
+    __hash__ = object.__hash__
 
 
 @dataclass(frozen=True)
-class CallMemoryRaw(CallMixin, MemoryBackend): ...
+class CallMemoryRaw(CallMixin, MemoryBackend):
+    __hash__ = object.__hash__
 
 
 @fleche


### PR DESCRIPTION
## Summary

`benchmarks/run_benchmarks.py` was aborting at `benchmark_integration.py` with:

```
TypeError: unhashable type: 'dict'
```

raised through `PerKeyLockMixin._get_key_lock → _per_instance_locks[self]`.

Root cause: `@dataclass(frozen=True)` regenerates `__hash__` on every subclass when `eq=True` (the default), so the explicit `__hash__ = object.__hash__` on `MemoryBackend` does **not** carry through to subclasses that don't repeat the override. The library's own `ValueMemory` / `CallMemory` correctly set `__hash__ = object.__hash__`, but the benchmark's bespoke `ValueMemoryRaw` / `CallMemoryRaw` did not. This only started biting after PR #622 reparented `Cache` onto `PerKeyLockMixin`, which now hashes the cache (and via its fields, the storage backends) into the per-key lock table.

Fix: add `__hash__ = object.__hash__` to both raw subclasses in the benchmark.

## Test plan

- [x] `python benchmarks/run_benchmarks.py` runs to completion and writes `benchmarks/results.csv`

Follow-up: I'll file a separate issue to re-audit the storage class hierarchy so this footgun (silent `__hash__` regeneration on frozen-dataclass subclasses) doesn't keep tripping new subclasses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2Et7bkdBcLH1MiXHRySAP)_