### PR TITLE
test: extract run_workers() helper for concurrency stress tests (#451)

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,6 @@
+import functools
 import os
+import threading
 import uuid
 from contextlib import contextmanager
 
@@ -21,6 +23,54 @@ from fleche.storage.bagofholding_file import BagOfHoldingH5FileBackend
 from fleche.caches import Cache
 
 secret_key = [b"test_secret_key_32_bytes_long!!!!"]
+
+
+# ---------------------------------------------------------------------------
+# Concurrency stress-test helper
+#
+# Many thread-safety tests share the same shape: spawn N threads, have each do
+# some work, collect any exceptions, join, and assert nothing blew up. This
+# helper collapses that boilerplate so the tests only describe the work.
+# ---------------------------------------------------------------------------
+
+def run_workers(worker, count=None, *, timeout=None):
+    """Run worker callables concurrently in threads; return captured exceptions.
+
+    Exceptions raised in any worker are captured (thread-safely) and returned as
+    a list, so callers just ``assert not run_workers(...)`` instead of repeating
+    the spawn/start/join/collect dance by hand.
+
+    Two calling forms:
+
+    * ``run_workers(fn, n)`` spawns ``n`` threads; thread ``i`` calls ``fn(i)``.
+    * ``run_workers([fn0, fn1, ...])`` spawns one thread per callable, each
+      invoked with no arguments. Use this for heterogeneous worker mixes (e.g.
+      some readers + some writers); bind per-worker arguments with
+      ``functools.partial``.
+
+    ``timeout`` is forwarded to each ``Thread.join``.
+    """
+    if count is not None:
+        workers = [functools.partial(worker, i) for i in range(count)]
+    else:
+        workers = list(worker)
+
+    errors: list[Exception] = []
+    errors_lock = threading.Lock()
+
+    def run(fn):
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 — surfaced to the caller via `errors`
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=run, args=(fn,)) for fn in workers]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout)
+    return errors
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_sql_concurrent_save.py
+++ b/tests/regression/test_sql_concurrent_save.py
@@ -1,9 +1,9 @@
 """Regression test for issue #218: Sql._save() race condition under concurrent access."""
 
-import concurrent.futures
-
 from fleche.call import Call
 from fleche.storage.sql import Sql
+
+from tests.fixtures import run_workers
 
 
 def test_sql_concurrent_save_no_integrity_error(tmp_path):
@@ -14,19 +14,11 @@ def test_sql_concurrent_save_no_integrity_error(tmp_path):
     """
     sql = Sql(str(tmp_path / "cache.db"))
 
-    errors = []
+    def save_call(worker):
+        call = Call(name="compute", arguments={"x": worker % 3}, result=None)
+        sql.save(call)
 
-    def save_call(x):
-        try:
-            call = Call(name="compute", arguments={"x": x}, result=None)
-            sql.save(call)
-        except Exception as exc:
-            errors.append(exc)
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
-        futures = [pool.submit(save_call, i % 3) for i in range(24)]
-        for f in futures:
-            f.result()
+    errors = run_workers(save_call, 24)
 
     assert not errors, f"Concurrent saves raised errors: {errors}"
     stored_keys = list(sql.list())

--- a/tests/unit/caches/test_operation_context_cache.py
+++ b/tests/unit/caches/test_operation_context_cache.py
@@ -1,6 +1,7 @@
 """Tests for _operation_context wiring on Cache and BaseCache(OperationContext)."""
 
 import contextlib
+import functools
 import threading
 
 import pytest
@@ -10,6 +11,8 @@ from fleche.caches import BaseCache, Cache
 from fleche.storage.base import Intent, OperationContext
 from fleche.storage.memory import ValueMemory, CallMemory
 from fleche.storage.thread_safe import PerKeyLockMixin
+
+from tests.fixtures import run_workers
 
 
 def make_call(name: str, x: int, result: int) -> Call:
@@ -120,25 +123,17 @@ def test_expand_enters_operation_context(tracking_cache):
 
 def test_concurrent_saves_are_thread_safe(clean_cache):
     """Multiple threads saving distinct calls must not corrupt the cache."""
-    errors = []
     saved_keys = []
     lock = threading.Lock()
 
     def worker(tid: int):
-        try:
-            for i in range(20):
-                c = make_call(f"f{tid}", i, tid * 100 + i)
-                key = clean_cache.save(c)
-                with lock:
-                    saved_keys.append(key)
-        except Exception as e:
-            errors.append(e)
+        for i in range(20):
+            c = make_call(f"f{tid}", i, tid * 100 + i)
+            key = clean_cache.save(c)
+            with lock:
+                saved_keys.append(key)
 
-    threads = [threading.Thread(target=worker, args=(tid,)) for tid in range(8)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    errors = run_workers(worker, 8)
 
     assert not errors, f"Exceptions during concurrent saves: {errors}"
     # Every saved key should be loadable
@@ -148,39 +143,29 @@ def test_concurrent_saves_are_thread_safe(clean_cache):
 
 def test_concurrent_save_load_round_trip(clean_cache):
     """Concurrent saves and loads on the same cache produce no data races."""
-    errors = []
     saved: list[tuple] = []
     lock = threading.Lock()
 
     def saver(tid: int):
-        try:
-            for i in range(10):
-                c = make_call("g", tid * 100 + i, i)
-                key = clean_cache.save(c)
-                with lock:
-                    saved.append((key, i))
-        except Exception as e:
-            errors.append(e)
+        for i in range(10):
+            c = make_call("g", tid * 100 + i, i)
+            key = clean_cache.save(c)
+            with lock:
+                saved.append((key, i))
 
     def loader():
-        try:
-            for _ in range(30):
-                with lock:
-                    snap = list(saved)
-                for key, _ in snap:
-                    try:
-                        clean_cache.load(key)
-                    except KeyError:
-                        pass
-        except Exception as e:
-            errors.append(e)
+        for _ in range(30):
+            with lock:
+                snap = list(saved)
+            for key, _ in snap:
+                try:
+                    clean_cache.load(key)
+                except KeyError:
+                    pass
 
-    threads = [threading.Thread(target=saver, args=(tid,)) for tid in range(4)]
-    threads += [threading.Thread(target=loader) for _ in range(4)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    errors = run_workers(
+        [functools.partial(saver, tid) for tid in range(4)] + [loader] * 4
+    )
 
     assert not errors, f"Exceptions during concurrent save/load: {errors}"
 

--- a/tests/unit/caches/test_size_limited.py
+++ b/tests/unit/caches/test_size_limited.py
@@ -1,9 +1,9 @@
 """Tests for SizeLimitedCache."""
-import threading
-
 from fleche.call import Call, QueryCall
 from fleche.caches import Cache, SizeLimitedCache
 from fleche.storage.memory import ValueMemory, CallMemory
+
+from tests.fixtures import run_workers
 
 
 def make_slcache(max_size: int) -> SizeLimitedCache:
@@ -81,20 +81,13 @@ def test_pick_eviction_target_is_overridable():
 def test_thread_safety():
     """Concurrent saves do not corrupt the size invariant."""
     cache = make_slcache(max_size=5)
-    errors = []
 
-    def save_calls(start):
-        try:
-            for i in range(start, start + 10):
-                cache.save(make_call("f", i, i * 2))
-        except Exception as e:
-            errors.append(e)
+    def save_calls(worker):
+        start = worker * 10
+        for i in range(start, start + 10):
+            cache.save(make_call("f", i, i * 2))
 
-    threads = [threading.Thread(target=save_calls, args=(i * 10,)) for i in range(4)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    errors = run_workers(save_calls, 4)
 
     assert not errors, f"Exceptions during concurrent saves: {errors}"
     keys = list(cache.calls.list())

--- a/tests/unit/storage/test_thread_safe.py
+++ b/tests/unit/storage/test_thread_safe.py
@@ -17,6 +17,8 @@ from fleche.storage.memory import MemoryBackend
 from fleche.storage.pickle_file import PickleFileBackend
 from fleche.storage.thread_safe import _PicklableLock, _PicklableRLock
 
+from tests.fixtures import run_workers
+
 
 # ---------------------------------------------------------------------------
 # Minimal test-local storage classes — no DestructuringMixin, so values are
@@ -99,12 +101,9 @@ def _run_concurrent_save_load(store, n_threads=8, n_writes=50):
         with lock:
             saved.extend(local)
 
-    threads = [threading.Thread(target=worker, args=(tid,)) for tid in range(n_threads)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    errors = run_workers(worker, n_threads)
 
+    assert not errors, f"Exceptions during concurrent saves: {errors}"
     assert len(saved) == n_threads * n_writes
     for key, value in saved:
         assert store.load(key) == value
@@ -131,28 +130,16 @@ def test_value_pickle_file_concurrent_saves(tmp_path):
 def test_concurrent_load_while_writing(cls):
     store = cls(storage={})
     keys = [store.save(i) for i in range(100)]
-    errors: list[Exception] = []
 
     def reader():
-        try:
-            for k in keys:
-                assert store.load(k) in range(100)
-        except Exception as e:
-            errors.append(e)
+        for k in keys:
+            assert store.load(k) in range(100)
 
     def writer():
-        try:
-            for i in range(100, 200):
-                store.save(i)
-        except Exception as e:
-            errors.append(e)
+        for i in range(100, 200):
+            store.save(i)
 
-    threads = [threading.Thread(target=reader) for _ in range(4)]
-    threads += [threading.Thread(target=writer) for _ in range(4)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    errors = run_workers([reader] * 4 + [writer] * 4)
 
     assert not errors
 


### PR DESCRIPTION
Pattern A from the #451 concurrency-test recon. Lifts the shared "spawn N threads, run work, collect exceptions, join, assert empty" boilerplate into a single `run_workers(...)` helper in `tests/fixtures.py` and refactors the five stress/fuzz copies onto it (test-only, no production code).

Refs #451

Generated with [Claude Code](https://claude.ai/code)