### PR TITLE
docs(lazy_call): fix misleading 'first time' caching claim in LazyArguments

### DIFF
--- a/docs/usage/lazy_call.rst
+++ b/docs/usage/lazy_call.rst
@@ -8,7 +8,7 @@ Fleche avoids this by returning **lazy call objects** from ``load()`` and ``quer
 What is a LazyCall?
 -------------------
 
-When you call ``cache().load(key)`` or iterate over ``cache().query(...)``, you get back a ``LazyCall`` rather than a full ``Call``. A ``LazyCall`` holds the digests (unique identifiers) of the arguments and result, plus a reference to the cache, but none of the actual Python objects. Those are loaded on demand the first time you touch them.
+When you call ``cache().load(key)`` or iterate over ``cache().query(...)``, you get back a ``LazyCall`` rather than a full ``Call``. A ``LazyCall`` holds the digests (unique identifiers) of the arguments and result, plus a reference to the cache, but none of the actual Python objects. Those are loaded from storage on demand whenever you access them.
 
 .. code-block:: python
 
@@ -40,7 +40,7 @@ Parity with Call
 LazyArguments
 -------------
 
-The ``arguments`` attribute of a ``LazyCall`` returns a ``LazyArguments`` proxy. This proxy implements the standard Python ``Mapping`` interface, so you can use it like a regular dictionary. Each argument is fetched from storage the first time it is accessed by key.
+The ``arguments`` attribute of a ``LazyCall`` returns a ``LazyArguments`` proxy. This proxy implements the standard Python ``Mapping`` interface, so you can use it like a regular dictionary. Each argument is fetched from storage on each access by key — there is no per-key caching inside the proxy itself.
 
 When lazy loading helps most
 -----------------------------


### PR DESCRIPTION
## Summary

`LazyArguments.__getitem__` and `LazyCall.result` both call the underlying storage backend on **every** access — there is no per-key memoisation inside the proxy.

The previous wording said:

- *"loaded on demand the first time you touch them"*
- *"Each argument is fetched from storage the first time it is accessed by key"*

Both imply that the result is cached after the first fetch, which is false. Subsequent accesses go back to storage. This PR corrects the language to remove that implication.

## How the discrepancy was found

Code inspection of `LazyArguments.__getitem__`:

```python
def __getitem__(self, key):
    value = self._arg_digests[key]
    if not isinstance(value, Digest):
        return value
    try:
        return self._cache.load_value(value)  # ← called every time, no cache
    except KeyError:
        return value
```

And `LazyCall.result`:

```python
@property
def result(self):
    if self._result is None:
        return None
    return self._cache.load_value(self._result)  # ← called every time, no cache
```

Neither stores the loaded value for reuse.

## Test plan

- [x] Verified with `python -c` that accessing `lazy_call.arguments['a']` twice produces the correct result on both accesses (correctness unchanged — only docs updated)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMqxvvTaXUJo1j3DWXnEwm)_