### PR TITLE
docs(ssh_cache): add fleche_version and cloudpickle_version to info() table

### DIFF
--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -309,24 +309,30 @@ the :data:`fleche.state._CACHE` ``ContextVar``.
 
 It returns:
 
-================ =================================================
-Key              Meaning
-================ =================================================
-``cache``        :func:`~fleche.config.cache_to_config` of the
-                 served cache — a structured dict (or list, for
-                 stacks) that round-trips back through
-                 :func:`~fleche.config.cache_from_config`.
-``cache_name``   The ``--cache`` argument the server was launched
-                 with, or ``None`` for the default cache.
-``read_only``    ``True`` when the served cache (or, for a
-                 :class:`~fleche.caches.CacheStack`, its
-                 ``stack[0]``) is a
-                 :class:`~fleche.caches.ReadOnlyMixin`.
-``cwd``          ``os.getcwd()`` on the remote.
-``hostname``     ``socket.gethostname()`` on the remote.
-``python``       ``sys.executable`` on the remote.
-``pid``          The server process's PID.
-================ =================================================
+======================== =================================================
+Key                      Meaning
+======================== =================================================
+``cache``                :func:`~fleche.config.cache_to_config` of the
+                         served cache — a structured dict (or list, for
+                         stacks) that round-trips back through
+                         :func:`~fleche.config.cache_from_config`.
+``cache_name``           The ``--cache`` argument the server was launched
+                         with, or ``None`` for the default cache.
+``read_only``            ``True`` when the served cache (or, for a
+                         :class:`~fleche.caches.CacheStack`, its
+                         ``stack[0]``) is a
+                         :class:`~fleche.caches.ReadOnlyMixin`.
+``cwd``                  ``os.getcwd()`` on the remote.
+``hostname``             ``socket.gethostname()`` on the remote.
+``python``               ``sys.executable`` on the remote.
+``pid``                  The server process's PID.
+``fleche_version``       The server's ``fleche`` package version string.
+                         Compared against the client's version by
+                         :func:`~fleche.remote._warn_on_version_skew`.
+``cloudpickle_version``  The server's ``cloudpickle`` version string.
+                         A mismatch with the client can cause silent
+                         wire-format incompatibilities.
+======================== =================================================
 
 ``info()`` is the debugging back-channel for any "the remote isn't
 doing what I expected" question — wrong cache loaded, wrong working


### PR DESCRIPTION
## Summary

`_server_info()` returns **nine** fields, but the diagnostics table in `ssh_cache.rst` only documented **seven**. The two missing fields — `fleche_version` and `cloudpickle_version` — are precisely the ones checked by `_warn_on_version_skew` to surface version-drift issues between client and server.

## How the discrepancy was found

Cross-referencing the table in the docs against the actual return value of `_server_info()` in `remote.py`:

```python
return {
    "cache": ...,
    "cache_name": ...,
    "read_only": ...,
    "fleche_version": _fleche_version(),       # ← missing from table
    "cloudpickle_version": cloudpickle.__version__,  # ← missing from table
    "cwd": ...,
    "hostname": ...,
    "python": ...,
    "pid": ...,
}
```

## Test plan

- [x] Verified field names against `remote.py` lines 251–260
- [x] Confirmed `_warn_on_version_skew` reads both keys (lines 341–351 of `remote.py`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMqxvvTaXUJo1j3DWXnEwm)_