### PR TITLE
docs(configuration): document Runtime as the default metadata class

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -70,7 +70,7 @@ Example:
 ``metadata``
 ~~~~~~~~~~~~
 
-The ``metadata`` key specifies the default metadata chain to use. This is a list of strings, where each string is the name of a metadata class from the ``fleche.metadata`` module.
+The ``metadata`` key specifies the default metadata chain to use. This is a list of strings, where each string is the name of a metadata class from the ``fleche.metadata`` module.  When this key is omitted, ``fleche`` defaults to ``["Runtime"]``, so :class:`~fleche.metadata.Runtime` timing information is collected automatically.
 
 Example:
 


### PR DESCRIPTION
## Summary

When the `[default] metadata` key is absent from all discovered config files, `load_default_metadata()` silently returns `(Runtime(),)`. The docs explained what the `metadata` key does but never stated this default, so users would see `Runtime` timing data appearing in their cache without any explanation.

## How the discrepancy was found

Code inspection of `config.py`:

```python
def load_default_metadata():
    config = _load_merged_config()
    if "default" not in config or "metadata" not in config["default"]:
        return (metadata.Runtime(),)   # ← undocumented default
    ...
```

Verified with:

```python
from fleche.config import load_default_metadata
print(load_default_metadata())  # → (<fleche.metadata.Runtime object>,)
```

## Test plan

- [x] Confirmed `load_default_metadata()` returns `(Runtime(),)` with no config file present

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMqxvvTaXUJo1j3DWXnEwm)_