### PR TITLE
Add minimum-dependency CI exercising lower version bounds

### DIFF
--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -1,0 +1,18 @@
+name: test-minimum-deps
+
+on: pull_request
+
+jobs:
+  test-minimum-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # setuptools-scm derives the version from git history.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v5
+      - run: uv venv
+      # --resolution lowest-direct pins every direct dependency to the lowest
+      # version its bound allows, exercising the floors declared in pyproject.
+      - run: uv pip install --resolution lowest-direct -e ".[tests]"
+      - run: uv run --no-sync pytest

--- a/notebooks/StorageBackends.ipynb
+++ b/notebooks/StorageBackends.ipynb
@@ -25,17 +25,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:49.949163Z",
-     "iopub.status.busy": "2026-03-22T19:56:49.948989Z",
-     "iopub.status.idle": "2026-03-22T19:56:50.449807Z",
-     "shell.execute_reply": "2026-03-22T19:56:50.448807Z"
+     "iopub.execute_input": "2026-06-10T03:42:09.556968Z",
+     "iopub.status.busy": "2026-06-10T03:42:09.556770Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.177113Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.175771Z"
     }
    },
-   "outputs": [],
-   "source": "from fleche import fleche, cache\nfrom fleche.caches import Cache\nfrom fleche.storage import ValueMemory, CallMemory\n\n# Using Memory for both values and calls\nmemory_cache = Cache(values=ValueMemory({}), calls=CallMemory({}))\n\nwith cache(memory_cache):\n    @fleche\n    def add(a, b):\n        print(f\"Executing add({a}, {b})\")\n        return a + b\n    \n    print(f\"Result 1: {add(2, 3)}\")\n    print(f\"Result 2: {add(2, 3)}\") # This should be cached\nprint('Cache keys in calls storage:', list(memory_cache.calls.list()))"
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using default memory cache: no config file found\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing add(2, 3)\n",
+      "Result 1: 5\n",
+      "Result 2: 5\n",
+      "Cache keys in calls storage: ['947d73b2adcb9f69e1ddd5d05678a08983d98a971591910b0466084214a9cc08']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fleche import fleche, cache\n",
+    "from fleche.caches import Cache\n",
+    "from fleche.storage import ValueMemory, CallMemory\n",
+    "\n",
+    "# Using Memory for both values and calls\n",
+    "memory_cache = Cache(values=ValueMemory({}), calls=CallMemory({}))\n",
+    "\n",
+    "with cache(memory_cache):\n",
+    "    @fleche\n",
+    "    def add(a, b):\n",
+    "        print(f\"Executing add({a}, {b})\")\n",
+    "        return a + b\n",
+    "    \n",
+    "    print(f\"Result 1: {add(2, 3)}\")\n",
+    "    print(f\"Result 2: {add(2, 3)}\") # This should be cached\n",
+    "print('Cache keys in calls storage:', list(memory_cache.calls.list()))"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -48,17 +83,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:50.451880Z",
-     "iopub.status.busy": "2026-03-22T19:56:50.451542Z",
-     "iopub.status.idle": "2026-03-22T19:56:50.575246Z",
-     "shell.execute_reply": "2026-03-22T19:56:50.574139Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.215783Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.215516Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.361809Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.360032Z"
     }
    },
-   "outputs": [],
-   "source": "import shutil\nfrom pathlib import Path\nfrom fleche.storage import ValuePickleFile, CallPickleFile\n\nshutil.rmtree('.pickle_cache', ignore_errors=True)\npickle_cache = Cache(\n    values=ValuePickleFile.with_pickle(root='.pickle_cache/values'),\n    calls=CallPickleFile.with_pickle(root='.pickle_cache/calls')\n)\n\nwith cache(pickle_cache):\n    @fleche\n    def greet(name):\n        print(f\"Executing greet({name})\")\n        return f\"Hello, {name}!\"\n    \n    print(greet(\"World\"))\n    print(greet(\"World\"))\n\nprint(\"Files in calls storage:\")\n!ls .pickle_cache/calls"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing greet(World)\n",
+      "Hello, World!\n",
+      "Hello, World!\n",
+      "Files in calls storage:\n",
+      "e9cc541e2a3c72d117bec87999a8966057cdd5f356c83a98583288163d8ef535\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "from fleche.storage import ValuePickleFile, CallPickleFile\n",
+    "\n",
+    "shutil.rmtree('.pickle_cache', ignore_errors=True)\n",
+    "pickle_cache = Cache(\n",
+    "    values=ValuePickleFile.with_pickle(root='.pickle_cache/values'),\n",
+    "    calls=CallPickleFile.with_pickle(root='.pickle_cache/calls')\n",
+    ")\n",
+    "\n",
+    "with cache(pickle_cache):\n",
+    "    @fleche\n",
+    "    def greet(name):\n",
+    "        print(f\"Executing greet({name})\")\n",
+    "        return f\"Hello, {name}!\"\n",
+    "    \n",
+    "    print(greet(\"World\"))\n",
+    "    print(greet(\"World\"))\n",
+    "\n",
+    "print(\"Files in calls storage:\")\n",
+    "!ls .pickle_cache/calls"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -71,17 +140,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:50.577316Z",
-     "iopub.status.busy": "2026-03-22T19:56:50.577099Z",
-     "iopub.status.idle": "2026-03-22T19:56:50.585392Z",
-     "shell.execute_reply": "2026-03-22T19:56:50.584495Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.364620Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.364359Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.374990Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.373559Z"
     }
    },
-   "outputs": [],
-   "source": "import shutil\nshutil.rmtree('.compressed_pickle_cache', ignore_errors=True)\ncompressed_cache = Cache(\n    values=ValuePickleFile.with_pickle(root='.compressed_pickle_cache/values', compress=True),\n    calls=CallPickleFile.with_pickle(root='.compressed_pickle_cache/calls', compress=True)\n)\n\nwith cache(compressed_cache):\n    @fleche\n    def big_result(n):\n        return \"a\" * n\n    \n    big_result(1000)\n\nfile_path = list(Path('.compressed_pickle_cache/values').iterdir())[0]\nwith open(file_path, 'rb') as f:\n    header = f.read(2)\n    # check for gzip magic number 0x1f 0x8b\n    is_compressed = (header[0] == 0x1f) and (header[1] == 0x8b)\n    print(f\"Is gzip compressed: {is_compressed}\")"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Is gzip compressed: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import shutil\n",
+    "shutil.rmtree('.compressed_pickle_cache', ignore_errors=True)\n",
+    "compressed_cache = Cache(\n",
+    "    values=ValuePickleFile.with_pickle(root='.compressed_pickle_cache/values', compress=True),\n",
+    "    calls=CallPickleFile.with_pickle(root='.compressed_pickle_cache/calls', compress=True)\n",
+    ")\n",
+    "\n",
+    "with cache(compressed_cache):\n",
+    "    @fleche\n",
+    "    def big_result(n):\n",
+    "        return \"a\" * n\n",
+    "    \n",
+    "    big_result(1000)\n",
+    "\n",
+    "# Pick the largest file: the directory also holds small metadata entries\n",
+    "# and 0-byte filelock lock files, in filesystem-dependent order.\n",
+    "file_path = max(Path('.compressed_pickle_cache/values').iterdir(), key=lambda p: p.stat().st_size)\n",
+    "with open(file_path, 'rb') as f:\n",
+    "    header = f.read(2)\n",
+    "    # check for gzip magic number 0x1f 0x8b\n",
+    "    is_compressed = (header[0] == 0x1f) and (header[1] == 0x8b)\n",
+    "    print(f\"Is gzip compressed: {is_compressed}\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -94,17 +194,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:50.587178Z",
-     "iopub.status.busy": "2026-03-22T19:56:50.586992Z",
-     "iopub.status.idle": "2026-03-22T19:56:50.706524Z",
-     "shell.execute_reply": "2026-03-22T19:56:50.705580Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.377106Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.376903Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.503498Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.501938Z"
     }
    },
-   "outputs": [],
-   "source": "shutil.rmtree('.cloudpickle_cache', ignore_errors=True)\ncp_cache = Cache(\n    values=ValuePickleFile.with_cloudpickle(root='.cloudpickle_cache/values'),\n    calls=CallPickleFile.with_cloudpickle(root='.cloudpickle_cache/calls')\n)\n\nwith cache(cp_cache):\n    @fleche\n    def mul(a, b):\n        print(f\"Executing mul({a}, {b})\")\n        return a * b\n    \n    print(f\"Result: {mul(3, 4)}\")\n    print(f\"Result: {mul(3, 4)}\")\n\nprint(\"Files in values storage:\")\n!ls .cloudpickle_cache/values"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing mul(3, 4)\n",
+      "Result: 12\n",
+      "Result: 12\n",
+      "Files in values storage:\n",
+      "056a34cfa7662755ef47b05e966a8cd152ad9cd663134c03b0a4e6f61349c7e5\r\n",
+      "65d52a82c5a72f12ca0499522dc9274a0e6822e1038630ba68f94400b3e4c98f\r\n",
+      "83ada2198553b88cb3d0882f7fca8c4e9531049b978df3e9e3b5d6301c6c0bfa\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "shutil.rmtree('.cloudpickle_cache', ignore_errors=True)\n",
+    "cp_cache = Cache(\n",
+    "    values=ValuePickleFile.with_cloudpickle(root='.cloudpickle_cache/values'),\n",
+    "    calls=CallPickleFile.with_cloudpickle(root='.cloudpickle_cache/calls')\n",
+    ")\n",
+    "\n",
+    "with cache(cp_cache):\n",
+    "    @fleche\n",
+    "    def mul(a, b):\n",
+    "        print(f\"Executing mul({a}, {b})\")\n",
+    "        return a * b\n",
+    "    \n",
+    "    print(f\"Result: {mul(3, 4)}\")\n",
+    "    print(f\"Result: {mul(3, 4)}\")\n",
+    "\n",
+    "print(\"Files in values storage:\")\n",
+    "!ls .cloudpickle_cache/values"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -117,17 +249,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:50.708571Z",
-     "iopub.status.busy": "2026-03-22T19:56:50.708378Z",
-     "iopub.status.idle": "2026-03-22T19:56:50.829061Z",
-     "shell.execute_reply": "2026-03-22T19:56:50.827888Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.506509Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.506006Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.635136Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.633608Z"
     }
    },
-   "outputs": [],
-   "source": "shutil.rmtree('.dill_cache', ignore_errors=True)\ndill_cache = Cache(\n    values=ValuePickleFile.with_dill(root='.dill_cache/values'),\n    calls=CallPickleFile.with_dill(root='.dill_cache/calls')\n)\n\nwith cache(dill_cache):\n    @fleche\n    def add(a, b):\n        print(f\"Executing add({a}, {b})\")\n        return a + b\n    \n    print(f\"Result: {add(3, 4)}\")\n    print(f\"Result: {add(3, 4)}\")\n\nprint(\"Files in values storage:\")\n!ls .dill_cache/values"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing add(3, 4)\n",
+      "Result: 7\n",
+      "Result: 7\n",
+      "Files in values storage:\n",
+      "307ea96b8b27c58a4c93e2e34e3783e475dc0e8ef99b4c5bbfa6b67e2cab7d80\r\n",
+      "65d52a82c5a72f12ca0499522dc9274a0e6822e1038630ba68f94400b3e4c98f\r\n",
+      "83ada2198553b88cb3d0882f7fca8c4e9531049b978df3e9e3b5d6301c6c0bfa\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "shutil.rmtree('.dill_cache', ignore_errors=True)\n",
+    "dill_cache = Cache(\n",
+    "    values=ValuePickleFile.with_dill(root='.dill_cache/values'),\n",
+    "    calls=CallPickleFile.with_dill(root='.dill_cache/calls')\n",
+    ")\n",
+    "\n",
+    "with cache(dill_cache):\n",
+    "    @fleche\n",
+    "    def add(a, b):\n",
+    "        print(f\"Executing add({a}, {b})\")\n",
+    "        return a + b\n",
+    "    \n",
+    "    print(f\"Result: {add(3, 4)}\")\n",
+    "    print(f\"Result: {add(3, 4)}\")\n",
+    "\n",
+    "print(\"Files in values storage:\")\n",
+    "!ls .dill_cache/values"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -140,17 +304,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:50.831273Z",
-     "iopub.status.busy": "2026-03-22T19:56:50.831064Z",
-     "iopub.status.idle": "2026-03-22T19:56:50.959794Z",
-     "shell.execute_reply": "2026-03-22T19:56:50.958659Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.637982Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.637733Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.774276Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.772482Z"
     }
    },
-   "outputs": [],
-   "source": "import numpy as np\nfrom fleche.storage import ValueBagOfHoldingH5File\n\nshutil.rmtree('.boh_cache', ignore_errors=True)\nboh_cache = Cache(\n    values=ValueBagOfHoldingH5File(root='.boh_cache/values'),\n    calls=CallPickleFile.with_cloudpickle(root='.boh_cache/calls')  # We can use Cloudpickle for calls\n)\n\nwith cache(boh_cache):\n    @fleche\n    def make_array(n):\n        print(f\"Executing make_array({n})\")\n        return np.ones((n, n))\n\n    print(f\"Array sum: {make_array(5).sum()}\")\n    print(f\"Array sum: {make_array(5).sum()}\")\n\nprint(\"Files in H5 values storage:\")\n!ls .boh_cache/values"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing make_array(5)\n",
+      "Array sum: 25.0\n",
+      "Array sum: 25.0\n",
+      "Files in H5 values storage:\n",
+      "183708770a6459111eb4effccefdb31bac94cee07d7ea356d8e99b08b8551bcf\r\n",
+      "5b07a837d91d67764109c11fb912c9b91b4e9d9d4c909fca542e5fbe39ddc244\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from fleche.storage import ValueBagOfHoldingH5File\n",
+    "\n",
+    "shutil.rmtree('.boh_cache', ignore_errors=True)\n",
+    "boh_cache = Cache(\n",
+    "    values=ValueBagOfHoldingH5File(root='.boh_cache/values'),\n",
+    "    calls=CallPickleFile.with_cloudpickle(root='.boh_cache/calls')  # We can use Cloudpickle for calls\n",
+    ")\n",
+    "\n",
+    "with cache(boh_cache):\n",
+    "    @fleche\n",
+    "    def make_array(n):\n",
+    "        print(f\"Executing make_array({n})\")\n",
+    "        return np.ones((n, n))\n",
+    "\n",
+    "    print(f\"Array sum: {make_array(5).sum()}\")\n",
+    "    print(f\"Array sum: {make_array(5).sum()}\")\n",
+    "\n",
+    "print(\"Files in H5 values storage:\")\n",
+    "!ls .boh_cache/values"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -163,17 +361,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:50.961998Z",
-     "iopub.status.busy": "2026-03-22T19:56:50.961789Z",
-     "iopub.status.idle": "2026-03-22T19:56:51.006219Z",
-     "shell.execute_reply": "2026-03-22T19:56:51.005233Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.776879Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.776644Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.835894Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.834552Z"
     }
    },
-   "outputs": [],
-   "source": "from fleche.storage import Sql\nimport os\n\nif os.path.exists('calls.db'): os.remove('calls.db')\n\nsql_cache = Cache(\n    values=ValueMemory({}),\n    calls=Sql(url='sqlite:///calls.db')\n)\n\nwith cache(sql_cache):\n    @fleche\n    def power(a, b):\n        print(f\"Executing power({a}, {b})\")\n        return a ** b\n\n    power(2, 8)\n    power(2, 8)\n\nprint(\"Calls in SQL storage:\")\nprint(list(sql_cache.calls.list()))"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Executing power(2, 8)\n",
+      "Calls in SQL storage:\n",
+      "['bbbcff21a09114bee332b0f0da9085948aadc5177ac01dccbf54023426813087']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fleche.storage import Sql\n",
+    "import os\n",
+    "\n",
+    "if os.path.exists('calls.db'): os.remove('calls.db')\n",
+    "\n",
+    "sql_cache = Cache(\n",
+    "    values=ValueMemory({}),\n",
+    "    calls=Sql(url='sqlite:///calls.db')\n",
+    ")\n",
+    "\n",
+    "with cache(sql_cache):\n",
+    "    @fleche\n",
+    "    def power(a, b):\n",
+    "        print(f\"Executing power({a}, {b})\")\n",
+    "        return a ** b\n",
+    "\n",
+    "    power(2, 8)\n",
+    "    power(2, 8)\n",
+    "\n",
+    "print(\"Calls in SQL storage:\")\n",
+    "print(list(sql_cache.calls.list()))"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -186,35 +416,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:51.008027Z",
-     "iopub.status.busy": "2026-03-22T19:56:51.007846Z",
-     "iopub.status.idle": "2026-03-22T19:56:51.032418Z",
-     "shell.execute_reply": "2026-03-22T19:56:51.031506Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.838396Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.838162Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.878045Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.876672Z"
     }
    },
-   "outputs": [],
-   "source": "mixed_cache = Cache(\n    values=ValueBagOfHoldingH5File(root='.mixed_cache/values'),\n    calls=Sql(url='sqlite:///.mixed_cache/calls.db')\n)\n\nwith cache(mixed_cache):\n    @fleche\n    def compute_heavy(x):\n        return np.random.rand(x, x)\n    \n    compute_heavy(10)\n    \nprint(f\"Value storage: {type(mixed_cache.values).__name__}\")\nprint(f\"Call storage: {type(mixed_cache.calls).__name__}\")"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Value storage: ValueBagOfHoldingH5File\n",
+      "Call storage: Sql\n"
+     ]
+    }
+   ],
+   "source": [
+    "mixed_cache = Cache(\n",
+    "    values=ValueBagOfHoldingH5File(root='.mixed_cache/values'),\n",
+    "    calls=Sql(url='sqlite:///.mixed_cache/calls.db')\n",
+    ")\n",
+    "\n",
+    "with cache(mixed_cache):\n",
+    "    @fleche\n",
+    "    def compute_heavy(x):\n",
+    "        return np.random.rand(x, x)\n",
+    "    \n",
+    "    compute_heavy(10)\n",
+    "    \n",
+    "print(f\"Value storage: {type(mixed_cache.values).__name__}\")\n",
+    "print(f\"Call storage: {type(mixed_cache.calls).__name__}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Clean Up\n\nRemove temporary cache directories."
+   "source": [
+    "## Clean Up\n",
+    "\n",
+    "Remove temporary cache directories."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-22T19:56:51.034211Z",
-     "iopub.status.busy": "2026-03-22T19:56:51.033999Z",
-     "iopub.status.idle": "2026-03-22T19:56:51.041707Z",
-     "shell.execute_reply": "2026-03-22T19:56:51.040810Z"
+     "iopub.execute_input": "2026-06-10T03:42:10.880685Z",
+     "iopub.status.busy": "2026-06-10T03:42:10.880463Z",
+     "iopub.status.idle": "2026-06-10T03:42:10.886041Z",
+     "shell.execute_reply": "2026-06-10T03:42:10.884964Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned up temporary cache directories.\n"
+     ]
+    }
+   ],
    "source": [
     "import shutil, os\n",
     "for d in ('.pickle_cache', '.compressed_pickle_cache', '.cloudpickle_cache',\n",
@@ -242,7 +508,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ classifiers = [
 ]
 license = "BSD-3-Clause"
 dependencies = [
-    'numpy',
+    'numpy >= 1.26',
     'pandas >= 2.2, <4',
-    'pyiron-snippets',
-    'filelock',
+    'pyiron-snippets >= 1.1',
+    'filelock >= 3.4',
 ]
 
 [project.optional-dependencies]
@@ -45,32 +45,32 @@ docs = [
     "ipython_pygments_lexers",
 ]
 cloudpickle = [
-    "cloudpickle",
+    "cloudpickle >= 2",
 ]
 dill = [
-    "dill",
+    "dill >= 0.3",
 ]
 sqlalchemy = [
-    "sqlalchemy",
+    "sqlalchemy >= 2",
 ]
 bagofholding = [
     "bagofholding == 0.1.12",
 ]
 ssh = [
     # SshCache uses cloudpickle for its wire protocol — required, not optional.
-    "cloudpickle",
+    "cloudpickle >= 2",
 ]
 tests = [
-    "pytest",
-    "hypothesis",
-    "cloudpickle",
-    "dill",
-    "sqlalchemy",
+    "pytest >= 7.4",
+    "hypothesis >= 6.100",
+    "cloudpickle >= 2",
+    "dill >= 0.3",
+    "sqlalchemy >= 2",
     "bagofholding == 0.1.12",
-    "nbconvert",
-    "ipykernel",
-    "tabulate",
-    "attrs",
+    "nbconvert >= 6.5",
+    "ipykernel >= 6.26",
+    "tabulate >= 0.8",
+    "attrs >= 21.3",
 ]
 executorlib = [
     "executorlib",


### PR DESCRIPTION
Adds a `test-minimum-deps` workflow that installs the lowest version of every direct dependency its bound allows and runs the suite, so the declared floors are exercised on each PR.

## Workflow

```yaml
- run: uv venv
- run: uv pip install --resolution lowest-direct -e ".[tests]"
- run: uv run --no-sync pytest
```

No Python version is pinned; uv selects from `requires-python` (the runner default). `uv pip install --resolution lowest-direct` is used rather than `uv sync` because `uv sync` locks **all** extras universally — it fails on the unbounded `docs` deps (resolves sphinx to a 2008 sdist) and masks real minimums by floating deps up through cross-extra constraints.

## Floors added

Most deps were unbounded, so lowest-direct resolved to ancient versions. Each floor below is the lowest version that installs and passes on Python 3.12:

| dep | floor | reason at the previous lowest resolution |
|-----|-------|------------------------------------------|
| numpy | `>=1.26` | lowest with cp312 wheels |
| pyiron-snippets | `>=1.1` | `pyiron_snippets.versions` (used by `src/fleche/call.py`) appeared in 1.1 |
| filelock | `>=3.4` | 3.0 is from 2018, predates the current `FileLock` timeout API behaviour |
| sqlalchemy | `>=2` | `storage/sql.py` uses 2.0-style `mapped_column` / `Mapped` |
| attrs | `>=21.3` | first release exposing the `attrs` import namespace (`tests/unit/digest/test_attrs.py` does `import attrs`) |
| nbconvert | `>=6.5` | 6.0 imports `jinja2.contextfilter`, removed in jinja2 3.1 — all notebook tests fail |
| ipykernel | `>=6.26` | resolves jupyter-client 8; with jupyter-client 6.1 the kernel dies on startup and notebook tests hang the suite |
| hypothesis | `>=6.100` | older engines spend 6–9 s per passing test in `pareto_optimise`/`shrink` (profiled), making the suite appear stuck |
| pytest | `>=7.4` | first with Python 3.12 support |
| cloudpickle `>=2`, dill `>=0.3`, tabulate `>=0.8` | | defensive floors |

## Verification

Python 3.12, `uv pip install --resolution lowest-direct -e ".[tests]"` then `pytest`: **1038 passed, 11 skipped, 1 failed** in 4:15.

The one failure, `tests/unit/fleche/test_fleche.py::test_fleche_with_version`, is not floor-related: in the same environment it fails identically with all-latest dependencies (1 failed, 1038 passed), and on a clean latest-deps venv it fails when run standalone while passing when the whole file runs:

```
pytest tests/unit/fleche/test_fleche.py::test_fleche_with_version  # fails
pytest tests/unit/fleche/test_fleche.py                            # 7 passed
```

The test relies on Mock objects flowing through `FunctionProfile.of`, where `func.__code__` is an auto-created child Mock that gets digested — making the digest sensitive to execution order/environment. Worth a separate issue.

https://claude.ai/code/session_01FJDckvavAxiiuLj1CtkZZ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJDckvavAxiiuLj1CtkZZ9)_