### PR TITLE
test(D): cover digest-fallback path for non-short-hex inputs

### DIFF
--- a/tests/unit/fleche/test_digest_args.py
+++ b/tests/unit/fleche/test_digest_args.py
@@ -150,3 +150,28 @@ def test_short_digest_expansion_via_D():
 def test_D_alias():
     assert D("abc") == Digest("abc")
     assert isinstance(D("abc"), Digest)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        42,                  # non-string
+        "g" * 8,             # non-hex string (g is not a hex digit)
+        "abc!",              # mixed hex + non-hex
+        "",                  # empty string fails 0 < len
+        "a" * 65,            # exceeds DIGEST_LENGTH
+    ],
+    ids=["int", "non_hex", "mixed", "empty", "too_long"],
+)
+def test_D_falls_through_to_digest_for_non_short_hex(value):
+    """D() must compute the digest of any input that isn't a short hex string.
+
+    Pins the documented contract: only non-empty hex strings up to
+    DIGEST_LENGTH characters are used verbatim; anything else (non-strings,
+    empty strings, non-hex characters, too-long strings) is hashed.
+    """
+    from fleche import digest as _digest
+
+    result = D(value)
+    assert isinstance(result, Digest)
+    assert result == _digest.digest(value)


### PR DESCRIPTION
## Summary

Coverage sweep flagged `src/fleche/__init__.py` as the lowest-covered module (73%, sole non-trivial gap). The single uncovered statement is the `digest.digest(value)` fallback in `D()` — the path taken when the input is **not** a short hex string. Existing `test_D_alias` only exercises the hex-passthrough side.

This PR adds one parametrized test (5 boundary cases) that pins the documented `D()` contract: anything outside the *non-empty hex string of length ≤ DIGEST_LENGTH* window is hashed, not wrapped verbatim.

Cases covered:
- non-string (`int`)
- non-hex characters (`"g" * 8`)
- mixed hex + non-hex (`"abc!"`)
- empty string (fails `0 < len`)
- over-length (`"a" * 65`)

## Coverage report

Coverage was run with `pytest --cov=src/fleche --cov-branch tests/unit tests/regression tests/integration --ignore=tests/integration/test_notebooks.py` on `main`:

```
Name                                      Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------
src/fleche/__init__.py                       13      3      2      1    73%   5-6, 44
src/fleche/__main__.py                       21      3      6      2    81%   52-53, 57
src/fleche/_attrs.py                         12      2      0      0    83%   14-15
src/fleche/remote.py                        376     77     98      9    78%   ...
src/fleche/caches.py                        341     20    100      5    94%   ...
src/fleche/digest.py                        159      7     92      8    94%   ...
src/fleche/security.py                       57      3     26      2    94%   ...
src/fleche/storage/sql.py                   246     10     88      6    95%   ...
...
TOTAL                                      2722    155    808     51    94%
```

The remaining `__init__.py` misses (lines 5–6) are the `from ._version import __version__` `ImportError` fallback — only hit in an editable checkout without a built `_version.py`, not reachable from the test suite. Line 44 (the `D()` fallback) and the branch `[42 → 44]` were the only practically reachable gaps.

After this PR (running the same command):
- `src/fleche/__init__.py`: **73% → 87%** (line) and **branch gap closed** (`BrPart` 1 → 0).

## Test plan

- [x] `pytest tests/unit/fleche/test_digest_args.py` — 14 passed.
- [x] `pytest --cov=src/fleche --cov-branch tests/unit/fleche/test_digest_args.py` confirms `__init__.py` jumps to 87% and the missing branch is gone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eh1CvBvXtjJKN3DwHDmSMg)_