### PR TITLE
test: drop test_roundtrip_cache_stack_nested_readonly (zero-coverage compound shape)

### DIFF
--- a/tests/unit/config/test_cache_to_config.py
+++ b/tests/unit/config/test_cache_to_config.py
@@ -232,23 +232,3 @@ def test_roundtrip_sql(tmp_path):
     assert isinstance(reconstructed, Cache)
     assert isinstance(reconstructed.calls, storage.Sql)
     assert reconstructed.calls.url == url
-
-
-def test_roundtrip_cache_stack_nested_readonly():
-    stack = CacheStack((
-        ReadOnlyCache(
-            Cache(
-                values=storage.ValueMemory({}),
-                calls=storage.CallMemory({}),
-            )
-        ),
-        Cache(
-            values=storage.ValueVoid(),
-            calls=storage.CallVoid(),
-        ),
-    ))
-    reconstructed = cache_from_config(cache_to_config(stack))
-    assert isinstance(reconstructed, CacheStack)
-    assert isinstance(reconstructed.stack[0], ReadOnlyCache)
-    assert isinstance(reconstructed.stack[0].cache, Cache)
-    assert isinstance(reconstructed.stack[1], Cache)


### PR DESCRIPTION
## Summary

Step 2 of a coverage sweep: knock out a random sample of tests, measure per-test arc coverage, and drop tests that contribute nothing unique without weakening contract surface.

Methodology:
1. Ran the suite under `--cov-context=test` to record per-test arc coverage in `.coverage`'s SQLite DB.
2. Sampled 8 random tests via `shuf --random-source=<(python ... seed 42)`.
3. For each, computed *uniquely-covered arcs* across the whole suite.

| Sampled test | Unique arcs | Disposition |
|---|---|---|
| `test_attrs_define_can_be_digested` | 0 | **kept** — contract trio (`@attrs.define` / `@attr.s` / frozen); other attrs tests overlap by necessity, not accident. |
| `test_digest_shrink_with_explicit_cache_forwards_to_cache` | 1 (`digest.py 50→53`) | **kept** — `if cache is None: False` branch of `Digest.shrink`. Cited explicitly in the test file's docstring. |
| `test_backend_put_get_roundtrip[pickle]` | 0 | **kept** — row of the cross-backend `storage_backend` parametrization sweep. |
| `test_cache_functional_roundtrip[dill-sql]` | 0 | **kept** — combinatorial sweep of `value_storage × call_storage` for pickle roundtrip. |
| `test_kwonly_partial_with_values` | 0 | **kept** — row of the `QueryCall.from_call` partial-binding contract matrix (one of `simple / args / kwargs / kwonly / posonly / defaults`). |
| `test_digest_shrink_without_cache_uses_active_cache` | 3 (`digest.py 50→51, 51→52, 52→53`) | **kept** — `if cache is None: True` branch of `Digest.shrink`. |
| `test_cache_query_decodes_values_and_args` | 0 | **kept** — documented contract that `Cache.query` decodes digested args/result before yielding. |
| `test_roundtrip_cache_stack_nested_readonly` | 0 | **removed in this PR**. |

### Why this one

`test_roundtrip_cache_stack_nested_readonly` asserts that a `CacheStack` containing a `ReadOnlyCache(Cache(...))` round-trips through `cache_to_config` / `cache_from_config`. The dispatcher is shape-by-shape independent (list → `CacheStack`; `read_only` → `ReadOnlyCache` wrap; etc.), and the constituent legs are already covered:
- `test_roundtrip_readonly` covers `ReadOnlyCache(Cache(...))`.
- `test_roundtrip_cache_stack` covers `CacheStack((Cache, Cache))`.

The compound shape adds no code path that isn't already exercised — it's mechanically the composition of the individual round-trips. Removing it leaves the contract surface intact.

The other zero-unique tests stay: each is part of a deliberate parametrization sweep, contract matrix, or docstring-cited contract. The instructions are explicit that contract/invariant tests should be kept even when their unique-coverage contribution is zero, and these all qualify.

## Coverage report

`pytest --cov=src/fleche --cov-branch tests/unit tests/regression tests/integration --ignore=tests/integration/test_notebooks.py`, before and after:

|  | Before | After |
|---|---|---|
| Lines covered | 2567 / 2722 | 2567 / 2722 |
| Line coverage | 93.65% | 93.65% |
| Branches covered | 739 / 808 | 739 / 808 |
| Branch coverage | 91.46% | 91.46% |

Exactly zero coverage delta from the removal. (The +1 line / +1 branch you may see if you cross-reference the per-test session output came from #646's new `D()` test, which is unrelated to this PR.)

## Test plan

- [x] `pytest tests/unit/config/test_cache_to_config.py` — 18 passed (down from 19 by exactly the deleted test).
- [x] Per-test arc analysis (script described above) confirms zero arcs were uniquely covered by this test.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eh1CvBvXtjJKN3DwHDmSMg)_