### PR TITLE
fix(digest): handle type objects without raising Indigestible

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -273,6 +273,12 @@ def _digest_bytes(value: Any) -> bytes:
             m.update(_digest_bytes(value.__func__))
         case property():
             m.update(_digest_bytes((value.fget, value.fset, value.fdel)))
+        case _ if isinstance(value, type):
+            # Digest a class (type object) by its fully-qualified name: module + qualname.
+            # This case must precede the dataclasses check because dataclasses.is_dataclass()
+            # returns True for both the class itself and its instances, but
+            # getattr(cls, field_name) raises AttributeError for required fields.
+            m.update(_digest_bytes(f"{getattr(value, '__module__', '')}.{getattr(value, '__qualname__', value.__name__)}"))
         case _ if dataclasses.is_dataclass(value):
             # cannot use asdict because it recursively converts values which destroys digests
             # instead (flat-) convert to dictionaries, salt with type name, then fallback to dictionary case.

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -279,7 +279,7 @@ def _digest_bytes(value: Any) -> bytes:
             # This case must precede the dataclasses check: is_dataclass() returns True
             # for both a class and its instances, but getattr(cls, field) raises
             # AttributeError for required fields that have no class-level default.
-            m.update(_digest_bytes(f"builtins.{value.__qualname__}"))
+            return _digest_bytes(f"builtins.{value.__qualname__}")
         case _ if dataclasses.is_dataclass(value) and not isinstance(value, type):
             # cannot use asdict because it recursively converts values which destroys digests
             # instead (flat-) convert to dictionaries, salt with type name, then fallback to dictionary case.

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -273,13 +273,14 @@ def _digest_bytes(value: Any) -> bytes:
             m.update(_digest_bytes(value.__func__))
         case property():
             m.update(_digest_bytes((value.fget, value.fset, value.fdel)))
-        case _ if isinstance(value, type):
-            # Digest a class (type object) by its fully-qualified name: module + qualname.
-            # This case must precede the dataclasses check because dataclasses.is_dataclass()
-            # returns True for both the class itself and its instances, but
-            # getattr(cls, field_name) raises AttributeError for required fields.
-            m.update(_digest_bytes(f"{getattr(value, '__module__', '')}.{getattr(value, '__qualname__', value.__name__)}"))
-        case _ if dataclasses.is_dataclass(value):
+        case _ if isinstance(value, type) and value.__module__ == 'builtins':
+            # Digest a built-in type (int, str, list, …) by its qualified name.
+            # Restricted to the builtins module; user-defined types remain Indigestible.
+            # This case must precede the dataclasses check: is_dataclass() returns True
+            # for both a class and its instances, but getattr(cls, field) raises
+            # AttributeError for required fields that have no class-level default.
+            m.update(_digest_bytes(f"builtins.{value.__qualname__}"))
+        case _ if dataclasses.is_dataclass(value) and not isinstance(value, type):
             # cannot use asdict because it recursively converts values which destroys digests
             # instead (flat-) convert to dictionaries, salt with type name, then fallback to dictionary case.
             fields = map(

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -851,68 +851,56 @@ def test_module_digest_function_content_independence():
 
 
 def test_builtin_types_are_digestible():
-    """Built-in types must not raise Indigestible."""
+    """Built-in types (builtins module) must not raise Indigestible."""
     for t in (int, str, float, bool, bytes, list, dict, tuple, set, type, object):
         assert isinstance(digest(t), Digest)
 
 
-def test_dataclass_type_is_digestible():
-    """Digesting a dataclass *class* (not an instance) must not raise."""
-
-    @dataclass
-    class Point:
-        x: float
-        y: float
-
-    assert isinstance(digest(Point), Digest)
-
-
-def test_plain_class_is_digestible():
-    """User-defined non-dataclass classes must be digestible."""
-
-    class MyClass:
-        pass
-
-    assert isinstance(digest(MyClass), Digest)
-
-
-def test_type_digest_is_stable():
-    """Digesting the same type object twice returns the same value."""
+def test_builtin_type_digest_is_stable():
+    """Digesting the same built-in type twice returns the same value."""
     assert digest(int) == digest(int)
     assert digest(str) == digest(str)
 
 
-def test_different_types_have_different_digests():
-    """int and str must produce different digests."""
+def test_different_builtin_types_have_different_digests():
+    """int, str, and float must produce distinct digests."""
     assert digest(int) != digest(str)
     assert digest(int) != digest(float)
 
 
-def test_type_digest_differs_from_instance_digest():
-    """digest(int) must differ from digest(0), the most natural int instance."""
+def test_builtin_type_digest_differs_from_instance_digest():
+    """digest(int) must differ from digest(0)."""
     assert digest(int) != digest(0)
 
 
-def test_dataclass_type_differs_from_instance():
-    """Digesting a dataclass class must differ from digesting one of its instances."""
+def test_user_defined_class_raises_indigestible():
+    """User-defined classes are not digestible (only builtins are)."""
+    from fleche.digest import Indigestible
+
+    class MyClass:
+        pass
+
+    with pytest.raises(Indigestible):
+        digest(MyClass)
+
+
+def test_dataclass_type_raises_indigestible():
+    """A dataclass *class* (not instance) is not digestible."""
+    from fleche.digest import Indigestible
 
     @dataclass
     class Pt:
         x: int
 
-    assert digest(Pt) != digest(Pt(x=1))
+    with pytest.raises(Indigestible):
+        digest(Pt)
 
 
-def test_two_classes_with_same_name_in_same_scope_have_same_digest():
-    """Two class objects sharing module + qualname (e.g. redefined in the same scope)
-    must produce the same digest — identity is determined by name, not object id."""
+def test_dataclass_instance_still_works():
+    """The dataclass instance path must not be broken by the type guard."""
 
-    class Temp:
-        pass
+    @dataclass
+    class Pt:
+        x: int
 
-    first_digest = digest(Temp)
-
-    class Temp:  # noqa: F811 — intentional redefinition
-        pass
-
-    assert digest(Temp) == first_digest
+    assert isinstance(digest(Pt(x=1)), Digest)

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -845,3 +845,74 @@ def test_module_digest_function_content_independence():
     m2.__all__ = ["func"]
 
     assert digest(m1) == digest(m2)
+
+
+# --- Tests for digesting types (classes) — issue #469 ---
+
+
+def test_builtin_types_are_digestible():
+    """Built-in types must not raise Indigestible."""
+    for t in (int, str, float, bool, bytes, list, dict, tuple, set, type, object):
+        assert isinstance(digest(t), Digest)
+
+
+def test_dataclass_type_is_digestible():
+    """Digesting a dataclass *class* (not an instance) must not raise."""
+
+    @dataclass
+    class Point:
+        x: float
+        y: float
+
+    assert isinstance(digest(Point), Digest)
+
+
+def test_plain_class_is_digestible():
+    """User-defined non-dataclass classes must be digestible."""
+
+    class MyClass:
+        pass
+
+    assert isinstance(digest(MyClass), Digest)
+
+
+def test_type_digest_is_stable():
+    """Digesting the same type object twice returns the same value."""
+    assert digest(int) == digest(int)
+    assert digest(str) == digest(str)
+
+
+def test_different_types_have_different_digests():
+    """int and str must produce different digests."""
+    assert digest(int) != digest(str)
+    assert digest(int) != digest(float)
+
+
+def test_type_digest_differs_from_instance_digest():
+    """digest(int) must differ from digest(0), the most natural int instance."""
+    assert digest(int) != digest(0)
+
+
+def test_dataclass_type_differs_from_instance():
+    """Digesting a dataclass class must differ from digesting one of its instances."""
+
+    @dataclass
+    class Pt:
+        x: int
+
+    assert digest(Pt) != digest(Pt(x=1))
+
+
+def test_two_classes_with_same_name_in_same_scope_have_same_digest():
+    """Two class objects sharing module + qualname (e.g. redefined in the same scope)
+    must produce the same digest — identity is determined by name, not object id."""
+
+    class Temp:
+        pass
+
+    first_digest = digest(Temp)
+
+    class Temp:  # noqa: F811 — intentional redefinition
+        pass
+
+    assert digest(Temp) == first_digest

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -75,6 +75,11 @@ def test_supported_types():
         {"a": 1, "b": None},
         np.array([1, 2, 3]),
         MyData(x=1, y="a"),
+        # built-in types (the class objects themselves) — issue #469
+        int,
+        str,
+        list,
+        dict,
     ]
 
     for example in supported_examples:
@@ -849,28 +854,26 @@ def test_module_digest_function_content_independence():
 
 # --- Tests for digesting types (classes) — issue #469 ---
 
+# Only built-in types (the ``builtins`` module) are digestible; everything else
+# raises ``Indigestible``.  Digestibility of these is also covered generically by
+# ``test_supported_types``; the parametrized tests below pin down distinctness.
+BUILTIN_TYPES = (int, str, float, bool, bytes, list, dict, tuple, set, type, object)
 
-def test_builtin_types_are_digestible():
+
+@pytest.mark.parametrize("t", BUILTIN_TYPES)
+def test_builtin_type_is_digestible(t):
     """Built-in types (builtins module) must not raise Indigestible."""
-    for t in (int, str, float, bool, bytes, list, dict, tuple, set, type, object):
-        assert isinstance(digest(t), Digest)
+    assert isinstance(digest(t), Digest)
 
 
-def test_builtin_type_digest_is_stable():
-    """Digesting the same built-in type twice returns the same value."""
-    assert digest(int) == digest(int)
-    assert digest(str) == digest(str)
-
-
-def test_different_builtin_types_have_different_digests():
-    """int, str, and float must produce distinct digests."""
-    assert digest(int) != digest(str)
-    assert digest(int) != digest(float)
-
-
-def test_builtin_type_digest_differs_from_instance_digest():
-    """digest(int) must differ from digest(0)."""
-    assert digest(int) != digest(0)
+@pytest.mark.parametrize("t2", BUILTIN_TYPES)
+@pytest.mark.parametrize("t1", BUILTIN_TYPES)
+def test_builtin_type_digests_distinct(t1, t2):
+    """Equal types digest equally; distinct types digest distinctly."""
+    if t1 is t2:
+        assert digest(t1) == digest(t2)
+    else:
+        assert digest(t1) != digest(t2)
 
 
 def test_user_defined_class_raises_indigestible():

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -18,7 +18,7 @@ import keyword
 
 
 from fleche import fleche
-from fleche.digest import digest, Digest
+from fleche.digest import digest, Digest, Indigestible
 from fleche.call import Call
 
 
@@ -854,16 +854,7 @@ def test_module_digest_function_content_independence():
 
 # --- Tests for digesting types (classes) — issue #469 ---
 
-# Only built-in types (the ``builtins`` module) are digestible; everything else
-# raises ``Indigestible``.  Digestibility of these is also covered generically by
-# ``test_supported_types``; the parametrized tests below pin down distinctness.
 BUILTIN_TYPES = (int, str, float, bool, bytes, list, dict, tuple, set, type, object)
-
-
-@pytest.mark.parametrize("t", BUILTIN_TYPES)
-def test_builtin_type_is_digestible(t):
-    """Built-in types (builtins module) must not raise Indigestible."""
-    assert isinstance(digest(t), Digest)
 
 
 @pytest.mark.parametrize("t2", BUILTIN_TYPES)
@@ -876,34 +867,13 @@ def test_builtin_type_digests_distinct(t1, t2):
         assert digest(t1) != digest(t2)
 
 
-def test_user_defined_class_raises_indigestible():
-    """User-defined classes are not digestible (only builtins are)."""
-    from fleche.digest import Indigestible
+@dataclass
+class _Pt:
+    x: int
 
-    class MyClass:
-        pass
 
+@pytest.mark.parametrize("t", [type("MyClass", (), {}), _Pt])
+def test_non_builtin_type_raises_indigestible(t):
+    """Non-builtin type objects (user-defined classes, dataclass classes) raise Indigestible."""
     with pytest.raises(Indigestible):
-        digest(MyClass)
-
-
-def test_dataclass_type_raises_indigestible():
-    """A dataclass *class* (not instance) is not digestible."""
-    from fleche.digest import Indigestible
-
-    @dataclass
-    class Pt:
-        x: int
-
-    with pytest.raises(Indigestible):
-        digest(Pt)
-
-
-def test_dataclass_instance_still_works():
-    """The dataclass instance path must not be broken by the type guard."""
-
-    @dataclass
-    class Pt:
-        x: int
-
-    assert isinstance(digest(Pt(x=1)), Digest)
+        digest(t)

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -56,34 +56,55 @@ def test_custom_digest_priority():
     assert digest(CustomDict(a=1)) == "custom_dict_digest"
 
 
+@dataclass
+class _SupportedData:
+    x: int
+    y: str
+
+
+# Built-in type objects (the classes themselves) are digestible per issue #469;
+# anything outside the ``builtins`` module raises ``Indigestible`` (see the
+# negative boundary test near the end of this file).
+BUILTIN_TYPES = (int, str, float, bool, bytes, list, dict, tuple, set, type, object)
+
+# One representative value per digestible category, all mutually distinct.  Used
+# both as the digestibility smoke test and as the basis for the distinctness
+# product test below.
+SUPPORTED_VALUES = [
+    "hello",
+    123,
+    123.456,
+    True,
+    None,
+    ("a", 1, None),
+    ["a", 1, None],
+    {"a": 1, "b": None},
+    np.array([1, 2, 3]),
+    _SupportedData(x=1, y="a"),
+    *BUILTIN_TYPES,
+]
+
+
 def test_supported_types():
-    """Test that all supported types can be digested without raising an exception."""
+    """All supported values can be digested without raising an exception."""
+    for value in SUPPORTED_VALUES:
+        digest(value)
 
-    @dataclass
-    class MyData:
-        x: int
-        y: str
 
-    supported_examples = [
-        "hello",
-        123,
-        123.456,
-        True,
-        None,
-        ("a", 1, None),
-        ["a", 1, None],
-        {"a": 1, "b": None},
-        np.array([1, 2, 3]),
-        MyData(x=1, y="a"),
-        # built-in types (the class objects themselves) — issue #469
-        int,
-        str,
-        list,
-        dict,
-    ]
+@pytest.mark.parametrize("j", range(len(SUPPORTED_VALUES)))
+@pytest.mark.parametrize("i", range(len(SUPPORTED_VALUES)))
+def test_supported_values_digest_distinctly(i, j):
+    """Distinct supported values digest distinctly; the same value digests stably.
 
-    for example in supported_examples:
-        digest(example)
+    Built-in type objects (issue #469) are folded into SUPPORTED_VALUES, so their
+    digestibility, stability, and pairwise distinctness — including type-vs-instance
+    — are all covered here rather than in a bespoke builtins-only test.
+    """
+    a, b = SUPPORTED_VALUES[i], SUPPORTED_VALUES[j]
+    if i == j:
+        assert digest(a) == digest(b)
+    else:
+        assert digest(a) != digest(b)
 
 
 @given(st.integers(), st.integers())
@@ -852,19 +873,12 @@ def test_module_digest_function_content_independence():
     assert digest(m1) == digest(m2)
 
 
-# --- Tests for digesting types (classes) — issue #469 ---
-
-BUILTIN_TYPES = (int, str, float, bool, bytes, list, dict, tuple, set, type, object)
-
-
-@pytest.mark.parametrize("t2", BUILTIN_TYPES)
-@pytest.mark.parametrize("t1", BUILTIN_TYPES)
-def test_builtin_type_digests_distinct(t1, t2):
-    """Equal types digest equally; distinct types digest distinctly."""
-    if t1 is t2:
-        assert digest(t1) == digest(t2)
-    else:
-        assert digest(t1) != digest(t2)
+# --- Tests for the Indigestible boundary of type objects — issue #469 ---
+#
+# Digestibility, stability, and distinctness of built-in type objects are covered
+# by ``test_supported_values_digest_distinctly`` (BUILTIN_TYPES are folded into
+# SUPPORTED_VALUES).  Only the negative boundary needs a dedicated test: anything
+# outside the ``builtins`` module — including dataclass *classes* — must raise.
 
 
 @dataclass


### PR DESCRIPTION
Closes #469.

## Problem

`digest(int)`, `digest(str)`, and `digest(SomeDataclass)` (a class object, not an instance) all failed:

- Built-in types raised `Indigestible` — no match arm handled them.
- Dataclass *classes* hit the `dataclasses.is_dataclass` arm and then crashed with `AttributeError` on `getattr(cls, field_name)` for required fields that have no class-level attribute.

`dataclasses.is_dataclass()` returns `True` for both the class and its instances, which was the source of the class/instance confusion.

## Fix

Two changes in `_digest_bytes` (`src/fleche/digest.py`):

1. Insert `case _ if isinstance(value, type) and value.__module__ == 'builtins':` **before** the dataclass arm. Built-in types (`int`, `str`, `list`, …) are digested by their qualified name (`builtins.<qualname>`). This is deliberately **restricted to the `builtins` module** — user-defined classes (including dataclass *classes*) still raise `Indigestible` as before.
2. Add a `and not isinstance(value, type)` guard to the dataclass arm, so it is only reached by dataclass *instances*, never the class object.

## Tests

New tests in `tests/unit/digest/test_digest.py` covering:
- Built-in types are digestible without error
- Built-in type digest is stable (`digest(int) == digest(int)`)
- Different built-in types produce different digests
- Built-in type digest differs from instance digest (`digest(int) != digest(0)`)
- User-defined classes raise `Indigestible`
- Dataclass *classes* raise `Indigestible`
- Dataclass *instances* still digest correctly (type guard doesn't break the instance path)

https://claude.ai/code/session_01UTuB8gbhCrdtR5Q2rvMoSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTuB8gbhCrdtR5Q2rvMoSS)_