### PR TITLE
docs(helpers): fix bind() example to demonstrate cross-context use

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -56,9 +56,11 @@ Optionally pre-applies ``*args`` and ``**kwargs`` via :func:`functools.partial`.
        return a + b
 
    with cache("memory"):
-       bound = add.bind()      # freezes the active "memory" cache
-       result = bound(1, 2)    # runs under that cache regardless of current context
-       assert result == 3
+       bound = add.bind()   # freezes the active "memory" cache
+
+   # bound carries the "memory" cache — callable anywhere, no context needed
+   result = bound(1, 2)
+   assert result == 3
 
    # Pre-apply arguments
    with cache("memory"):


### PR DESCRIPTION
## Problem

The `bind()` example in `docs/usage/helpers.rst` called `bound(1, 2)` inside the **same** `with cache("memory"):` block where `bind()` was called:

```python
with cache("memory"):
    bound = add.bind()      # freezes the active "memory" cache
    result = bound(1, 2)    # runs under that cache regardless of current context
    assert result == 3
```

The comment *"regardless of current context"* is misleading because the `"memory"` context is still active at the call site — `BoundWrapper` adds no observable value inside the same block. The whole point of `bind()` is that the frozen cache travels with the callable *outside* its creation context.

## Fix

Move `bound(1, 2)` outside the `with` block so the example actually demonstrates the freeze-and-carry semantics:

```python
with cache("memory"):
    bound = add.bind()   # freezes the active "memory" cache

# bound carries the "memory" cache — callable anywhere, no context needed
result = bound(1, 2)
assert result == 3
```

## Verification

Running the corrected snippet confirms `result == 3` with no active cache context at the call site.

https://claude.ai/code/session_01KmpuvojoLsfzyLZDAdAxDk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmpuvojoLsfzyLZDAdAxDk)_