### PR TITLE
test(remote): cover real-subprocess lifecycle of _SshConnection

### DIFF
--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -655,6 +655,58 @@ def test_sshcache_workdir_omitted_from_config_when_unset():
     assert "workdir" not in d
 
 
+# ---------------------------------------------------------------------------
+# Real subprocess lifecycle (covers _SshConnection._open / _diagnose / _close)
+# ---------------------------------------------------------------------------
+
+
+def test_sshconnection_surfaces_remote_exit_code_and_stderr_tail():
+    """Real-subprocess failure surfaces exit code + stderr tail to the caller.
+
+    All other tests stub the transport with in-process pipes, so the
+    :class:`_SshConnection` lifecycle (spawn, stderr forwarder, diagnose,
+    teardown) is otherwise unexercised. Here we substitute the SSH argv
+    with a local Python one-liner that writes to stderr and exits
+    non-zero, then drive a single RPC: the resulting
+    :class:`RemoteConnectionError` must carry the exit code and stderr
+    tail produced by :meth:`_SshConnection._diagnose`. This is the
+    user-visible promise that a failed ``module load`` / missing remote
+    venv shows up as a useful error instead of a bare ``EOFError``.
+    """
+    from fleche.remote import RemoteConnectionError, _SshConnection
+
+    script = (
+        "import sys\n"
+        "sys.stderr.write('module: command not found\\n')\n"
+        "sys.stderr.flush()\n"
+        "sys.exit(7)\n"
+    )
+
+    class _LocalSubprocess(_SshConnection):
+        def _build_command(self):
+            return [sys.executable, "-c", script]
+
+    conn = _LocalSubprocess(
+        host="local.host",
+        python=sys.executable,
+        cache_name=None,
+        ssh_options=(),
+        setup_commands=(),
+    )
+    try:
+        with pytest.raises(RemoteConnectionError) as excinfo:
+            conn.call("contains", "deadbeef")
+    finally:
+        conn.close()
+    msg = str(excinfo.value)
+    assert "Remote cache connection lost during 'contains'" in msg
+    assert "remote exit code: 7" in msg
+    assert "module: command not found" in msg
+    # _close() drops the proc and the stderr thread.
+    assert conn._proc is None
+    assert conn._stderr_thread is None
+
+
 def test_cache_stack_with_ssh_layer():
     """A stack of [local, ssh] composes via the existing array-of-tables path."""
     from fleche.config import cache_from_config


### PR DESCRIPTION
## Summary

Ran branch-coverage across the test suite. `src/fleche/remote.py` was the clear outlier at **78%** — every other module is ≥87%, and most are ≥94%. The single biggest contiguous gap is the real-subprocess path through `_SshConnection._open` / `_diagnose` / `_close` (lines 550-616, ~40 stmts + branches): every existing test of `fleche.remote` substitutes an in-process `os.pipe()` transport, so the SSH-side lifecycle — spawn, stderr drain, exit-code capture, teardown — is entirely unexercised.

This PR adds one focused test:

- **`test_sshconnection_surfaces_remote_exit_code_and_stderr_tail`** swaps the SSH argv for a local `python -c` one-liner that writes `module: command not found` to stderr and exits `7`. The next RPC must raise `RemoteConnectionError` carrying both the exit code and the stderr tail produced by `_diagnose`. This is the user-visible promise that a failed `module load` / missing remote venv shows up as a useful error instead of a bare `EOFError` — currently only contract-tested with a stubbed `_diagnose`, never against the real subprocess.

## Coverage report

Before:

```
src/fleche/remote.py     376    77   98     9   78%
TOTAL                   2722   153  808    50   94%
```

After:

```
src/fleche/remote.py     376    43   98    16   87%
TOTAL                   2722   121  808    57   95%
```

`remote.py` branch coverage **78% → 87%** (+9 pts, 34 fewer missing lines); overall **94% → 95%**. Newly covered: most of `_SshConnection._open` (550-574), the bulk of `_diagnose` (580-592), and the happy-path of `_close` (594-616). What remains uncovered there is the `FileNotFoundError` branch (560-561) and the timeout-then-terminate-then-kill ladder (607-612), both of which need either ssh-binary absence or a hung subprocess to drive.

## Test plan

- [x] `pytest tests/unit/test_remote.py::test_sshconnection_surfaces_remote_exit_code_and_stderr_tail` passes locally
- [x] Full suite (1044 tests) still green
- [x] No regression in coverage of any other module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UoFqvvd5xQgiREPWR9ssN

---
_Generated by [Claude Code](https://claude.ai/code/session_016UoFqvvd5xQgiREPWR9ssN)_