### PR TITLE
fix(tests): allow byte-distinct NaNs to digest differently

### DIFF
--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -93,11 +93,15 @@ def test_different_integers_have_different_hashes(x, y):
 @given(st.floats(allow_nan=True), st.floats(allow_nan=True))
 def test_different_floats_have_different_hashes(x, y):
     """Test that two different floats have different hashes."""
-    # Handle NaN comparison and sign comparison
-    both_nan = math.isnan(x) and math.isnan(y)
-    same_sign = math.copysign(1, x) == math.copysign(1, y)
-
-    if (both_nan and same_sign) or x == y:
+    if math.isnan(x) or math.isnan(y):
+        # NaN case: digest is based on raw binary packing
+        x_bytes = struct.pack("<d", x)
+        y_bytes = struct.pack("<d", y)
+        if x_bytes == y_bytes:
+            assert digest(x) == digest(y)
+        else:
+            assert digest(x) != digest(y)
+    elif x == y:
         assert digest(x) == digest(y)
     else:
         assert digest(x) != digest(y)


### PR DESCRIPTION
## Summary
- `test_different_floats_have_different_hashes` was flaky on NaN: it asserted that any two same-sign NaNs digest identically, but the digest packs floats via `struct.pack("<d", value)`, which preserves the full bit pattern. Signaling vs quiet NaNs (and other payload differences) legitimately hash differently.
- Mirror the byte-comparison branch already used by `test_different_complex_numbers_have_different_digests`: if either input is NaN, compare on `struct.pack("<d", …)` bytes — equal bytes must share a digest, distinct bytes must not.

## Test plan
- [x] `pytest tests/unit/digest/test_digest.py::test_different_floats_have_different_hashes`
- [x] `pytest tests/unit/digest/test_digest.py` (69 passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_015M9TuxdRpxDfaqSeKKH5DB)_