### PR TITLE
ci: persist Hypothesis example database as GitHub artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,8 +47,19 @@ jobs:
     - name: run tests
       if: needs.changes.outputs.run == 'true'
       shell: bash -l {0}
+      env:
+        HYPOTHESIS_ARTIFACT_NAME: hypothesis-example-db-py${{ matrix.python-version }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pytest
+    - name: Upload Hypothesis example database
+      if: needs.changes.outputs.run == 'true' && always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hypothesis-example-db-py${{ matrix.python-version }}
+        path: .hypothesis/examples
+        if-no-files-found: ignore
+        retention-days: 90
 
   sql-backends:
     needs: changes
@@ -99,8 +110,19 @@ jobs:
         pip install psycopg2-binary pymysql
     - name: Run sqlalchemy backend tests
       shell: bash -l {0}
+      env:
+        HYPOTHESIS_ARTIFACT_NAME: hypothesis-example-db-sql-backends
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Run the cross-backend conformance tests plus every test that uses
         # the parametrized call_storage fixture. The env vars cause the
         # ``sql_postgres`` / ``sql_mysql`` parametrizations to activate.
         pytest tests/regression/test_sql_non_sqlite_backends.py tests/unit/storage/ -v
+    - name: Upload Hypothesis example database
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: hypothesis-example-db-sql-backends
+        path: .hypothesis/examples
+        if-no-files-found: ignore
+        retention-days: 90

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,25 @@
+import os
+
+from hypothesis import settings
+from hypothesis.database import (
+    DirectoryBasedExampleDatabase,
+    GitHubArtifactDatabase,
+    MultiplexedDatabase,
+    ReadOnlyDatabase,
+)
+
 pytest_plugins = ["tests.fixtures"]
+
+if os.environ.get("GITHUB_ACTIONS") == "true":
+    _local = DirectoryBasedExampleDatabase(".hypothesis/examples")
+    _shared = ReadOnlyDatabase(
+        GitHubArtifactDatabase(
+            "pmrv",
+            "fleche",
+            artifact_name=os.environ.get(
+                "HYPOTHESIS_ARTIFACT_NAME", "hypothesis-example-db"
+            ),
+        )
+    )
+    settings.register_profile("ci", database=MultiplexedDatabase(_local, _shared))
+    settings.load_profile("ci")


### PR DESCRIPTION
## Summary

Persist the Hypothesis example database across CI runs so that failing examples found in one run are replayed in subsequent runs.

- **`tests/conftest.py`** — registers a CI-only Hypothesis profile that multiplexes the local `.hypothesis/examples` directory with a read-only `GitHubArtifactDatabase` view of the latest artifact on `main`. Gated on `GITHUB_ACTIONS=true` so local runs are untouched. The artifact name is overridable via `HYPOTHESIS_ARTIFACT_NAME` so each matrix cell can fetch its own.
- **`.github/workflows/tests.yml`** — adds an `upload-artifact@v4` step at the end of both the `build` matrix and the `sql-backends` job. Each matrix cell gets its own artifact (`hypothesis-example-db-py{version}` / `hypothesis-example-db-sql-backends`) so the four Python versions don't collide. `GITHUB_TOKEN` is forwarded to the test step to avoid hitting the unauthenticated 60/hr rate limit on the artifact lookup.

## Test plan

- [ ] Confirm CI artifacts named `hypothesis-example-db-py3.{11,12,13,14}` and `hypothesis-example-db-sql-backends` appear on this PR's workflow run.
- [ ] On a subsequent run, check the pytest output for the Hypothesis "Loading X failing examples from GitHub artifact" line, confirming the read-only side is wired.
- [ ] Verify local `pytest` is unaffected (no `GITHUB_ACTIONS` env var → CI profile not loaded).


---
_Generated by [Claude Code](https://claude.ai/code/session_011AhoTDRSwhey1iSFE7VTCb)_