### PR TITLE
ci(claude): narrow allowedTools to keep app identity on comments/pushes

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -27,8 +27,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: |
-            --model opus --effort high
-            --allowedTools "WebFetch(*)" "Bash(git *)" "Bash(python *)" "Bash(pip install *)" "Bash(pytest *)" "Bash(gh *)" "mcp__github__*"
+          claude_args: '--model opus --effort high --allowedTools WebFetch Bash(pip:*) Bash(python:*) Bash(pytest:*) Bash(git:*) Bash(gh pr:*)'
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

Narrow `claude_args` in `.github/workflows/claude.yaml` so Claude is forced back onto the action's bundled comment-update and `git-push.sh` helpers, which run as the Claude App installation token. The wider grants (`mcp__github__*`, `Bash(gh *)`, `Bash(git *)`) let Claude post via `gh` CLI or raw MCP calls that fall back to the workflow's auto `GITHUB_TOKEN` — i.e. `github-actions[bot]` — so comments stopped showing the Claude icon and pushes appeared under the wrong identity.

After this change the allowed tool list matches landau's working configuration:

```
WebFetch Bash(pip:*) Bash(python:*) Bash(pytest:*) Bash(git:*) Bash(gh pr:*)
```

`Bash(pytest:*)` is kept from the previous fleche config since the suite is non-trivial to run; `Bash(git:*)` is kept because the action still needs git for staging/committing before invoking its push helper.

## Test plan

- [ ] Comment `@claude ping` on a PR and verify the tracking comment shows the Claude avatar/icon.
- [ ] Ask Claude to push a small change and verify the commit and push are attributed to the Claude bot, not `github-actions[bot]`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mi1q429BocLP8hMCLdJ7sb)_