### PR TITLE
docs(query): fix misleading lazy/eager contrast for result vs arguments

### DIFF
--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -36,7 +36,7 @@ The wrapper-based API builds the correct Call template for you.
    ...     assert call.metadata["tags"]["project"] == "alpha"
    ...     # call.result fetches the full result from value storage on access
    ...     print(call.result)                # e.g. 3
-   ...     # call.arguments is a LazyArguments proxy — each key triggers a separate load
+   ...     # call.arguments is a lazy proxy — each key triggers a separate load
    ...     print(call.arguments["a"])        # e.g. 1
    ...     print(dict(call.arguments))       # load all arguments at once
 

--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -34,11 +34,11 @@ The wrapper-based API builds the correct Call template for you.
    >>> for call in add.query(1, 2, metadata={"tags": {"project": "alpha"}}):
    ...     assert call.name == "add"
    ...     assert call.metadata["tags"]["project"] == "alpha"
-   ...     # call.result is decoded immediately on access
+   ...     # call.result fetches the full result from value storage on access
    ...     print(call.result)                # e.g. 3
-   ...     # call.arguments is a lazy proxy — individual keys are decoded on access
+   ...     # call.arguments is a LazyArguments proxy — each key triggers a separate load
    ...     print(call.arguments["a"])        # e.g. 1
-   ...     print(dict(call.arguments))       # decode all arguments at once
+   ...     print(dict(call.arguments))       # load all arguments at once
 
 Notes:
 - ``metadata={"tags": {}}`` matches any call with a "tags" metadata entry (presence check).


### PR DESCRIPTION
## Summary

- Both `.result` and `.arguments[key]` fetch from value storage on access — neither is eagerly pre-loaded.
- The previous comment "call.result is decoded immediately on access" implied `.result` was eager while only `.arguments` was lazy, which was incorrect.
- The real distinction is granularity: `.result` loads the full value in one operation; `.arguments` is a `LazyArguments` Mapping proxy where each key triggers a separate load.

**Before:**
```python
# call.result is decoded immediately on access
print(call.result)                # e.g. 3
# call.arguments is a lazy proxy — individual keys are decoded on access
print(call.arguments["a"])        # e.g. 1
print(dict(call.arguments))       # decode all arguments at once
```

**After:**
```python
# call.result fetches the full result from value storage on access
print(call.result)                # e.g. 3
# call.arguments is a LazyArguments proxy — each key triggers a separate load
print(call.arguments["a"])        # e.g. 1
print(dict(call.arguments))       # load all arguments at once
```

## Test plan
- [ ] Verify `LazyCall.result` in `src/fleche/call.py` — property calls `self._cache.load_value(self._result)` on access (lazy)
- [ ] Verify `LazyArguments.__getitem__` in `src/fleche/call.py` — calls `self._cache.load_value(value)` per key (lazy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg8uCZRPfHe1NEcj7azztu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg8uCZRPfHe1NEcj7azztu)_