### PR TITLE
docs(configuration): clarify memory cache persistence and with-block semantics

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -25,15 +25,27 @@ Reserved Cache Names
 ``memory``
 ~~~~~~~~~~
 
-The name ``memory`` is a reserved cache name. When requested, ``fleche`` will provide a transient in-memory cache. This cache is persistent for the duration of the process, but is not shared with other processes and is lost when the current process exits.
+The name ``memory`` is a reserved cache name. When requested, ``fleche`` will provide a
+transient in-memory cache. The cache object is interned (the same instance is reused on
+every call to ``cache("memory")``), so data stored in it persists for the lifetime of
+the process.  It is **not** shared with other processes and is lost when the current
+process exits.
 
-Example:
+Note that ``with cache("memory"):`` makes the memory cache active *only for the duration
+of the* ``with`` *block* — the previous cache is restored on exit.  To make the memory
+cache sticky (active until explicitly changed), discard the returned context manager::
+
+   cache("memory")   # sticky — memory cache stays active
+
+Example using the context-manager form to temporarily switch to memory caching:
 
 .. code-block:: pycon
 
    >>> from fleche import cache
    >>> with cache("memory"):
-   ...     # Results will be cached in memory. The cache persists for the lifetime of the process.
+   ...     # The memory cache is the active cache inside this block.
+   ...     # Results stored here persist for the process lifetime via the interned instance,
+   ...     # but after the block exits the previous active cache is restored.
    ...     ...
 
 ``void``


### PR DESCRIPTION
## Summary

- The `memory` cache section had a comment inside the `with cache("memory"):` block saying "The cache persists for the lifetime of the process."
- This was misleading: the `with` block only *activates* the memory cache temporarily; on exit the previous cache is restored. What persists is the cache *object* (interned in `_live_caches`), not its status as the active cache.
- Expanded the prose to explain: (1) interning — `cache("memory")` always returns the same instance, so its data survives the `with` block; (2) the `with`-block restores the previous cache on exit; (3) the sticky form (`cache("memory")` without `with`) keeps it active for the rest of the process.
- Rewrote the in-block comment to accurately describe what is and isn't preserved.

## Test plan
- [ ] Confirm `_live_caches` interning in `src/fleche/state.py` — named caches are interned so the same object is returned on each call
- [ ] Confirm `with cache("memory"):` restores previous cache on exit via `ContextVar.reset(token)`
- [ ] Read updated prose in `docs/storage/configuration.rst` for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg8uCZRPfHe1NEcj7azztu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg8uCZRPfHe1NEcj7azztu)_