### PR TITLE
docs(parallel): correct cache stampede description re: _in_flight mechanism

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -406,14 +406,21 @@ computes the function and writes the result — wasting redundant work and
 potentially producing inconsistent call metadata (e.g. ``Runtime`` values will
 differ between the duplicate records).
 
-The root cause is that there is no reservation mechanism between the cache
-miss check and the cache write in ``wrapper.py``.  A correct fix would require
-pre-allocating a "pending" slot in the cache so that other workers can detect
-the in-flight computation and wait, rather than starting their own.
-Implementing this correctly is non-trivial: it requires key-scoped locking,
-timeout handling for stale allocations (e.g. if the computing worker crashes),
-and cross-process coordination for file- and SQL-backed stores.  This is
-currently out of scope.
+Fleche does provide a narrow same-process guard for **Future-based** decorated
+functions: while a ``Future`` result is being saved, the key is registered in
+an ``_in_flight`` dict so that a second call on the same thread can return the
+in-flight future's result immediately rather than re-running the function.
+This only covers the brief window between the future completing and
+``cache.save()`` finishing, and has no effect across processes.
+
+For the common case — multiple workers calling the same non-``Future``-returning
+function with identical arguments before any result is stored — there is no
+reservation mechanism.  A correct cross-worker fix would require pre-allocating
+a "pending" slot in the cache so that other workers can detect the in-flight
+computation and wait, rather than starting their own.  Implementing this
+correctly is non-trivial: it requires key-scoped locking, timeout handling for
+stale allocations (e.g. if the computing worker crashes), and cross-process
+coordination for file- and SQL-backed stores.  This is currently out of scope.
 
 .. warning::
 

--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -34,11 +34,11 @@ The wrapper-based API builds the correct Call template for you.
    >>> for call in add.query(1, 2, metadata={"tags": {"project": "alpha"}}):
    ...     assert call.name == "add"
    ...     assert call.metadata["tags"]["project"] == "alpha"
-   ...     # call.result is decoded immediately on access
+   ...     # call.result fetches the full result from value storage on access
    ...     print(call.result)                # e.g. 3
-   ...     # call.arguments is a lazy proxy — individual keys are decoded on access
+   ...     # call.arguments is a LazyArguments proxy — each key triggers a separate load
    ...     print(call.arguments["a"])        # e.g. 1
-   ...     print(dict(call.arguments))       # decode all arguments at once
+   ...     print(dict(call.arguments))       # load all arguments at once
 
 Notes:
 - ``metadata={"tags": {}}`` matches any call with a "tags" metadata entry (presence check).


### PR DESCRIPTION
## Summary

- The "Cache Stampede" section claimed "there is no reservation mechanism between the cache miss check and the cache write in `wrapper.py`" — this is inaccurate.
- An `_in_flight: dict[str, Future]` does exist in `make_wrapper()` and provides a reservation mechanism, but it is narrow in scope:
  - Only active for **Future-based** decorated functions (populated in the `add_done_callback` path)
  - Only covers the brief window between `future.set_result()` and `cache.save()` completing
  - Has no effect across processes
- The real gap is the common stampede scenario: multiple workers calling a **non-Future-returning** function with identical arguments before any result is cached — no protection exists there.
- Updated the section to accurately describe both what `_in_flight` does and where the limitation remains.

**Root code reference:** `src/fleche/wrapper.py`, `make_wrapper()` — the `_in_flight` dict and the `if (f := _in_flight.get(key)) is not None` check.

## Test plan
- [ ] Read `src/fleche/wrapper.py` `make_wrapper()`: confirm `_in_flight[key] = future` is only set when `future is not None` (i.e. inside `add_done_callback`)
- [ ] Confirm the `_in_flight` check fires only for same-process, same-thread duplicate calls during the save window
- [ ] Review updated prose in `docs/parallel_execution.rst` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg8uCZRPfHe1NEcj7azztu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg8uCZRPfHe1NEcj7azztu)_