### PR TITLE
fix(digest): hash pandas DataFrame/Series/Index by content

### DIFF
--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -242,11 +242,22 @@ def _digest_bytes(value: Any) -> bytes:
         case pd.DataFrame():
             # DataFrame is Iterable (yields column names) but NOT Mapping, so without
             # this arm two DataFrames sharing column names collide regardless of values.
+            #
+            # We digest columns/dtypes/index ourselves and pass index=False to
+            # hash_pandas_object rather than letting index=True fold the index in.
+            # hash_pandas_object only mixes per-element value bytes — it ignores
+            # column names, column dtypes, index.name, and index.dtype — so
+            # index=True alone would still collide DataFrames whose indices differ
+            # only in name or dtype.  Recursing through _digest_bytes on
+            # value.index also reuses the pd.Index arm below, keeping a standalone
+            # Index and a DataFrame's .index digest-consistent.
             m.update(_digest_bytes(list(value.columns)))
             m.update(_digest_bytes([str(d) for d in value.dtypes]))
             m.update(_digest_bytes(value.index))
             m.update(pd.util.hash_pandas_object(value, index=False).values.tobytes())
         case pd.Series():
+            # Same reasoning as DataFrame: hash_pandas_object ignores name/dtype/
+            # index metadata, so we digest those ourselves and pass index=False.
             m.update(_digest_bytes(value.name))
             m.update(_digest_bytes(str(value.dtype)))
             m.update(_digest_bytes(value.index))

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -11,6 +11,7 @@ import importlib.metadata
 from collections.abc import Iterable, Mapping
 from typing import Any, TypeVar, Callable, Type, Generic
 import numpy as np
+import pandas as pd
 
 from . import _attrs
 
@@ -238,6 +239,22 @@ def _digest_bytes(value: Any) -> bytes:
         case np.bool_():
             # np.bool_ ∉ Number so this arm is reachable
             return _digest_bytes(bool(value))
+        case pd.DataFrame():
+            # DataFrame is Iterable (yields column names) but NOT Mapping, so without
+            # this arm two DataFrames sharing column names collide regardless of values.
+            m.update(_digest_bytes(list(value.columns)))
+            m.update(_digest_bytes([str(d) for d in value.dtypes]))
+            m.update(_digest_bytes(value.index))
+            m.update(pd.util.hash_pandas_object(value, index=False).values.tobytes())
+        case pd.Series():
+            m.update(_digest_bytes(value.name))
+            m.update(_digest_bytes(str(value.dtype)))
+            m.update(_digest_bytes(value.index))
+            m.update(pd.util.hash_pandas_object(value, index=False).values.tobytes())
+        case pd.Index():
+            m.update(_digest_bytes(value.name))
+            m.update(_digest_bytes(str(value.dtype)))
+            m.update(pd.util.hash_pandas_object(value).values.tobytes())
         case types.FunctionType():
             return _digest_bytes(value.__code__)
         case types.CodeType():

--- a/tests/unit/digest/test_digest.py
+++ b/tests/unit/digest/test_digest.py
@@ -382,6 +382,60 @@ def test_numpy_explicit_cases():
     assert digest(c) != digest(d)
 
 
+def test_pandas_dataframe_hashes_by_content():
+    """Regression: DataFrame iter yields column names only, so falling through to
+    the Iterable arm makes any two DataFrames with the same columns collide."""
+    import pandas as pd
+
+    df1 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df2 = pd.DataFrame({"a": [10, 20, 30], "b": [40, 50, 60]})
+    df3 = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    assert digest(df1) != digest(df2)
+    assert digest(df1) == digest(df3)
+    assert isinstance(digest(df1), Digest)
+
+
+def test_pandas_dataframe_distinguishes_columns_dtype_index():
+    import pandas as pd
+
+    base = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    reordered_cols = pd.DataFrame({"b": [4, 5, 6], "a": [1, 2, 3]})
+    different_dtype = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+    different_index = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[10, 20, 30])
+    renamed_cols = pd.DataFrame({"a": [1, 2, 3], "c": [4, 5, 6]})
+
+    digests = {digest(base), digest(reordered_cols), digest(different_dtype),
+               digest(different_index), digest(renamed_cols)}
+    assert len(digests) == 5
+
+
+def test_pandas_series_hashes_by_content():
+    import pandas as pd
+
+    s1 = pd.Series([1, 2, 3])
+    s2 = pd.Series([10, 20, 30])
+    s3 = pd.Series([1, 2, 3])
+    s_named = pd.Series([1, 2, 3], name="x")
+
+    assert digest(s1) != digest(s2)
+    assert digest(s1) == digest(s3)
+    assert digest(s1) != digest(s_named)
+
+
+def test_pandas_index_hashes_by_content():
+    import pandas as pd
+
+    i1 = pd.Index([1, 2, 3])
+    i2 = pd.Index([1, 2, 4])
+    i3 = pd.Index([1, 2, 3])
+    i_named = pd.Index([1, 2, 3], name="x")
+
+    assert digest(i1) != digest(i2)
+    assert digest(i1) == digest(i3)
+    assert digest(i1) != digest(i_named)
+
+
 def test_lambda_can_be_digested():
     """Test that lambda functions can be digested without raising Indigestible."""
     f = lambda x: x + 1


### PR DESCRIPTION
## Summary

Bug report: pandas DataFrames with the same columns but different row values produce identical digests, so cached results are incorrectly reused across distinct inputs.

**Root cause** (`src/fleche/digest.py`): `pd.DataFrame` is not a `Mapping` but *is* an `Iterable`, and iterating a DataFrame yields its column names only — not the data. The `case Iterable():` arm hashed just `["a", "b", ...]`, so any two DataFrames sharing column names collided:

```python
df1 = pd.DataFrame({'a': [1,2,3], 'b': [4,5,6]})  # 57dbc0...
df2 = pd.DataFrame({'a': [10,20,30], 'b': [40,50,60]})  # 57dbc0... (collision)
```

`pd.Series` and `pd.Index` had related problems (Series iterates values but ignores `name`/`dtype`/`index`).

## Fix

Add explicit pre-`Iterable` arms for `DataFrame`, `Series`, and `Index` that fold in:
- columns / name
- dtype(s)
- index
- `pd.util.hash_pandas_object(value).values.tobytes()` for the values themselves

pandas is already a hard dependency, so the import is unconditional (mirrors the existing `np.ndarray` arm).

No `hash_version` bump / migration shim — per request, this changes pandas digests silently; any pre-existing cache entries keyed off pandas inputs are now unreachable.

## Test plan

- [x] New regression tests in `tests/unit/digest/test_digest.py`:
  - `test_pandas_dataframe_hashes_by_content` — the exact collision from the bug report
  - `test_pandas_dataframe_distinguishes_columns_dtype_index` — column order, dtype, index, renamed columns each produce distinct digests
  - `test_pandas_series_hashes_by_content` — values, equality, `name`
  - `test_pandas_index_hashes_by_content` — values, equality, `name`
- [x] Full `tests/unit/` suite passes (1425 passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_015SYyTiDpq9MADVyeGnmkAW)_