### PR TITLE
test(remote): cover `_run_server` over stubbed stdio

### DIFF
--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -9,17 +9,21 @@ import io
 import os
 import sys
 import threading
+import types
 
 import pytest
 
+import fleche.state as _state
 from fleche.call import Call, QueryCall
 from fleche.caches import Cache, Rejected
+from fleche.config import cache_to_config, load_cache_config
 from fleche.digest import Digest
 from fleche.remote import (
     RemoteConnectionError,
     SshCache,
     _Connection,
     _read_frame,
+    _run_server,
     _write_frame,
     serve,
 )
@@ -746,19 +750,12 @@ def test_run_server_serves_active_cache_over_stdio_until_eof(monkeypatch, cache_
     server launched with ``--cache NAME`` is recognisable from the
     client's ``info()``.
     """
-    import sys as _sys
-    import types as _types
-
-    import fleche.state as _state
-    from fleche.config import cache_to_config, load_cache_config
-    from fleche.remote import _read_frame, _run_server, _write_frame
-
     fake_stdin = io.BytesIO()
     _write_frame(fake_stdin, ("info", (), {}))
     fake_stdin.seek(0)
     fake_stdout = io.BytesIO()
-    monkeypatch.setattr(_sys, "stdin", _types.SimpleNamespace(buffer=fake_stdin))
-    monkeypatch.setattr(_sys, "stdout", _types.SimpleNamespace(buffer=fake_stdout))
+    monkeypatch.setattr(sys, "stdin", types.SimpleNamespace(buffer=fake_stdin))
+    monkeypatch.setattr(sys, "stdout", types.SimpleNamespace(buffer=fake_stdout))
 
     # Pin a freshly-constructed clean cache as active.  Two reasons:
     # (1) `_run_server(cache_name)` calls `cache(cache_name)` which mutates

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -721,3 +721,66 @@ def test_cache_stack_with_ssh_layer():
     assert isinstance(c, CacheStack)
     assert isinstance(c.stack[1], SshCache)
     c.stack[1].close()
+
+
+# ---------------------------------------------------------------------------
+# `_run_server` — the `python -m fleche remote --serve` entry point
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cache_name", [None, "memory"])
+def test_run_server_serves_active_cache_over_stdio_until_eof(monkeypatch, cache_name):
+    """``_run_server`` is the entry point invoked by ``python -m fleche
+    remote --serve``: it activates the named cache (when given), runs
+    :func:`serve` over ``sys.stdin.buffer`` / ``sys.stdout.buffer``, and
+    returns ``0`` on clean stdin EOF.
+
+    The integration tests exercise this through a real subprocess where
+    coverage doesn't propagate to the parent run, so this drives the
+    function in-process with stubbed binary stdio streams. The single
+    ``info`` request preloaded into the fake stdin lets us verify two
+    contracts in one round-trip: the served cache matches the one
+    selected by ``cache_name`` (``None`` → the active cache as it stood
+    on entry; ``"memory"`` → the named cache installed via
+    :func:`fleche.state.cache`), and ``cache_name`` is echoed back so a
+    server launched with ``--cache NAME`` is recognisable from the
+    client's ``info()``.
+    """
+    import sys as _sys
+    import types as _types
+
+    import fleche.state as _state
+    from fleche.config import cache_to_config, load_cache_config
+    from fleche.remote import _read_frame, _run_server, _write_frame
+
+    fake_stdin = io.BytesIO()
+    _write_frame(fake_stdin, ("info", (), {}))
+    fake_stdin.seek(0)
+    fake_stdout = io.BytesIO()
+    monkeypatch.setattr(_sys, "stdin", _types.SimpleNamespace(buffer=fake_stdin))
+    monkeypatch.setattr(_sys, "stdout", _types.SimpleNamespace(buffer=fake_stdout))
+
+    # Pin a freshly-constructed clean cache as active.  Two reasons:
+    # (1) `_run_server(cache_name)` calls `cache(cache_name)` which mutates
+    # the active-cache ContextVar stickily — without a token reset the change
+    # leaks into subsequent tests; (2) ``cache_to_config`` recurses into a
+    # ``MemoryBackend.storage`` dict via ``dataclasses.asdict``, so an active
+    # cache left populated by earlier tests would make the round-trip
+    # comparison below crash on unrelated state.
+    clean_cache = Cache(ValueMemory({}), CallMemory({}))
+    cache_token = _state._CACHE.set(clean_cache)
+    try:
+        assert _run_server(cache_name=cache_name) == 0
+    finally:
+        _state._CACHE.reset(cache_token)
+
+    fake_stdout.seek(0)
+    tag, info = _read_frame(fake_stdout)
+    assert tag == "ok"
+    assert info["cache_name"] == cache_name
+    expected_cache = (
+        load_cache_config(cache_name) if cache_name is not None else clean_cache
+    )
+    assert info["cache"] == cache_to_config(expected_cache)
+    # Clean EOF: no second frame queued.
+    assert fake_stdout.read() == b""


### PR DESCRIPTION
## Summary

`remote.py` was the least-covered module after a fresh coverage run (87%,
42 missed statements). The largest contiguous gap was `_run_server`
itself — the entry point that `python -m fleche remote --serve` invokes
via `__main__.py`. The existing integration test
(`tests/integration/test_remote.py`) runs it inside a real subprocess,
so its body never appears in the parent coverage run; all seven
statements (`remote.py:848-855`) and both branches of `if cache_name is
not None` showed up as missed.

Drive it in-process by swapping `sys.stdin` / `sys.stdout` for
`SimpleNamespace`s with `BytesIO` buffers, preloading a single `info`
RPC frame, and letting clean EOF drop the `serve()` loop. The same
parametrized test covers both branches of `if cache_name is not None`
and pins the user-facing contracts:

- `info["cache"]` reflects the served cache (the active cache untouched
  when `cache_name is None`, the resolved named cache otherwise).
- `info["cache_name"]` echoes the launch argument, so a server started
  with `--cache NAME` is recognisable from the client.

The active-cache `ContextVar` is reset via a token in `finally` so the
sticky activation `_run_server("memory")` performs doesn't leak into
subsequent tests, matching the pattern in `tests/unit/test_cache_sticky.py`.

## Coverage report

Before:

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/remote.py                        376     43     98     16    87%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/caches.py                        358     21    104      6    94%
...
TOTAL                                      2761    124    824     59    95%
```

After:

```
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/remote.py                        376     36     98     16    89%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/caches.py                        358     21    104      6    94%
...
TOTAL                                      2761    115    824     59    95%
```

`remote.py` 87% → 89% (43 → 36 missed; the seven previously-missed
lines `848-855` are gone from the missing-line list, branch-partial
count unchanged). Total missed 124 → 115; the 9-line delta breaks down
as **7 from the new test** plus 2 in `bagofholding_file.py` from
unrelated test-order variance (no change to that module's source or
tests, so re-running the suite shifts which path through it is hit
first).

The remaining gaps in `remote.py` are scattered error paths (unknown
RPC method, malformed frame, unpicklable exception fallback, ssh
`FileNotFoundError`, subprocess kill cascade) — each worth ~1-3 lines
and better handled in dedicated PRs rather than piled here.

## Test plan

- [x] `pytest tests/unit/test_remote.py` — 43 passed (41 prior + 2 new
  parametrized cases) in 0.11s
- [x] `coverage run --branch -m pytest tests/ --ignore=tests/integration/test_notebooks.py --ignore=tests/integration/test_remote.py`
  — full suite passes (1488 passed, 11 skipped); `remote.py` ticks up
  from 87% to 89%
- [x] Active-cache `ContextVar` restored after each test invocation —
  no leak into the rest of the suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01KptVthETgWXDvBBD4B47un)_