### PR TITLE
refactor(storage): route evict/contains through _normalize_key

### DIFF
--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -122,21 +122,15 @@ class KeyManagement(OperationContext):
     def evict(self, key: Digest | str) -> None:
         """Removes the entry corresponding to the key from the storage."""
         with self._operation_context(key):
-            if len(key) < DIGEST_LENGTH:
-                key = self.expand(key)
-            else:
-                key = Digest(key)
-            self._evict(key)
+            self._evict(self._normalize_key(key))
 
     def contains(self, key: Digest | str) -> bool:
+        """Return True if the key is present in the storage, False otherwise."""
         with self._operation_context(key):
-            if len(key) < DIGEST_LENGTH:
-                try:
-                    key = self.expand(key)
-                except KeyError:
-                    return False
-            else:
-                key = Digest(key)
+            try:
+                key = self._normalize_key(key)
+            except KeyError:
+                return False
             return self._contains(key)
 
     def expand(self, key: Digest | str) -> Digest:


### PR DESCRIPTION
Refs #636.

`KeyManagement` had the "short prefix → `expand`, full key → wrap as `Digest`" rule written out inline in both `evict` and `contains`, while `_normalize_key` already captured it for `load`.

Changes in `base.py`:

- `evict`: the five-line `if/else` + `_evict` becomes `self._evict(self._normalize_key(key))`.
- `contains`: the nested `try` inside the `if len < DIGEST_LENGTH` branch is replaced by a flat `try: key = self._normalize_key(key); except KeyError: return False` — the `KeyError`-means-absent short-circuit stays visible at the call site rather than being hidden inside the helper.
- Added a one-line docstring to `contains` (it had none).

All three public methods (`evict`, `contains`, `load`) now share a single implementation of key normalization. A future subclass override of `_normalize_key` affects all three consistently.

1427 unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0123QWvVwXuFwpDAk84Fzvv5)_