### PR TITLE
docs(helpers): document hash_version and hash_module decorator flags

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -95,7 +95,10 @@ per-function metadata in one frozen dataclass:
 - ``inspect.signature(func)`` — used for argument binding
 - the digest of ``func.__code__`` (included in cache keys only when ``hash_code=True``; the default is ``False``)
 - ``(qualname, module, version)`` extracted via
-  :class:`pyiron_snippets.versions.VersionInfo`
+  :class:`pyiron_snippets.versions.VersionInfo` — ``module`` and ``version``
+  are included in cache keys by default (``hash_module=True``,
+  ``hash_version=True``); set either flag to ``False`` to exclude the
+  corresponding field from the key
 - the sets of :class:`~fleche.call.Ignored`- and
   :class:`~fleche.call.Required`-annotated argument names
 


### PR DESCRIPTION
## Problem

The "Per-Function Static Caching" section in `docs/usage/helpers.rst` listed the fields captured by `FunctionProfile` but only mentioned `hash_code=False` (the flag that defaults to `False`). It said nothing about `hash_module=True` and `hash_version=True`, leaving a reader who looks at the `@fleche()` signature unable to understand what those two flags do from this page.

The asymmetry is non-obvious: `hash_code` defaults to `False` (opt-in), while `hash_module` and `hash_version` both default to `True` (opt-out). A reader might reasonably assume all three work the same way.

## Fix

Extend the bullet point for `(qualname, module, version)` to note:
- `module` and `version` are included in cache keys **by default**
- Set `hash_module=False` or `hash_version=False` to exclude the corresponding field

One sentence added inline; no restructuring of the section.

## Verification

Confirmed against `src/fleche/wrapper.py` `make_get_call()`:

```python
if not hash_version:
    call.version = None
if not hash_module:
    call.module = None
if not hash_code:
    call.code_digest = None
```

All three flags strip the corresponding field when `False`; the defaults are `hash_version=True`, `hash_module=True`, `hash_code=False`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkD6NJ284JhQiwB2NbxGsm)_