### PR TITLE
ci(claude): default mention model to sonnet

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -31,7 +31,7 @@ jobs:
           REVIEW_BODY: ${{ github.event.review.body }}
         run: |
           body="${COMMENT_BODY}${REVIEW_BODY}"
-          model=opus
+          model=sonnet
           if [[ "$body" =~ @claude\[([a-zA-Z]+)\] ]]; then
             choice="${BASH_REMATCH[1],,}"
             case "$choice" in


### PR DESCRIPTION
The `@claude` mention workflow (`.github/workflows/claude.yaml`) already
resolves an `@claude[haiku|sonnet|opus]` switch into `--model`. This
changes the fallback default in the `Resolve model from mention` step
from `opus` to `sonnet`, so bare `@claude` mentions and unknown aliases
now run on sonnet. The unknown-alias warning text follows automatically
since it interpolates `$model`.

The bracket switch itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDQFf5cqrEedPEWiGfidG9)_