### PR TITLE
ci: run ty on all PRs, restrict min-dep tests to main-targeting PRs

### DIFF
--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -1,6 +1,8 @@
 name: test-minimum-deps
 
-on: pull_request
+on:
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test-minimum-deps:

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary

- **`ty.yml`**: remove the `branches: [main]` filter from the `pull_request` trigger so type-checking runs on all PRs, not only those targeting `main`
- **`test-minimum-deps.yml`**: add `branches: [main]` to the `pull_request` trigger so the lowest-direct-resolution test only runs on PRs that target `main`

Previously `ty` was silently skipped on feature-branch PRs, giving no type-check signal until the PR retargeted `main`. The minimum-deps check is intentionally kept to main-targeting PRs as it is more expensive and less critical during day-to-day feature work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXyqGZu8N8fxYoucvcWSHp)_