### PR TITLE
ci(claude): select model from a spaced @claude [model] mention

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -30,9 +30,14 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
           REVIEW_BODY: ${{ github.event.review.body }}
         run: |
+          # The action does its own trigger detection: it only fires on '@claude'
+          # followed by whitespace, punctuation, or end-of-line, so a model is
+          # selected with a space -- '@claude [haiku|sonnet|opus]'. This step only
+          # maps that alias onto a --model arg; bare or unrecognised mentions fall
+          # back to sonnet. (A glued '@claude[model]' would not trigger the action.)
           body="${COMMENT_BODY}${REVIEW_BODY}"
           model=sonnet
-          if [[ "$body" =~ @claude\[([a-zA-Z]+)\] ]]; then
+          if [[ "$body" =~ @claude[[:space:]]*\[([a-zA-Z]+)\] ]]; then
             choice="${BASH_REMATCH[1],,}"
             case "$choice" in
               haiku|sonnet|opus)


### PR DESCRIPTION
A glued `@claude[model]` never triggered `claude-code-action`: its native trigger only fires on `@claude` followed by whitespace, punctuation, or end-of-line, so the bracket suffix was never recognised and the run stayed silent (while the job-level `contains(..., '@claude')` `if:` still ran, resolved a model, and invoked the action, which then bailed — hiding the bug).

## Fix

Select the model with a space: `@claude [haiku|sonnet|opus]`. The only change is whitespace tolerance in the alias regex (`@claude\[…\]` → `@claude[[:space:]]*\[…\]`), so `@claude` stays followed by whitespace and the action's own trigger fires through normal tag mode. The resolve step still only maps the alias onto `--model`; bare or unrecognised mentions fall back to sonnet.

Ports [eisenforschung/landau#305](https://github.com/eisenforschung/landau/pull/305).

Verified locally: `@claude [sonnet]`→sonnet, `@claude [opus]`→opus, `@claude  [haiku]`→haiku, `@claude fix ci`→sonnet, `@claude [gpt]`→sonnet (warns). `yaml.safe_load` parses the workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEgwMneHr3xmHFkRJ8jrrg)_