### PR TITLE
ci: include workflow files in test gate, gate min-deps job

### DIFF
--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -19,7 +19,7 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/test-minimum-deps.yml'
 
   test-minimum-deps:
     needs: changes

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -5,16 +5,41 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/**'
+
   test-minimum-deps:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip notice
+        if: needs.changes.outputs.run != 'true'
+        run: echo "No source, test, or workflow changes; skipping."
       - uses: actions/checkout@v5
+        if: needs.changes.outputs.run == 'true'
         with:
           # setuptools-scm derives the version from git history.
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
+        if: needs.changes.outputs.run == 'true'
       - run: uv venv
+        if: needs.changes.outputs.run == 'true'
       # --resolution lowest-direct pins every direct dependency to the lowest
       # version its bound allows, exercising the floors declared in pyproject.
       - run: uv pip install --resolution lowest-direct -e ".[tests]"
+        if: needs.changes.outputs.run == 'true'
       - run: uv run --no-sync pytest
+        if: needs.changes.outputs.run == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/tests.yml'
 
   build:
     needs: changes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'pyproject.toml'
+              - '.github/workflows/**'
 
   build:
     needs: changes

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -20,7 +20,7 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'pyproject.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ty.yml'
 
   ty:
     needs: changes

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -20,6 +20,7 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'pyproject.toml'
+              - '.github/workflows/**'
 
   ty:
     needs: changes


### PR DESCRIPTION
The `tests.yml` and `ty.yml` `changes` gate already filtered on `src/**`, `tests/**`, and `pyproject.toml`, but a change to the workflow file itself would not re-run the checks. Add each workflow's own file to its filter (`tests.yml` gates on `.github/workflows/tests.yml`, `ty.yml` on `.github/workflows/ty.yml`) so editing a workflow re-runs only that workflow.

Also add the same `changes` gate to `test-minimum-deps.yml`, which was previously ungated and ran on every PR regardless of which files changed.