### PR TITLE
test(remote): cover serve() error-recovery contracts

### DIFF
--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -485,6 +485,85 @@ def test_forward_stderr_appends_to_buffer():
 
 
 # ---------------------------------------------------------------------------
+# Server-side error recovery
+# ---------------------------------------------------------------------------
+#
+# ``serve()`` documents two error-recovery contracts:
+#
+#   1. A frame whose payload isn't ``(method, args, kwargs)`` is logged and
+#      skipped; the loop keeps reading subsequent frames instead of dying.
+#   2. If a cache-raised exception cannot be cloudpickled, the server replaces
+#      it with a ``RuntimeError`` carrying its repr + traceback so the client
+#      always receives an ``("err", ...)`` frame instead of a wire-protocol
+#      error (which would surface as a bare ``EOFError`` on the client).
+#
+# Both branches are exercised in-process by piping pre-built request bytes
+# through ``serve()`` and inspecting the responses it writes back.
+
+
+def test_serve_malformed_frame_is_skipped_and_loop_continues(caplog):
+    """A non-tuple request is logged as malformed; the next well-formed
+    frame is still handled, so a noisy client can't wedge the server."""
+    import logging
+
+    server_in = io.BytesIO()
+    _write_frame(server_in, "not a tuple")          # malformed
+    _write_frame(server_in, ("contains", ("0" * 64,), {}))  # well-formed
+    server_in.seek(0)
+    server_out = io.BytesIO()
+
+    cache = Cache(ValueMemory({}), CallMemory({}))
+    caplog.set_level(logging.ERROR, logger="fleche.remote")
+    serve(server_in, server_out, cache)
+
+    assert any(
+        "Malformed request frame" in r.getMessage() for r in caplog.records
+    ), "expected the malformed frame to be logged"
+
+    # Exactly one response written — for the second, well-formed frame.
+    server_out.seek(0)
+    tag, payload = _read_frame(server_out)
+    assert tag == "ok"
+    assert payload is False  # `contains` misses on an empty cache
+    with pytest.raises(EOFError):
+        _read_frame(server_out)
+
+
+def test_serve_falls_back_when_exception_is_unpicklable(monkeypatch):
+    """Cache exceptions that can't be cloudpickled are wrapped in a
+    ``RuntimeError`` so an ``("err", ...)`` frame is always delivered."""
+    from fleche import remote as _remote
+
+    class Unpicklable(RuntimeError):
+        def __reduce__(self):
+            raise TypeError("this exception cannot travel across the wire")
+
+    def raising_dispatch(cache, method, args, kwargs):
+        raise Unpicklable("boom")
+
+    monkeypatch.setattr(_remote, "_dispatch", raising_dispatch)
+
+    server_in = io.BytesIO()
+    _write_frame(server_in, ("contains", ("0" * 64,), {}))
+    server_in.seek(0)
+    server_out = io.BytesIO()
+
+    cache = Cache(ValueMemory({}), CallMemory({}))
+    serve(server_in, server_out, cache)
+
+    server_out.seek(0)
+    tag, payload = _read_frame(server_out)
+    assert tag == "err"
+    # The fallback replaces the un-cloudpicklable exception with a plain
+    # RuntimeError carrying enough context for a human to diagnose it.
+    assert isinstance(payload, RuntimeError)
+    assert not isinstance(payload, Unpicklable)
+    msg = str(payload)
+    assert "Unpicklable" in msg
+    assert "boom" in msg
+
+
+# ---------------------------------------------------------------------------
 # Config integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Running branch coverage over the test suite surfaced `src/fleche/remote.py` as the largest partially-covered module (87 % — the small `__main__.py` / `_attrs.py` / `__init__.py` gaps are import-time / missing-dep branches that require unusual environments to reach). The two lowest-hanging uncovered blocks are both inside `serve()` and encode advertised contracts:

- **Malformed request tolerance** (`remote.py:303-305`): a frame whose payload isn't `(method, args, kwargs)` is logged and skipped so the loop keeps handling subsequent frames instead of dying on a noisy client.
- **Unpicklable-exception fallback** (`remote.py:315-319`): if a cache-raised exception cannot be cloudpickled, the server replaces it with a `RuntimeError` carrying the original class name + traceback, so the client always receives an `("err", …)` frame instead of a bare `EOFError`.

This PR adds one focused test per contract to `tests/unit/test_remote.py`. Both drive `serve()` in-process by piping pre-built frames through `io.BytesIO` — no SSH subprocess, no threading. Each test is single-purpose and orthogonal to the existing ones (which cover the happy path plus known-picklable errors).

## Coverage impact

`remote.py` line + branch coverage moves from **87 % → 89 %** (7 statements, both target line ranges covered). Overall suite coverage: 95 %.

Report after the change (`coverage run --branch --source=src/fleche -m pytest tests/`):

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        358     21    104      6    94%
src/fleche/call.py                          241      8     62      5    96%
src/fleche/config.py                        195      6     92      4    97%
src/fleche/digest.py                        176      7    100      8    95%
src/fleche/executor.py                       35      2     10      0    96%
src/fleche/metadata.py                       74      6      4      0    92%
src/fleche/query.py                         127      0     50      1    99%
src/fleche/remote.py                        376     36     98     16    89%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/state.py                          52      1     10      1    97%
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py      49      0     10      1    98%
src/fleche/storage/base.py                  132      3     38      3    96%
src/fleche/storage/destructuring.py         156      2     48      1    99%
src/fleche/storage/file.py                   54      0      4      0   100%
src/fleche/storage/memory.py                 32      0      2      0   100%
src/fleche/storage/pickle_file.py            77      2     12      0    98%
src/fleche/storage/sql.py                   246     10     88      6    95%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/storage/void.py                   20      1      4      0    96%
src/fleche/wrapper.py                       193      1     48      1    99%
---------------------------------------------------------------------------
TOTAL                                      2771    118    826     59    95%
```

Baseline before this PR was 125 misses / 87 % on `remote.py`.

## Test plan

- [x] `pytest tests/unit/test_remote.py -k "malformed or unpicklable"` passes locally
- [x] `pytest tests/` — full suite still green (1498 passed, 11 skipped)
- [x] `coverage report` confirms lines 303-305 and 315-319 of `remote.py` are now covered


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8JeUUMSvifMz5i7E8rVBB)_