### PR TITLE
test: drop four tests that don't move coverage

### DIFF
--- a/tests/unit/digest/test_attrs.py
+++ b/tests/unit/digest/test_attrs.py
@@ -184,16 +184,6 @@ def test_fleche_caches_attrs_result():
         assert isinstance(b, AttrsBasic)
 
 
-def test_fleche_distinguishes_different_attrs_arguments():
-    @fleche
-    def f(obj):
-        return obj.x
-
-    with cache(Cache(ValueMemory({}), CallMemory({}))):
-        assert f(AttrsBasic(x=1, y="a")) == 1
-        assert f(AttrsBasic(x=2, y="a")) == 2
-
-
 # ---------------------------------------------------------------------------
 # Destructuring-storage integration: attrs instances should be destructured
 # into a per-field representation just like dataclasses.

--- a/tests/unit/fleche/test_futures.py
+++ b/tests/unit/fleche/test_futures.py
@@ -127,29 +127,6 @@ class TestThreadPoolFutures:
         finally:
             executor.shutdown(wait=False)
 
-    def test_multiple_futures_concurrent(self):
-        """Multiple concurrent futures should all be cached independently."""
-        executor = ThreadPoolExecutor(max_workers=4)
-        try:
-            @fleche
-            def compute(x):
-                return executor.submit(lambda: x ** 2)
-
-            with cache(_make_cache()):
-                futures = [compute(i) for i in range(5)]
-                results = [f.result() for f in futures]
-                assert results == [0, 1, 4, 9, 16]
-
-                # Wait for all done callbacks before re-calling
-                for i in range(5):
-                    _wait_for_cache(compute, i)
-
-                # All results should now be cached
-                cached = [compute(i) for i in range(5)]
-                assert cached == [0, 1, 4, 9, 16]
-        finally:
-            executor.shutdown(wait=False)
-
 # Module-level decorated function for ProcessPoolExecutor (must be picklable)
 @fleche
 def _pp_compute(x):

--- a/tests/unit/fleche/test_query_iterator.py
+++ b/tests/unit/fleche/test_query_iterator.py
@@ -93,20 +93,6 @@ def test_query_iterator_results_empty():
     assert list(QueryIterator(lambda: []).results()) == []
 
 
-def test_query_iterator_results_from_wrapper(test_cache):
-    """results() works correctly when the iterator comes from a fleche wrapper."""
-    with cache(test_cache):
-        @fleche
-        def square(n):
-            return n * n
-
-        square(3)
-        square(4)
-
-        results = sorted(square.fleche.query().results())
-        assert results == [9, 16]
-
-
 # ---------------------------------------------------------------------------
 # .table() — basic structure
 # ---------------------------------------------------------------------------

--- a/tests/unit/fleche/test_rerun.py
+++ b/tests/unit/fleche/test_rerun.py
@@ -28,40 +28,6 @@ def test_rerun_basic():
         assert func(1) == 2
         assert mock_func.call_count == 2
 
-def test_rerun_nested():
-    mock_inner = Mock(side_effect=[10, 20])
-    mock_outer = Mock(side_effect=[100, 200])
-
-    @fleche
-    def inner(x):
-        return mock_inner(x)
-
-    @fleche
-    def outer(x):
-        mock_outer(x)
-        return inner(x)
-
-    with cache(Cache(ValueMemory({}), CallMemory({}))):
-        # First call: both miss
-        assert outer(1) == 10
-        assert mock_outer.call_count == 1
-        assert mock_inner.call_count == 1
-
-        # Second call: both hit
-        assert outer(1) == 10
-        assert mock_outer.call_count == 1
-        assert mock_inner.call_count == 1
-
-        # Rerun: both should re-execute because of RefreshingCache
-        assert outer.fleche.rerun(1) == 20
-        assert mock_outer.call_count == 2
-        assert mock_inner.call_count == 2
-
-        # Verify they are now cached with new values
-        assert outer(1) == 20
-        assert mock_outer.call_count == 2
-        assert mock_inner.call_count == 2
-
 def test_rerun_nested_multiple_levels():
     mock_l3 = Mock(side_effect=[1, 2, 3])
 


### PR DESCRIPTION
## Summary

Ran per-test dynamic-context coverage (`dynamic_context = test_function`) over the full suite to find tests whose lines in `src/fleche/` are all also covered by at least one other test — 738 of 833 tests hit zero unique lines by that metric. Removing all of them at once would obviously break coverage, so I picked four candidates from that pool (one per feature area) and re-ran the full suite with them removed to confirm the totals stayed put.

## What was removed and why the coverage is still there

| Test | Where the same coverage comes from |
|------|------------------------------------|
| `test_rerun.test_rerun_nested` | `test_rerun_nested_multiple_levels` (same file) already exercises "rerun cascades down through nested `@fleche` calls" at 3 levels, plus pins the orthogonal contract that a rerun does **not** invalidate upstream callers — a strict superset of what the 2-level test asserted. |
| `test_attrs.test_fleche_distinguishes_different_attrs_arguments` | Entailed by `test_attrs_digest_distinguishes_field_values` (different field values → different digests) composed with `test_fleche_caches_call_with_attrs_argument` (fleche uses the digest as the cache key). The composition contract is the sum of two narrower contracts each pinned in its own test. |
| `test_futures.TestThreadPoolFutures.test_multiple_futures_concurrent` | The "each distinct arg gets its own cache entry" contract is already pinned by `test_different_args_are_cached_independently` (same class, N=2). N=5 doesn't exercise new behaviour. |
| `test_query_iterator.test_query_iterator_results_from_wrapper` | The `func.fleche.query()` → `QueryIterator` path is pinned by `test_query_iterator_can_be_iterated_from_wrapper`; `.results()` is pinned by `test_query_iterator_results` (both same file). This one was pure composition. |

None of the four looked like a "contract test" that stood alone — each one's assertion is entailed by the composition of tests that remain. In particular I deliberately kept `test_rerun_nested_multiple_levels` because it pins two orthogonal contracts (rerun cascades down; rerun does not cascade up) that neither the removed 2-level test nor the surviving 1-level test would preserve on their own.

## Coverage impact

Both runs are `coverage run --branch --source=src/fleche -m pytest tests/` from a clean checkout of `main` (i.e. before the sibling PR that adds two `remote.py` tests):

**Before:**
```
TOTAL                                      2771    126    826     59    95%
1496 passed, 11 skipped
```

**After (this PR):**
```
TOTAL                                      2771    125    826     59    95%
1492 passed, 11 skipped
```

Line + branch totals are unchanged (a one-line drift each in `remote.py` and `storage/bagofholding_file.py` — per-test context data confirms none of the removed tests hit either file, so these are test-ordering artifacts, not coverage lost with the tests).

Full report:

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        358     21    104      6    94%
src/fleche/call.py                          241      8     62      5    96%
src/fleche/config.py                        195      6     92      4    97%
src/fleche/digest.py                        176      7    100      8    95%
src/fleche/executor.py                       35      2     10      0    96%
src/fleche/metadata.py                       74      6      4      0    92%
src/fleche/query.py                         127      0     50      1    99%
src/fleche/remote.py                        376     43     98     16    87%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/state.py                          52      1     10      1    97%
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py      49      0     10      1    98%
src/fleche/storage/base.py                  132      3     38      3    96%
src/fleche/storage/destructuring.py         156      2     48      1    99%
src/fleche/storage/file.py                   54      0      4      0   100%
src/fleche/storage/memory.py                 32      0      2      0   100%
src/fleche/storage/pickle_file.py            77      2     12      0    98%
src/fleche/storage/sql.py                   246     10     88      6    95%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/storage/void.py                   20      1      4      0    96%
src/fleche/wrapper.py                       193      1     48      1    99%
---------------------------------------------------------------------------
TOTAL                                      2771    125    826     59    95%
```

## Test plan

- [x] `pytest tests/` — 1492 passed, 11 skipped (was 1496 / 11)
- [x] `coverage report` shows line + branch totals unchanged
- [x] Per-test dynamic-context data confirms each removed test's `src/fleche/` line set is a subset of the union of the remaining tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8JeUUMSvifMz5i7E8rVBB)_