### PR TITLE
docs(readme): remove duplicate In-Memory Storage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ def my_function(x):
 - Forwards every cache operation over a persistent `ssh host python -m fleche remote --serve` subprocess
 - Stack with a local cache to read-through to a shared remote one — see `fleche.remote.SshCache`
 
-### In-Memory Storage
-- For testing or temporary caching
-- Loses data when process exits
-
 ### Custom Backends
 Implement the `Storage` interface to create custom backends.
 


### PR DESCRIPTION
## Summary

The **Storage Backends** section of `README.md` listed in-memory storage twice:

1. **"In-Memory Storage (Default)"** (the authoritative entry): correctly explains that in-memory storage is the automatic fallback when no `fleche.toml` configuration file is present, and that data is transient.
2. **"In-Memory Storage"** (the duplicate): added nothing new — "For testing or temporary caching / Loses data when process exits" — and appeared four bullet points later in the same section.

A reader scanning the list for the first time would reasonably wonder whether these are two distinct backends with different behaviours. They are not; it is the same backend described twice.

## Change

Remove the redundant second entry. The first entry already covers both the default-fallback use-case and the transience property.

## Why it was caught

Systematic cross-reference of all documentation pages against the source code revealed the duplicate during a full docs audit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsP3xV7s9KRMPMwh3gnHHX)_