### PR TITLE
docs(configuration): document 'default' as a reserved cache name

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -62,6 +62,22 @@ Example:
    ...     # Results will not be cached at all. Every call executes the function.
    ...     ...
 
+``default``
+~~~~~~~~~~~
+
+The name ``default`` is a reserved cache name. When requested, ``fleche`` activates
+whichever cache the configuration file designates as the default — equivalent to
+the cache that is active at process start.  This is **not** the same as passing
+``None`` to :func:`~fleche.state.cache`, which returns the *currently active* cache
+without changing anything.
+
+.. code-block:: pycon
+
+   >>> from fleche import cache
+   >>> with cache("default"):
+   ...     # The config-file default cache is active inside this block.
+   ...     ...
+
 The ``[default]`` section
 -------------------------
 


### PR DESCRIPTION
## Summary

`config.py`'s `load_cache_config()` special-cases three cache names: `'memory'`, `'void'`, and `'default'`. The "Reserved Cache Names" section of `docs/storage/configuration.rst` documented only the first two.

### Why the omission matters

`cache("default")` has subtly different semantics from `cache(None)`:

- `cache("default")` — **switches** the active cache to whichever cache the config file designates as the default (i.e. what was active at process start).
- `cache(None)` — **returns** the currently active cache without changing anything (a query, not a switch).

This distinction is already documented in the `cache()` docstring in `state.py`, but a user reading `configuration.rst` would have no way to know `'default'` is valid at all.

### Change

Add a `default` subsection after `void` that:

- states that `'default'` is a reserved name
- explains that it activates the config-file-designated default cache
- clarifies the distinction from `cache(None)` 
- includes a minimal `with cache("default"):` example matching the style of the existing `memory` and `void` entries

## Verification

`config.py` lines confirmed:
```python
if name == "default":
    cache = load_cache_config(None)
    _live_caches["default"] = cache
    return cache
```

`state.py` docstring already states:
> The string `'default'` activates whichever cache the config file designates as the default — note that this is **not** the same as passing `None`, which returns the *currently active* cache without changing anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsP3xV7s9KRMPMwh3gnHHX)_