### PR TITLE
feat(config): add [default] root tag to stop upward config merge

### DIFF
--- a/agents/USAGE.md
+++ b/agents/USAGE.md
@@ -77,6 +77,13 @@ So a project-local `./fleche.toml` overrides `~/fleche.toml`, which
 overrides the XDG fallback. If no file is found anywhere, fleche silently
 falls back to an in-memory-only cache — no error is raised.
 
+To stop that upward inheritance, set `root = true` in a file's `[default]`
+table. The walk halts at the closest `root` file: files farther up the tree
+(and the XDG fallback) are ignored, so only that file and any closer to the
+CWD contribute. This is the ESLint `root: true` pattern — pin a project's
+config without inheriting whatever `fleche.toml` lives in a parent directory
+or `$HOME`.
+
 A minimal file:
 
 ```toml

--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -16,6 +16,11 @@ merged).  This makes it easy to keep a base config at ``~/fleche.toml``
 (or in XDG) and override individual cache definitions in project
 subdirectories.
 
+A file can opt out of this upward inheritance by setting ``root = true`` in
+its ``[default]`` table (see :ref:`the default section <default-section>`
+below).  The walk stops at the closest such file: files farther up the tree
+— and the ``$XDG_CONFIG_HOME`` fallback — are not merged in.
+
 If no configuration file is discovered, ``fleche`` falls back to a default
 in-memory cache.
 
@@ -78,6 +83,8 @@ without changing anything.
    ...     # The config-file default cache is active inside this block.
    ...     ...
 
+.. _default-section:
+
 The ``[default]`` section
 -------------------------
 
@@ -108,6 +115,27 @@ Example:
    metadata = ["Runtime"]
 
 **Note:** The ``Tags`` metadata cannot be configured from the config file, as it requires arguments.
+
+``root``
+~~~~~~~~
+
+The ``root`` key is a boolean (default ``false``) that marks this file as the
+top of the config hierarchy.  When set to ``true``, the discovery walk stops
+here: any ``fleche.toml`` farther up the directory tree, along with the
+``$XDG_CONFIG_HOME`` fallback, is ignored.  Files *closer* to the current
+directory are still merged on top as usual.
+
+This mirrors the ESLint ``root: true`` convention — use it to pin a
+project's configuration so it does not inherit whatever ``fleche.toml``
+happens to live in a parent directory or ``$HOME``.
+
+Example:
+
+.. code-block:: toml
+
+   [default]
+   cache = "mycache"
+   root = true
 
 Cache sections
 --------------

--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -125,7 +125,7 @@ here: any ``fleche.toml`` farther up the directory tree, along with the
 ``$XDG_CONFIG_HOME`` fallback, is ignored.  Files *closer* to the current
 directory are still merged on top as usual.
 
-This mirrors the ESLint ``root: true`` convention — use it to pin a
+Use it to pin a
 project's configuration so it does not inherit whatever ``fleche.toml``
 happens to live in a parent directory or ``$HOME``.
 

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -271,16 +271,15 @@ def _load_merged_config() -> dict[str, Any]:
     that file acts as the top of the hierarchy, and any files farther up
     (including the XDG fallback) are ignored.
     """
-    configs: list[dict[str, Any]] = []
+    merged: dict[str, Any] = {}
     for path in _collect_config_paths():  # closest first
         config = _load_config(path)
-        configs.append(config)
+        # setdefault, not update: a closer file already in `merged` wins over
+        # the same top-level key in a farther file.
+        for key, value in config.items():
+            merged.setdefault(key, value)
         if _is_root_config(config):
             break
-
-    merged: dict[str, Any] = {}
-    for config in reversed(configs):  # farthest retained first, closest wins
-        merged.update(config)
     return merged
 
 

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -166,6 +166,20 @@ as a final lowest-priority layer.
 All discovered files are **shallow-merged** at the top level: files closer
 to the CWD win, and a closer file's top-level table fully replaces the
 same key in a farther file (tables are *not* recursively merged).
+
+Stopping the walk
+-----------------
+
+A ``fleche.toml`` can declare ``root = true`` in its ``[default]`` table to
+act as the top of the config hierarchy.  When the walk reaches such a file,
+files farther up the tree (and the ``$XDG_CONFIG_HOME`` fallback) are *not*
+merged in — only the ``root`` file and any files closer to the CWD
+contribute.  This lets a project pin its configuration without inheriting
+whatever ``fleche.toml`` happens to live in a parent directory or ``$HOME``::
+
+    [default]
+    cache = "persistent"
+    root = true              # ignore any fleche.toml farther up the tree
 """
 
 import dataclasses
@@ -235,16 +249,37 @@ def _collect_config_paths() -> list[Path]:
     return paths
 
 
+def _is_root_config(config: dict[str, Any]) -> bool:
+    """Whether ``config`` declares ``root = true`` in its ``[default]`` table.
+
+    A file that sets ``[default].root`` acts as the top of the config
+    hierarchy: files farther up the walk (and the XDG fallback) are not
+    merged in.
+    """
+    default = config.get("default")
+    return isinstance(default, dict) and bool(default.get("root", False))
+
+
 def _load_merged_config() -> dict[str, Any]:
     """Load and shallow-merge all config files on the walk path.
 
     Files closer to the CWD override files farther away.  Top-level keys
     from the closest file fully replace the same key from any farther file
     (no recursive table merging).
+
+    The walk stops at the closest file that sets ``[default].root = true``:
+    that file acts as the top of the hierarchy, and any files farther up
+    (including the XDG fallback) are ignored.
     """
-    merged: dict[str, Any] = {}
-    for path in reversed(_collect_config_paths()):
+    configs: list[dict[str, Any]] = []
+    for path in _collect_config_paths():  # closest first
         config = _load_config(path)
+        configs.append(config)
+        if _is_root_config(config):
+            break
+
+    merged: dict[str, Any] = {}
+    for config in reversed(configs):  # farthest retained first, closest wins
         merged.update(config)
     return merged
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -743,128 +743,110 @@ def test_walk_merged_metadata(monkeypatch, tmp_path):
     assert isinstance(meta[0], Runtime)
 
 
-def test_walk_root_stops_upward_merge(monkeypatch, tmp_path):
-    """A closer file with `root = true` blocks farther files from merging in."""
+def _write_config(directory, body, name="fleche.toml"):
+    """Write a dedented TOML config file into ``directory``."""
+    (directory / name).write_text(textwrap.dedent(body))
+
+
+@pytest.fixture
+def home_and_project(monkeypatch, tmp_path):
+    """Lay out ``$HOME=<tmp>`` with CWD at ``<tmp>/project`` and XDG unset.
+
+    Returns ``(home, project)`` so a test only has to write the config
+    files whose interaction it is actually exercising.
+    """
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     home = tmp_path
-    sub = home / "project"
-    sub.mkdir()
+    project = home / "project"
+    project.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.chdir(sub)
+    monkeypatch.chdir(project)
+    return home, project
 
-    # Farther file defines a cache the closer file references by name.
-    (home / "fleche.toml").write_text(textwrap.dedent("""
+
+def test_walk_root_stops_upward_merge(home_and_project):
+    """A closer file with `root = true` blocks farther files from merging in."""
+    home, project = home_and_project
+    # 'home_only' lives only in the farther ($HOME) file.
+    _write_config(home, """
         [home_only]
         values.type = "void"
         calls.type = "void"
-    """))
-
-    # Closer file declares itself root → the farther file is ignored, so
-    # 'home_only' is not resolvable and we fall back to the memory default.
-    (sub / "fleche.toml").write_text(textwrap.dedent("""
+    """)
+    _write_config(project, """
         [default]
         cache = "home_only"
         root = true
-    """))
-
-    cache_obj = load_cache_config()
-    # 'home_only' was never merged → fallback memory cache.
-    assert isinstance(cache_obj.values, storage.ValueMemory)
+    """)
+    # root = true ignores the farther file → 'home_only' unresolved → memory.
+    assert isinstance(load_cache_config().values, storage.ValueMemory)
 
 
-def test_walk_root_keeps_closer_files(monkeypatch, tmp_path):
-    """`root` stops farther files but closer files still merge on top."""
-    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-    home = tmp_path
-    mid = home / "project"
-    mid.mkdir()
-    sub = mid / "nested"
-    sub.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.chdir(sub)
-
-    # Farthest ($HOME) — must be ignored because 'mid' is root.
-    (home / "fleche.toml").write_text(textwrap.dedent("""
+def test_walk_root_keeps_closer_files(monkeypatch, home_and_project):
+    """A `root` file still lets files closer to the CWD merge on top."""
+    _, root_dir = home_and_project
+    nested = root_dir / "nested"
+    nested.mkdir()
+    monkeypatch.chdir(nested)
+    # The root file's own [default] points at a void cache...
+    _write_config(root_dir, """
         [default]
-        cache = "from_home"
-
-        [from_home]
-        values.type = "void"
-        calls.type = "void"
-    """))
-
-    # Middle — the root of the hierarchy; supplies the 'chosen' cache.
-    (mid / "fleche.toml").write_text(textwrap.dedent("""
-        [default]
-        cache = "from_home"
+        cache = "rootcache"
         root = true
 
-        [chosen]
+        [rootcache]
+        values.type = "void"
+        calls.type = "void"
+
+        [nearcache]
         values.type = "memory"
         calls.type = "memory"
-    """))
-
-    # Closest — still merges on top of the root file, overriding [default].
-    (sub / "fleche.toml").write_text(textwrap.dedent("""
+    """)
+    # ...but the closer file overrides [default] to the memory cache.
+    _write_config(nested, """
         [default]
-        cache = "chosen"
-    """))
-
-    cache_obj = load_cache_config()
-    # Closer file's [default] wins ('chosen'); farther $HOME file is ignored.
-    assert isinstance(cache_obj.values, storage.ValueMemory)
+        cache = "nearcache"
+    """)
+    assert isinstance(load_cache_config().values, storage.ValueMemory)
 
 
 def test_walk_root_ignores_xdg_fallback(monkeypatch, tmp_path):
     """`root = true` also excludes the XDG lowest-priority fallback."""
     home = tmp_path / "home"
-    home.mkdir()
-    sub = home / "project"
-    sub.mkdir()
+    project = home / "project"
     xdg = tmp_path / "xdg"
+    project.mkdir(parents=True)
     (xdg / "fleche").mkdir(parents=True)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.chdir(sub)
-
-    (xdg / "fleche" / "cache.toml").write_text(textwrap.dedent("""
+    monkeypatch.chdir(project)
+    # 'from_xdg' lives only in the XDG fallback layer.
+    _write_config(xdg / "fleche", """
         [from_xdg]
         values.type = "void"
         calls.type = "void"
-    """))
-
-    (sub / "fleche.toml").write_text(textwrap.dedent("""
+    """, name="cache.toml")
+    _write_config(project, """
         [default]
         cache = "from_xdg"
         root = true
-    """))
-
-    cache_obj = load_cache_config()
-    # XDG layer was not merged → 'from_xdg' unresolved → memory fallback.
-    assert isinstance(cache_obj.values, storage.ValueMemory)
+    """)
+    # XDG layer not merged → 'from_xdg' unresolved → memory fallback.
+    assert isinstance(load_cache_config().values, storage.ValueMemory)
 
 
-def test_walk_root_false_still_merges(monkeypatch, tmp_path):
+def test_walk_root_false_still_merges(home_and_project):
     """`root = false` is a no-op: farther files still merge in."""
-    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-    home = tmp_path
-    sub = home / "project"
-    sub.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    monkeypatch.chdir(sub)
-
-    (home / "fleche.toml").write_text(textwrap.dedent("""
+    home, project = home_and_project
+    _write_config(home, """
         [home_only]
         values.type = "void"
         calls.type = "void"
-    """))
-
-    (sub / "fleche.toml").write_text(textwrap.dedent("""
+    """)
+    _write_config(project, """
         [default]
         cache = "home_only"
         root = false
-    """))
-
-    cache_obj = load_cache_config()
-    # root = false → farther file still merged → 'home_only' resolves.
-    assert isinstance(cache_obj.values, storage.ValueVoid)
+    """)
+    # root = false → farther file still merged → 'home_only' resolves (void).
+    assert isinstance(load_cache_config().values, storage.ValueVoid)

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -741,3 +741,130 @@ def test_walk_merged_metadata(monkeypatch, tmp_path):
     meta = load_default_metadata()
     assert len(meta) == 1
     assert isinstance(meta[0], Runtime)
+
+
+def test_walk_root_stops_upward_merge(monkeypatch, tmp_path):
+    """A closer file with `root = true` blocks farther files from merging in."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    home = tmp_path
+    sub = home / "project"
+    sub.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(sub)
+
+    # Farther file defines a cache the closer file references by name.
+    (home / "fleche.toml").write_text(textwrap.dedent("""
+        [home_only]
+        values.type = "void"
+        calls.type = "void"
+    """))
+
+    # Closer file declares itself root → the farther file is ignored, so
+    # 'home_only' is not resolvable and we fall back to the memory default.
+    (sub / "fleche.toml").write_text(textwrap.dedent("""
+        [default]
+        cache = "home_only"
+        root = true
+    """))
+
+    cache_obj = load_cache_config()
+    # 'home_only' was never merged → fallback memory cache.
+    assert isinstance(cache_obj.values, storage.ValueMemory)
+
+
+def test_walk_root_keeps_closer_files(monkeypatch, tmp_path):
+    """`root` stops farther files but closer files still merge on top."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    home = tmp_path
+    mid = home / "project"
+    mid.mkdir()
+    sub = mid / "nested"
+    sub.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(sub)
+
+    # Farthest ($HOME) — must be ignored because 'mid' is root.
+    (home / "fleche.toml").write_text(textwrap.dedent("""
+        [default]
+        cache = "from_home"
+
+        [from_home]
+        values.type = "void"
+        calls.type = "void"
+    """))
+
+    # Middle — the root of the hierarchy; supplies the 'chosen' cache.
+    (mid / "fleche.toml").write_text(textwrap.dedent("""
+        [default]
+        cache = "from_home"
+        root = true
+
+        [chosen]
+        values.type = "memory"
+        calls.type = "memory"
+    """))
+
+    # Closest — still merges on top of the root file, overriding [default].
+    (sub / "fleche.toml").write_text(textwrap.dedent("""
+        [default]
+        cache = "chosen"
+    """))
+
+    cache_obj = load_cache_config()
+    # Closer file's [default] wins ('chosen'); farther $HOME file is ignored.
+    assert isinstance(cache_obj.values, storage.ValueMemory)
+
+
+def test_walk_root_ignores_xdg_fallback(monkeypatch, tmp_path):
+    """`root = true` also excludes the XDG lowest-priority fallback."""
+    home = tmp_path / "home"
+    home.mkdir()
+    sub = home / "project"
+    sub.mkdir()
+    xdg = tmp_path / "xdg"
+    (xdg / "fleche").mkdir(parents=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(sub)
+
+    (xdg / "fleche" / "cache.toml").write_text(textwrap.dedent("""
+        [from_xdg]
+        values.type = "void"
+        calls.type = "void"
+    """))
+
+    (sub / "fleche.toml").write_text(textwrap.dedent("""
+        [default]
+        cache = "from_xdg"
+        root = true
+    """))
+
+    cache_obj = load_cache_config()
+    # XDG layer was not merged → 'from_xdg' unresolved → memory fallback.
+    assert isinstance(cache_obj.values, storage.ValueMemory)
+
+
+def test_walk_root_false_still_merges(monkeypatch, tmp_path):
+    """`root = false` is a no-op: farther files still merge in."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    home = tmp_path
+    sub = home / "project"
+    sub.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(sub)
+
+    (home / "fleche.toml").write_text(textwrap.dedent("""
+        [home_only]
+        values.type = "void"
+        calls.type = "void"
+    """))
+
+    (sub / "fleche.toml").write_text(textwrap.dedent("""
+        [default]
+        cache = "home_only"
+        root = false
+    """))
+
+    cache_obj = load_cache_config()
+    # root = false → farther file still merged → 'home_only' resolves.
+    assert isinstance(cache_obj.values, storage.ValueVoid)


### PR DESCRIPTION
## What

Adds a `root` boolean tag to the `[default]` section of `fleche.toml`. When set to `true`, the config-discovery walk stops at that file: `fleche.toml` files farther **up** the directory tree — and the `$XDG_CONFIG_HOME` fallback — are no longer merged in. Files **closer** to the CWD still merge on top as usual.

```toml
[default]
cache = "persistent"
root = true              # ignore any fleche.toml farther up the tree
```

## Why

Previously every discovered config on the walk from the CWD up to `$HOME` (plus the XDG fallback) was unconditionally shallow-merged, so a project inherited whatever `fleche.toml` happened to live in a parent directory or `$HOME`. The new tag lets a project pin its configuration and act as the top of the hierarchy — the same convention as ESLint's `root: true`.

## How

- `_load_merged_config()` now collects files closest-first and breaks the walk at the first file whose `[default].root` is truthy, then shallow-merges the retained files as before (closest wins). A small `_is_root_config()` helper does the check defensively (only treats `[default]` as a source when it is a table).
- Since the XDG fallback is appended last on the walk path, stopping at an earlier `root` file naturally excludes it too.

## Docs

- Module docstring in `src/fleche/config.py` (discovery section + new "Stopping the walk").
- `docs/storage/configuration.rst`: discovery note + a `root` subsection under `[default]`.
- `agents/USAGE.md`: config-discovery paragraph.

## Tests

Added four tests in `tests/unit/config/test_config.py`:
- `test_walk_root_stops_upward_merge` — a `root` file blocks a farther file from merging.
- `test_walk_root_keeps_closer_files` — closer files still merge on top of a `root` file.
- `test_walk_root_ignores_xdg_fallback` — `root` also excludes the XDG layer.
- `test_walk_root_false_still_merges` — `root = false` is a no-op.

All 44 config tests pass; `ty check src/` is clean. Verified end-to-end that `root = true` drops the parent's cache section from the merged config while removing it lets the parent merge back in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SLcyqXWPSY9vWZbW76qtM

---
_Generated by [Claude Code](https://claude.ai/code/session_012SLcyqXWPSY9vWZbW76qtM)_