### PR TITLE
ci: skip performance triage on dependabot PRs

### DIFF
--- a/.github/workflows/perf-triage.yml
+++ b/.github/workflows/perf-triage.yml
@@ -23,9 +23,11 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
-    # Skip drafts and PRs that already carry the label (nothing to decide).
+    # Skip drafts, dependabot PRs, and PRs that already carry the label
+    # (nothing to decide).
     if: |
       github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'benchmark')
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

Dependabot PRs (dependency bumps) don't warrant running the performance triage / benchmark decision, so this adds a guard to skip the `Performance Triage` workflow when the PR author is `dependabot[bot]`.

## Changes

- `.github/workflows/perf-triage.yml`: extend the `triage` job's `if` condition with `github.event.pull_request.user.login != 'dependabot[bot]'`, alongside the existing draft and `benchmark`-label skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuFEGSyFSDNZfYVkcQePFU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuFEGSyFSDNZfYVkcQePFU)_