### PR TITLE
fix: always bind non-fleche callables in wrap_executor.submit

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -246,10 +246,13 @@ executor **instance** (no subclassing — callers pass us instances of
 third-party executors) so that fleche-decorated functions are handled
 automatically:
 
-- Non-fleche callables pass straight through to the original ``submit``.
-- Cache hits are served from an already-completed
-  :class:`~concurrent.futures.Future` without ever touching the executor,
-  avoiding submit/serialise overhead on cached inputs.
+- Non-fleche callables are bound via :meth:`~fleche.BoundWrapper.bind` before
+  being forwarded to the original ``submit``, so the parent's cache and
+  metadata are available in the worker even for a plain function that only
+  *calls* a fleche-decorated function somewhere in its body.
+- Cache hits (for fleche-decorated callables submitted directly) are served
+  from an already-completed :class:`~concurrent.futures.Future` without ever
+  touching the executor, avoiding submit/serialise overhead on cached inputs.
 - Cache misses are bound via :meth:`~fleche.BoundWrapper.bind` so the parent's
   cache and metadata travel with the call into the worker.
 

--- a/src/fleche/executor.py
+++ b/src/fleche/executor.py
@@ -3,13 +3,18 @@
 Motivation: users passing a :func:`fleche.fleche`-decorated function to
 ``executor.submit(...)`` have to remember to call :meth:`.BoundWrapper.bind`
 themselves to carry the active cache/metadata state into the worker.  They also
-pay the submit/serialisation cost even when the result is already cached.
+pay the submit/serialisation cost even when the result is already cached.  The
+same problem affects plain (non-fleche) callables that merely *call* a
+fleche-decorated function somewhere in their body: unless they are bound too,
+the active cache/metadata state never reaches the worker process.
 
 :func:`wrap_executor` patches the ``submit`` method of an executor *instance*
 (we cannot subclass, since callers pass us instances of third-party executors)
 so that:
 
-* non-fleche callables are forwarded unchanged,
+* non-fleche callables are bound via :meth:`.BoundWrapper.bind` and submitted
+  to the original ``submit`` unchanged otherwise, so that any fleche calls
+  nested inside them still see the active cache/metadata state,
 * fleche callables whose result is already cached are returned via an
   already-completed :class:`~concurrent.futures.Future` without touching the
   executor, and
@@ -25,6 +30,8 @@ remaining keyword arguments are bound as part of the function payload.
 from concurrent.futures import Future
 from inspect import signature, Parameter
 from types import SimpleNamespace
+
+from . import state
 
 
 __all__ = ["wrap_executor"]
@@ -80,7 +87,8 @@ def wrap_executor(executor):
 
     def submit(func, *args, **kwargs):
         if not _is_fleche_function(func):
-            return original_submit(func, *args, **kwargs)
+            bound = state.BoundWrapper.bind(func)
+            return original_submit(bound, *args, **kwargs)
 
         submit_kwargs, func_kwargs = _split_submit_kwargs(
             original_submit, kwargs

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -31,7 +31,6 @@ completely invisible to workers.
 
 import concurrent.futures
 import contextvars
-import pathlib
 import tempfile
 import pytest
 
@@ -444,73 +443,3 @@ def test_executorlib_wrap_executor(file_cache):
     assert result == 42, f"Expected 42, got {result}"
     assert file_cache.contains(double.digest(21))
 
-
-# ---------------------------------------------------------------------------
-# Regression test for #691
-# ---------------------------------------------------------------------------
-# https://github.com/pmrv/fleche/issues/691
-#
-# A plain (non-fleche) function that merely *calls* a fleche-decorated
-# function did not get cache hits when submitted via a wrap_executor'd
-# ProcessPoolExecutor: only the outer callable was inspected by ``submit``,
-# and since it had no ``.fleche`` namespace it was forwarded to the executor
-# unbound, so the worker process never saw the active cache. ``submit`` now
-# always applies ``BoundWrapper.bind`` to non-fleche callables too, so the
-# active cache/metadata state is carried into the worker regardless of which
-# function in the call chain is actually decorated.
-
-
-def _issue_691_slow(t, marker_path):
-    """Analogue of ``slow`` from the issue; records every real invocation."""
-    path = pathlib.Path(marker_path)
-    path.write_text(str(int(path.read_text()) + 1))
-    return t
-
-
-_issue_691_slow = fleche.fleche(_issue_691_slow)
-
-
-def _issue_691_carries_slow(t, marker_path):
-    """Analogue of ``carries_slow``: plain function, not itself fleche-decorated."""
-    return _issue_691_slow(t, marker_path)
-
-
-def test_wrap_executor_binds_plain_wrapper_around_fleche_call(file_cache, tmp_path):
-    """A plain wrapper around a fleche call gets cache hits across processes.
-
-    Uses ``max_tasks_per_child=1`` so each submission spawns a fresh worker
-    process with no warm in-memory state, matching the reproduction steps
-    from the issue.
-    """
-    marker = tmp_path / "marker"
-    marker.write_text("0")
-
-    with fleche.cache(file_cache):
-        with concurrent.futures.ProcessPoolExecutor(
-            max_workers=1, max_tasks_per_child=1
-        ) as executor:
-            fleche.wrap_executor(executor)
-            first = executor.submit(
-                _issue_691_carries_slow, 3, str(marker)
-            ).result()
-
-    with fleche.cache(file_cache):
-        with concurrent.futures.ProcessPoolExecutor(
-            max_workers=1, max_tasks_per_child=1
-        ) as executor:
-            fleche.wrap_executor(executor)
-            second = executor.submit(
-                _issue_691_carries_slow, 3, str(marker)
-            ).result()
-
-    assert first == 3
-    assert second == 3
-    assert file_cache.contains(_issue_691_slow.digest(3, str(marker)))
-    # The inner fleche-decorated call must only have actually executed once:
-    # the second pass is served from cache even though ``carries_slow`` itself
-    # is a plain, non-fleche function.
-    assert marker.read_text() == "1", (
-        "carries_slow is not itself fleche-decorated, but wrap_executor must "
-        "still bind the active cache into the worker so the nested call to "
-        "the fleche-decorated `slow` gets a cache hit on the second pass."
-    )

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -31,6 +31,7 @@ completely invisible to workers.
 
 import concurrent.futures
 import contextvars
+import pathlib
 import tempfile
 import pytest
 
@@ -341,8 +342,8 @@ class _RecordingExecutor:
         return fut
 
 
-def test_wrap_executor_passthrough_non_fleche():
-    """Non-fleche callables go straight to the original submit."""
+def test_wrap_executor_binds_non_fleche_callable():
+    """Non-fleche callables are still bound via BoundWrapper before submission."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         fleche.wrap_executor(executor)
         result = executor.submit(_plain_add, 2, 3).result()
@@ -442,3 +443,74 @@ def test_executorlib_wrap_executor(file_cache):
 
     assert result == 42, f"Expected 42, got {result}"
     assert file_cache.contains(double.digest(21))
+
+
+# ---------------------------------------------------------------------------
+# Regression test for #691
+# ---------------------------------------------------------------------------
+# https://github.com/pmrv/fleche/issues/691
+#
+# A plain (non-fleche) function that merely *calls* a fleche-decorated
+# function did not get cache hits when submitted via a wrap_executor'd
+# ProcessPoolExecutor: only the outer callable was inspected by ``submit``,
+# and since it had no ``.fleche`` namespace it was forwarded to the executor
+# unbound, so the worker process never saw the active cache. ``submit`` now
+# always applies ``BoundWrapper.bind`` to non-fleche callables too, so the
+# active cache/metadata state is carried into the worker regardless of which
+# function in the call chain is actually decorated.
+
+
+def _issue_691_slow(t, marker_path):
+    """Analogue of ``slow`` from the issue; records every real invocation."""
+    path = pathlib.Path(marker_path)
+    path.write_text(str(int(path.read_text()) + 1))
+    return t
+
+
+_issue_691_slow = fleche.fleche(_issue_691_slow)
+
+
+def _issue_691_carries_slow(t, marker_path):
+    """Analogue of ``carries_slow``: plain function, not itself fleche-decorated."""
+    return _issue_691_slow(t, marker_path)
+
+
+def test_wrap_executor_binds_plain_wrapper_around_fleche_call(file_cache, tmp_path):
+    """A plain wrapper around a fleche call gets cache hits across processes.
+
+    Uses ``max_tasks_per_child=1`` so each submission spawns a fresh worker
+    process with no warm in-memory state, matching the reproduction steps
+    from the issue.
+    """
+    marker = tmp_path / "marker"
+    marker.write_text("0")
+
+    with fleche.cache(file_cache):
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=1, max_tasks_per_child=1
+        ) as executor:
+            fleche.wrap_executor(executor)
+            first = executor.submit(
+                _issue_691_carries_slow, 3, str(marker)
+            ).result()
+
+    with fleche.cache(file_cache):
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=1, max_tasks_per_child=1
+        ) as executor:
+            fleche.wrap_executor(executor)
+            second = executor.submit(
+                _issue_691_carries_slow, 3, str(marker)
+            ).result()
+
+    assert first == 3
+    assert second == 3
+    assert file_cache.contains(_issue_691_slow.digest(3, str(marker)))
+    # The inner fleche-decorated call must only have actually executed once:
+    # the second pass is served from cache even though ``carries_slow`` itself
+    # is a plain, non-fleche function.
+    assert marker.read_text() == "1", (
+        "carries_slow is not itself fleche-decorated, but wrap_executor must "
+        "still bind the active cache into the worker so the nested call to "
+        "the fleche-decorated `slow` gets a cache hit on the second pass."
+    )

--- a/tests/regression/test_issue_691.py
+++ b/tests/regression/test_issue_691.py
@@ -1,0 +1,74 @@
+"""Regression test for issue #691.
+
+https://github.com/pmrv/fleche/issues/691
+
+A plain (non-fleche) function that merely *calls* a fleche-decorated
+function did not get cache hits when submitted via a wrap_executor'd
+ProcessPoolExecutor: only the outer callable was inspected by ``submit``,
+and since it had no ``.fleche`` namespace it was forwarded to the executor
+unbound, so the worker process never saw the active cache. ``submit`` now
+always applies ``BoundWrapper.bind`` to non-fleche callables too, so the
+active cache/metadata state is carried into the worker regardless of which
+function in the call chain is actually decorated.
+"""
+
+import concurrent.futures
+import pathlib
+
+import fleche
+
+
+def _issue_691_slow(t, marker_path):
+    """Analogue of ``slow`` from the issue; records every real invocation."""
+    path = pathlib.Path(marker_path)
+    path.write_text(str(int(path.read_text()) + 1))
+    return t
+
+
+_issue_691_slow = fleche.fleche(_issue_691_slow)
+
+
+def _issue_691_carries_slow(t, marker_path):
+    """Analogue of ``carries_slow``: plain function, not itself fleche-decorated."""
+    return _issue_691_slow(t, marker_path)
+
+
+def test_wrap_executor_binds_plain_wrapper_around_fleche_call(file_cache, tmp_path):
+    """A plain wrapper around a fleche call gets cache hits across processes.
+
+    Uses ``max_tasks_per_child=1`` so each submission spawns a fresh worker
+    process with no warm in-memory state, matching the reproduction steps
+    from the issue.
+    """
+    marker = tmp_path / "marker"
+    marker.write_text("0")
+
+    with fleche.cache(file_cache):
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=1, max_tasks_per_child=1
+        ) as executor:
+            fleche.wrap_executor(executor)
+            first = executor.submit(
+                _issue_691_carries_slow, 3, str(marker)
+            ).result()
+
+    with fleche.cache(file_cache):
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=1, max_tasks_per_child=1
+        ) as executor:
+            fleche.wrap_executor(executor)
+            second = executor.submit(
+                _issue_691_carries_slow, 3, str(marker)
+            ).result()
+
+    assert first == 3
+    assert second == 3
+    assert file_cache.contains(_issue_691_slow.digest(3, str(marker)))
+    # The inner fleche-decorated call must only have actually executed once:
+    # the second pass is served from cache even though ``carries_slow`` itself
+    # is a plain, non-fleche function.
+    assert marker.read_text() == "1", (
+        "carries_slow is not itself fleche-decorated, but wrap_executor must "
+        "still bind the active cache into the worker so the nested call to "
+        "the fleche-decorated `slow` gets a cache hit on the second pass."
+    )


### PR DESCRIPTION
## Summary
- `wrap_executor(...).submit()` now always applies `BoundWrapper.bind` to non-fleche callables before forwarding them to the underlying executor, so a plain function that merely calls a `@fleche`-decorated function still gets the active cache/metadata state propagated into the worker process.
- Added a regression test modeled on the original issue snippet (`slow`/`carries_slow`), using a file-backed cache and `ProcessPoolExecutor(max_tasks_per_child=1)` to confirm the inner fleche call only executes once across two submissions.
- Updated docs/parallel_execution.rst to match the new behavior.

Fixes #691

## Test plan
- [x] `pytest tests/` — 1528 passed, 11 skipped

🤖 Generated with [Claude Code](https://claude.ai/code)