### PR TITLE
fix: don't double-bind an already-bound BoundWrapper in wrap_executor.submit

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -249,7 +249,9 @@ automatically:
 - Non-fleche callables are bound via :meth:`~fleche.BoundWrapper.bind` before
   being forwarded to the original ``submit``, so the parent's cache and
   metadata are available in the worker even for a plain function that only
-  *calls* a fleche-decorated function somewhere in its body.
+  *calls* a fleche-decorated function somewhere in its body. A callable that
+  is already a :class:`~fleche.BoundWrapper` is forwarded unchanged instead
+  of being bound again.
 - Cache hits (for fleche-decorated callables submitted directly) are served
   from an already-completed :class:`~concurrent.futures.Future` without ever
   touching the executor, avoiding submit/serialise overhead on cached inputs.

--- a/src/fleche/executor.py
+++ b/src/fleche/executor.py
@@ -14,7 +14,9 @@ so that:
 
 * non-fleche callables are bound via :meth:`.BoundWrapper.bind` and submitted
   to the original ``submit`` unchanged otherwise, so that any fleche calls
-  nested inside them still see the active cache/metadata state,
+  nested inside them still see the active cache/metadata state (a callable
+  that is already a :class:`.BoundWrapper` is submitted as-is, since it is
+  already bound),
 * fleche callables whose result is already cached are returned via an
   already-completed :class:`~concurrent.futures.Future` without touching the
   executor, and
@@ -87,8 +89,9 @@ def wrap_executor(executor):
 
     def submit(func, *args, **kwargs):
         if not _is_fleche_function(func):
-            bound = state.BoundWrapper.bind(func)
-            return original_submit(bound, *args, **kwargs)
+            if not isinstance(func, state.BoundWrapper):
+                func = state.BoundWrapper.bind(func)
+            return original_submit(func, *args, **kwargs)
 
         submit_kwargs, func_kwargs = _split_submit_kwargs(
             original_submit, kwargs

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -320,6 +320,7 @@ class _RecordingExecutor:
     """
 
     def __init__(self):
+        self.func = None
         self.submit_args = None
         self.submit_kwargs = None
         self.call_args = None
@@ -327,6 +328,7 @@ class _RecordingExecutor:
         self.result = None
 
     def submit(self, func, *args, resource_dict=None, **kwargs):
+        self.func = func
         self.submit_args = args
         self.submit_kwargs = {"resource_dict": resource_dict, **kwargs}
 
@@ -348,6 +350,23 @@ def test_wrap_executor_binds_non_fleche_callable():
         result = executor.submit(_plain_add, 2, 3).result()
 
     assert result == 5
+
+
+def test_wrap_executor_does_not_double_bind_bound_wrapper():
+    """An already-bound BoundWrapper passed to submit is forwarded unchanged."""
+    cache1 = Cache(ValueMemory({}), CallMemory({}))
+
+    with fleche.cache(cache1):
+        bound = BoundWrapper.bind(_plain_add)
+
+    executor = _RecordingExecutor()
+    fleche.wrap_executor(executor)
+    future = executor.submit(bound, 2, 3)
+
+    assert future.result() == 5
+    assert executor.func is bound, (
+        "an already-bound BoundWrapper must be forwarded as-is, not wrapped again"
+    )
 
 
 def test_wrap_executor_thread_cache_miss():


### PR DESCRIPTION
## Summary
- Follow-up to #722: a non-fleche callable passed to `wrap_executor(...).submit()` that is already a `BoundWrapper` instance is now forwarded unchanged, instead of being wrapped in a second `BoundWrapper` layer.
- Implements @pmrv's suggestion from the #722 review thread.
- Added a regression test asserting the exact `bound` instance reaches the underlying executor's `submit`.

Fixes review comment on #722.

## Test plan
- [x] `pytest tests/` — 1529 passed, 11 skipped

🤖 Generated with [Claude Code](https://claude.ai/code)