### PR TITLE
docs: guidance for looking up a cached value directly

### DIFF
--- a/docs/digests/digests_as_args.rst
+++ b/docs/digests/digests_as_args.rst
@@ -42,6 +42,45 @@ Behavior
 - **Missing Digests**: If a `Digest` is passed but its value cannot be found in the current cache, a `KeyError` will be raised.
 - **Short Digests**: If the underlying storage supports short-hand digest expansion, you can pass a short digest (at least 4 characters) to `D()`, and it will be expanded to the full value.
 
+Looking Up a Value Directly
+----------------------------
+
+``D()`` is also the ergonomic entry point for the opposite direction: given a value
+you already hold, or a digest hex string copied from a log line or from
+``cache().table()``, fetch the corresponding entry from the active cache's value
+storage without importing ``fleche.digest.digest`` yourself.
+
+- **You have the value itself.** ``D()`` computes its digest, which
+  :meth:`~fleche.caches.BaseCache.load_value` accepts directly:
+
+  .. code-block:: pycon
+
+     >>> from fleche import fleche, cache, D
+
+     >>> @fleche
+     ... def compute(x):
+     ...     return x * 2
+
+     >>> with cache("memory"):
+     ...     result = compute(21)                # populates the cache
+     ...     assert cache().load_value(D(result)) == result
+
+- **You have a digest hex string** (possibly shortened). ``D()`` recognises hex
+  strings and wraps them into a :class:`~fleche.digest.Digest` instead of hashing
+  them; call :meth:`~fleche.digest.Digest.expand` to resolve a short prefix back to
+  the full digest before loading it:
+
+  .. code-block:: pycon
+
+     >>> with cache("memory"):
+     ...     result = compute(21)
+     ...     short = D(result).shrink()          # shortest unambiguous prefix
+     ...     assert cache().load_value(D(short).expand()) == result
+
+If you instead have the *original arguments* of a decorated call rather than its
+result, prefer ``func.load(*args, **kwargs)`` (see :doc:`/usage/helpers`) — it
+re-derives the lookup key from the arguments and needs no digest at all.
+
 The `D` Wrapper
 ---------------
 


### PR DESCRIPTION
Closes #105.

## What

The code side of #105 (`D()` accepting arbitrary values, `Digest.expand(cache=None)`/`Digest.shrink(cache=None)`) already landed. The issue stayed open because the maintainer's last comment asked for one more thing:

> We'll need a bit more documentation on guidance on how users are supposed to do it, but doing it via `D` is succinct.

This PR adds that guidance: a new "Looking Up a Value Directly" section in `docs/digests/digests_as_args.rst` covering the two cases users hit:

- **You have the value itself** — `cache().load_value(D(value))`.
- **You have a digest hex string** (e.g. copied from `cache().table()`), possibly shortened — `D(short).expand()` then `load_value()`.

It also cross-references `func.load(*args, **kwargs)` (already documented in `usage/helpers.rst`) for the case where the original call arguments are known instead of the result.

## Verification

Both new code examples were run directly against the library to confirm they work as documented:

```
case1 ok
shrink: 6844
expand: 6844ce0b3b32f5d602732f6814a42a1839dbd5251bf2fe30f722c94f5eeb4144
case2 ok
```

`sphinx-build -b html docs ...` produces no new warnings/errors from the edited file (pre-existing autoapi warnings elsewhere are unrelated).

No source code changes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H3PxckCHHiuXrkfvn3uH4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3PxckCHHiuXrkfvn3uH4x)_