### PR TITLE
test(remote): cover `_redact_config` list walk and nested URL redaction

### DIFF
--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -477,6 +477,43 @@ def test_info_redacts_url_password():
     )
 
 
+def test_redact_config_walks_stack_with_nested_sql_url():
+    """`_redact_config` recurses through list-shaped stack configs and masks nested SQL URLs.
+
+    :func:`cache_to_config` serialises a :class:`~fleche.caches.CacheStack` as a
+    top-level list of member dicts.  A member with a :class:`~fleche.storage.sql.Sql`
+    call storage carries the DB password inside its nested ``calls.url``.  Both
+    the list traversal (recursion into each member) and the nested ``url``
+    rewrite must fire for a stack-of-SQL-caches ``info()`` handshake not to leak
+    the password.  The primitives are exercised in isolation by
+    ``test_info_redacts_secret_key`` / ``test_info_redacts_url_password``; this
+    test pins their composition on the shape that ends up on the wire.
+    """
+    from fleche.remote import _redact_config
+
+    stack_config = [
+        {
+            "values": {"type": "memory"},
+            "calls": {
+                "type": "sql",
+                "url": "postgresql://alice:hunter2@db.example.com:5432/x",
+            },
+        },
+        {
+            "values": {"type": "memory"},
+            "calls": {"type": "memory"},
+        },
+    ]
+    redacted = _redact_config(stack_config)
+    assert isinstance(redacted, list)
+    assert len(redacted) == 2
+    assert (
+        redacted[0]["calls"]["url"]
+        == "postgresql://alice:***@db.example.com:5432/x"
+    )
+    assert redacted[1]["calls"] == {"type": "memory"}
+
+
 def test_info_exposes_versions(remote):
     """info() includes `fleche_version` and `cloudpickle_version`."""
     info = remote.info()


### PR DESCRIPTION
## Summary

`remote.py` is the least-covered module (90.5% before this change, next non-trivial gap after the tiny `__main__`/`_attrs`/`__init__` fallback stubs).  The lowest-hanging gap inside it is the composition path in `_redact_config` — the primitives (`_redact_url_password`, top-level `secret_key` dict) are individually tested, but the shape that actually goes on the wire from `_server_info` (a **list** at the top level for a `CacheStack`, with a nested `sql` `url` inside a member's `calls`) is not exercised.  Two lines guarding real credential-leak behavior stayed uncovered:

- `remote.py:234` — nested `url` rewriting inside a dict walk
- `remote.py:239` — list traversal

A stack of SQL-backed caches served over SSH would leak the DB password in the `info()` handshake dict if either branch regressed, and the current tests would still pass.

This PR adds one focused test — `test_redact_config_walks_stack_with_nested_sql_url` — that pins the composition on the on-the-wire shape: a top-level list of `Cache`-shaped dicts, one member's `calls` being an `sql` dict with a password-carrying URL.  It leaves the primitive tests as the isolated pins they already are.

## Coverage report

Before / after, branch coverage on, full test suite:

| Module | Stmts | Miss (before → after) | Branch | BrPart (before → after) | Cover (before → after) |
|---|---:|---:|---:|---:|---:|
| `src/fleche/remote.py` | 369 | 28 → **26** | 82 | 15 → **13** | 90.5% → **91.4%** |
| **TOTAL** | 2787 | 110 → **108** | 816 | 58 → **56** | 95% → **95%** |

Full breakdown (unchanged rows omitted for brevity):

```
Name                     Stmts   Miss Branch BrPart  Cover
src/fleche/remote.py       369     26     82     13    91%
TOTAL                     2787    108    816     56    95%
```

Lines picked up: `remote.py:234` and `remote.py:239`.  Missing-branch pairs removed: `[233, 234]` and `[238, 239]`.

## Test plan

- [x] `python -m pytest tests/unit/test_remote.py::test_redact_config_walks_stack_with_nested_sql_url` passes
- [x] Full suite still green (`1530 passed, 11 skipped`, prior baseline 1529 passed)
- [x] Coverage delta verified via `pytest --cov=src/fleche --cov-branch --cov-report=json` before / after


---
_Generated by [Claude Code](https://claude.ai/code/session_01EiGXLiPZcJViVTvzzn626k)_