### PR TITLE
test(security): drop `test_normalize_list_of_bytes` — fully redundant

### DIFF
--- a/tests/unit/storage/test_secure_storage.py
+++ b/tests/unit/storage/test_secure_storage.py
@@ -150,11 +150,6 @@ def test_normalize_list_of_str():
     assert normalize_secret_key(keys) == [bytes.fromhex(k) for k in keys]
 
 
-def test_normalize_list_of_bytes():
-    keys = [b"A" * 32, b"B" * 32]
-    assert normalize_secret_key(keys) == keys
-
-
 def test_normalize_list_str_with_delimiter():
     k1, k2 = "ab" * 16, "cd" * 16
     keys = [k1 + ":" + k2]


### PR DESCRIPTION
## Summary

Follow-up to the coverage audit from #729.  I sampled ~20 tests randomly across the suite, deselected them in batches, and diffed the resulting per-file branch-coverage report against the baseline.  All but one either uniquely covered a real code path or were labelled contract/regression tests (docstring-pinned invariants or explicit `test_issue_*` regressions) that I leave untouched per the audit rules.

The one clean drop: `test_normalize_list_of_bytes` in `tests/unit/storage/test_secure_storage.py`.  Its two assertions are already reached by other tests in the same file:

- The **bytes branch inside the `normalize_secret_key` loop** (`elif isinstance(k, bytes)`) is hit by `test_normalize_bytes_wrapped_in_list`, which passes bare `bytes` — that input is wrapped in a one-element list and enters the same loop branch.
- The **outer `isinstance(key, (list, tuple))` branch** is hit by `test_normalize_list_of_str`, which passes a list.

Together those cover every code path this test exercised.  The test is not a regression pin and not a docstring-documented contract shape beyond what the two above already assert.

## Coverage report

Full-suite branch coverage, `pytest --cov=src/fleche --cov-branch --cov-report=json`, before and after this diff:

| Module | Stmts | Miss (before → after) | Branch | BrPart (before → after) | Cover |
|---|---:|---:|---:|---:|---:|
| `src/fleche/security.py` | 57 | 3 → **3** | 26 | 2 → **2** | 94% → **94%** |
| **TOTAL** | 2787 | 110 → **110** | 816 | 58 → **58** | 95% → **95%** |

Zero-delta across the whole `src/fleche/` tree.  Full diff was computed in-tree via:

```python
for f, info_b in before['files'].items():
    info_a = after['files'][f]
    dm  = info_a['summary']['missing_lines']    - info_b['summary']['missing_lines']
    dbr = info_a['summary']['missing_branches'] - info_b['summary']['missing_branches']
    if dm or dbr: print(f, dm, dbr)
# → no output
```

## Rationale for what I did *not* remove

Two other tests from the initial random pull showed a coverage drop when deselected, but I kept them:

- `test_D_falls_through_to_digest_for_non_short_hex` uniquely covers `fleche/__init__.py:44` (the `digest.digest(value)` fallback in `D()`), and its docstring explicitly says *"Pins the documented contract: only non-empty hex strings up to DIGEST_LENGTH characters are used verbatim; anything else is hashed"* — canonical contract test.
- Two lines in `bagofholding_file.py` (the `except (ValueError, TypeError)` inside `_to_file`) were also lost by the batch deselect, but none of the deselected tests touch h5 directly; the sensitivity is almost certainly hypothesis strategy state drifting from the changed collection order.  Not chased down further.

Other sampled tests were all `test_issue_*` regressions, docstring-pinned contracts, or feature acceptance tests — kept.

## Test plan

- [x] Full suite passes (`1528 passed, 11 skipped` after this diff; `1529 passed, 11 skipped` before).
- [x] `pytest --cov=src/fleche --cov-branch --cov-report=json` before / after diffed — zero-delta.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EiGXLiPZcJViVTvzzn626k)_