### PR TITLE
Logging cleanup: config.py levels, drop dead pickle_file logger

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -385,7 +385,10 @@ class Cache(PerKeyLockMixin, BaseCache):
                 yield c.fetch(self)
             except Exception as err:
                 logger.error(
-                        f"Failed to load matching call {c.to_lookup_key()} with {err}! Indicates corrupt cache."
+                        "Failed to load matching call %s with %s! Indicates corrupt cache.",
+                        c.to_lookup_key(),
+                        err,
+                        exc_info=True,
                 )
 
     def evict(self, key: str | Digest) -> None:

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -204,7 +204,7 @@ def _load_config(path: Path) -> dict[str, Any]:
         with open(path, "rb") as f:
             return tomllib.load(f)
     except Exception as e:
-        logger.info("Failed to load configuration from %s: %s", path, e, exc_info=True)
+        logger.error("Failed to load configuration from %s: %s", path, e, exc_info=True)
         return {}
 
 
@@ -555,7 +555,7 @@ def cache_to_config(c: caches.BaseCache) -> "dict[str, Any] | list[dict[str, Any
 def _default_memory_cache(name: str | None, reason: str | None = None) -> caches.Cache:
     """Return (and intern) a fresh in-memory cache, optionally logging the fallback reason."""
     if reason is not None:
-        logger.warning("Using default memory cache: %s", reason)
+        logger.info("Using default memory cache: %s", reason)
     cache = caches.Cache(storage.ValueMemory({}), storage.CallMemory({}))
     _live_caches[name] = cache
     return cache

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -204,7 +204,7 @@ def _load_config(path: Path) -> dict[str, Any]:
         with open(path, "rb") as f:
             return tomllib.load(f)
     except Exception as e:
-        logger.error("Failed to load configuration from %s: %s", path, e)
+        logger.info("Failed to load configuration from %s: %s", path, e, exc_info=True)
         return {}
 
 

--- a/src/fleche/digest.py
+++ b/src/fleche/digest.py
@@ -133,7 +133,7 @@ def load_entry_points():
                 _EP_HOOKS.append(hook)
                 seen_types[hook.type] = ep.value
         except Exception as e:
-            logger.error("Failed to load entry point %s: %s", ep.name, e)
+            logger.error("Failed to load entry point %s: %s", ep.name, e, exc_info=True)
 
 
 def _digest_mapping(m, contents: Mapping) -> bytes:

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -318,7 +318,7 @@ def serve(
         try:
             method, args, kwargs = req
         except (TypeError, ValueError):
-            logger.error("Malformed request frame: %r", req)
+            logger.error("Malformed request frame: %r", req, exc_info=True)
             continue
         try:
             if method == "info":
@@ -436,7 +436,7 @@ class _Connection(abc.ABC):
                 )
                 if diag:
                     msg = f"{msg}\n{diag}"
-                    logger.error("%s", msg)
+                    logger.error("%s", msg, exc_info=True)
                 raise RemoteConnectionError(msg) from e
         logger.debug("rpc ← %s %s", method, tag)
         if tag == "ok":

--- a/src/fleche/storage/bagofholding_file.py
+++ b/src/fleche/storage/bagofholding_file.py
@@ -49,7 +49,7 @@ class BagOfHoldingH5FileBackend(FileStorage):
         except FileNotFoundError:
             raise KeyError(path) from None
         except OSError as e:
-            logger.error(f"Corrupt file present in cache at path {path}: {e}")
+            logger.error("Corrupt file present in cache at path %s: %s", path, e, exc_info=True)
             raise KeyError(path) from e
 
     def rebag(self, version_validator: VersionValidator = "none") -> None:

--- a/src/fleche/storage/file.py
+++ b/src/fleche/storage/file.py
@@ -35,6 +35,7 @@ def _file_read_lock_with_fallback(
                 "Failed to read %s after timeout while lock was held: %s",
                 key,
                 e,
+                exc_info=True,
             )
             raise KeyError(key) from None
         raise

--- a/src/fleche/storage/pickle_file.py
+++ b/src/fleche/storage/pickle_file.py
@@ -1,5 +1,4 @@
 import pickle
-import logging
 import gzip
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,8 +13,6 @@ from .destructuring import DestructuringMixin
 from ..security import get_secret_key, normalize_secret_key, SignedBytes, SignatureError
 
 from pyiron_snippets.import_alarm import ImportAlarm
-
-logger = logging.getLogger("fleche.storage.pickle_file")
 
 with ImportAlarm(
     "PickleFile.with_cloudpickle requires 'cloudpickle' to be installed. "


### PR DESCRIPTION
## Summary

First round of the logging cleanup from the audit overview:

- `config.py` `_load_config`: kept the failure log at `error` (per review), but added `exc_info=True` so the traceback is preserved. Formatting already used lazy `%s` args.
- `config.py` `_default_memory_cache`: downgraded the "using default memory cache" fallback log from `warning` to `info` — it's an expected fallback, not a problem.
- `storage/pickle_file.py`: removed the unused `logger = logging.getLogger(...)` (never called anywhere in the file) and the now-unused `import logging`.
- Added `exc_info=True` to the other `error`-level logs that catch a live exception but were dropping the traceback: `digest.py`, `storage/file.py`, `storage/bagofholding_file.py`, `caches.py`, `remote.py` (two call sites). Also switched the two f-string-formatted calls (`bagofholding_file.py`, `caches.py`) to lazy `%s` args for consistency.
- Left `security.py`'s `error` logs untouched — those fire outside any `except` block (they're validation failures before raising), so there's no live exception for `exc_info` to attach.

## Test plan
- [x] `uv run pytest tests/unit -q` — 1458 passed
- [x] `uv run python -c "import fleche.storage.pickle_file"` — imports cleanly
