### PR TITLE
docs: document that CacheStack cannot be nested inside another CacheStack

### DIFF
--- a/docs/storage/cache_stack.rst
+++ b/docs/storage/cache_stack.rst
@@ -41,3 +41,16 @@ Example
     ...     my_function(10)
 
 Automatic hit transfer only applies to full function calls (``Call`` objects) and not to individual values loaded via ``load_value``.
+
+Restrictions
+------------
+
+``CacheStack`` **cannot be nested**: passing a ``CacheStack`` as a member of
+another ``CacheStack`` raises ``ValueError`` immediately::
+
+   inner = CacheStack((cache_a, cache_b))
+   outer = CacheStack((inner, cache_c))  # raises ValueError
+
+Flatten the layers directly instead::
+
+   flat = CacheStack((cache_a, cache_b, cache_c))

--- a/docs/storage/cache_stack.rst
+++ b/docs/storage/cache_stack.rst
@@ -42,6 +42,29 @@ Example
 
 Automatic hit transfer only applies to full function calls (``Call`` objects) and not to individual values loaded via ``load_value``.
 
+Layering Caches at Runtime
+---------------------------
+
+Rather than constructing a ``CacheStack`` by hand, you can push a new cache on top of
+whichever cache is currently active with :meth:`~fleche.caches.BaseCache.push`, or its
+context-manager shortcut ``cache(new_cache, stack=True)``:
+
+.. code-block:: pycon
+
+    >>> from fleche import cache
+
+    >>> cache(remote_cache)  # sticky: remote_cache becomes the active cache
+
+    >>> with cache(local_cache, stack=True):
+    ...     # local_cache is pushed on top: it is now stack[0] (checked and
+    ...     # saved to first), remote_cache is the fallback.
+    ...     ...
+    >>> # remote_cache is restored on exit
+
+``push`` always flattens rather than nests: pushing onto an existing ``CacheStack``
+prepends the new cache to that stack's members instead of wrapping the whole stack, so
+``stack=True`` never runs into the nesting restriction below.
+
 Restrictions
 ------------
 
@@ -54,3 +77,8 @@ another ``CacheStack`` raises ``ValueError`` immediately::
 Flatten the layers directly instead::
 
    flat = CacheStack((cache_a, cache_b, cache_c))
+
+Or build up the same flattened stack with chained ``push`` calls, which is handy when
+each cache becomes available one at a time::
+
+   flat = cache_c.push(cache_b).push(cache_a)  # CacheStack((cache_a, cache_b, cache_c))


### PR DESCRIPTION
## Summary

`CacheStack.__post_init__` raises `ValueError` when any member of the stack is itself a `CacheStack`. This constraint was not mentioned anywhere in the documentation, so users who tried to compose stacks by nesting them would hit an opaque runtime error with no guidance on the correct alternative.

### Changes in `docs/storage/cache_stack.rst`

- **New "Restrictions" section** — states the constraint, shows the failing pattern and the error it produces, and provides the correct fix (flatten all layers into a single `CacheStack`).

## Why this matters

From `src/fleche/caches.py`:

```python
def __post_init__(self):
    for c in self.stack:
        if isinstance(c, CacheStack):
            raise ValueError("CacheStack cannot be nested inside another CacheStack")
```

A user who reads that `CacheStack` composes multiple caches into a hierarchy would reasonably try:

```python
inner = CacheStack((fast_cache, medium_cache))
outer = CacheStack((inner, slow_cache))  # ValueError!
```

The fix is straightforward — flatten to `CacheStack((fast_cache, medium_cache, slow_cache))` — but nothing in the docs pointed this out.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BWYfzZA1BrqkYsHfbwzJr)_