### PR TITLE
docs: add TL;DR page as first entry of the Using Fleche section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Welcome to the **Fleche** library documentation.
    :maxdepth: 2
    :caption: Using Fleche
 
+   usage/tldr
    usage/helpers
    usage/lazy_call
    usage/query

--- a/docs/usage/tldr.rst
+++ b/docs/usage/tldr.rst
@@ -1,0 +1,55 @@
+TL;DR
+=====
+
+Decorate a function; calls with the same arguments are computed once and
+served from the cache afterwards:
+
+.. code-block:: python
+
+   from fleche import fleche
+
+   @fleche()
+   def expensive(x, y):
+       print(f"computing {x} + {y}")
+       return x + y
+
+   expensive(1, 2)   # computes, caches
+   expensive(1, 2)   # cache hit — nothing printed
+   expensive(2, 3)   # new arguments, computes again
+
+To persist results across runs, put a ``fleche.toml`` in your project
+directory (or anywhere up to ``$HOME``):
+
+.. code-block:: toml
+
+   [default]
+   cache = "persistent"
+
+   [persistent]
+   values.type = "pickle"
+   values.root = "~/.cache/fleche/values"
+   calls.type = "pickle"
+   calls.root = "~/.cache/fleche/calls"
+
+Without a config file, results are cached in memory for the current process
+only.
+
+The essentials beyond that:
+
+.. code-block:: python
+
+   from fleche import cache
+
+   cache("persistent")         # switch the active cache by config name
+   cache("void")               # turn caching off without touching code
+
+   expensive.contains(1, 2)    # is this call cached?
+   expensive.load(1, 2)        # fetch a result without executing (KeyError on miss)
+   expensive.rerun(1, 2)       # force re-execution and overwrite the entry
+   expensive.query().table()   # all stored calls as a pandas DataFrame
+
+That is all you need for everyday use.  The rest of this section covers the
+helper methods in depth (:doc:`helpers`), lazy loading of large cached
+objects (:doc:`lazy_call`), and querying stored calls (:doc:`query`);
+storage backends and configuration details live under
+:doc:`/storage/configuration`.


### PR DESCRIPTION
Adds a short, no-fuss TL;DR page (`docs/usage/tldr.rst`) as the first entry under the "Using Fleche" toctree caption in the Sphinx docs.

The page covers:
- the `@fleche()` decorator with a three-line hit/miss example
- a minimal `fleche.toml` for persistence across runs (and the in-memory fallback when no config exists)
- the everyday one-liners: `cache(...)`, `.contains`, `.load`, `.rerun`, `.query().table()`
- pointers to the detailed pages (helpers, lazy loading, query, storage configuration) for everything else

Verified with a full `sphinx-build -b html` run: build succeeds and the new page renders with no warnings (the remaining warnings are pre-existing, all in autoapi-generated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPwKdEV5VRRoKZUYoPtYfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPwKdEV5VRRoKZUYoPtYfR)_