### PR TITLE
refactor(caches): call inner _shrink directly, drop re-tuple boilerplate

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -320,9 +320,7 @@ class Cache(PerKeyLockMixin, BaseCache):
         for sub, ks in ((self.calls, call_keys), (self.values, value_keys)):
             if not ks:
                 continue
-            r = sub.shrink(*ks)
-            if len(ks) == 1:
-                r = (r,)
+            r = sub._shrink(*ks)
             for k, s in zip(ks, r):
                 results[k] = s
         return tuple(results[k] for k in keys)
@@ -474,9 +472,7 @@ class CacheWrapper(BaseCache):
         return self.cache.expand(key)
 
     def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
-        if len(keys) == 1:
-            return (self.cache.shrink(keys[0]),)
-        return self.cache.shrink(*keys)
+        return self.cache._shrink(*keys)
 
     def _query(self, call: call.QueryCall) -> Iterable[LazyCall]:
         return self.cache.query(call)
@@ -600,9 +596,7 @@ class _MultiCache(BaseCache):
             present = [k for k in keys if cache.contains(k)]
             if not present:
                 continue
-            r = cache.shrink(*present)
-            if len(present) == 1:
-                r = (r,)
+            r = cache._shrink(*present)
             for k, s in zip(present, r):
                 per_key[k].append(s)
         out_list = []

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -802,10 +802,11 @@ class SshCache(BaseCache):
         return self._rpc("expand", key)
 
     def _shrink(self, *keys: Digest | str) -> "tuple[Digest, ...]":
-        # Variadic single-vs-tuple unwrap stays here rather than in
-        # `_CLIENT_METHODS` — it's the same special case shared by
-        # `Cache`/`CacheStack`/`CacheWrapper` and has its own refactor
-        # proposal (#687), out of scope for the dispatcher collapse.
+        # Unlike `Cache`/`CacheStack`/`CacheWrapper` (#687), which now call
+        # the inner layer's tuple-returning `_shrink` directly, this class
+        # has no local inner layer to call `_shrink` on — the server-side
+        # dispatch calls the public `shrink()` (which unwraps for a single
+        # key), so the wrap has to happen here at the wire boundary.
         if len(keys) == 1:
             return (self._rpc("shrink", keys[0]),)
         return self._rpc("shrink", *keys)

--- a/tests/unit/caches/test_expand_shrink.py
+++ b/tests/unit/caches/test_expand_shrink.py
@@ -63,12 +63,12 @@ def test_cache_shrink_dispatches_to_call_storage_when_key_is_a_call():
     calls = Mock()
     values = Mock()
     calls.contains.return_value = True
-    calls.shrink.return_value = Digest("abcd")
+    calls._shrink.return_value = (Digest("abcd"),)
     cache = Cache(values, calls)
 
     assert cache.shrink("a" * 64) == "abcd"
     values.contains.assert_not_called()
-    values.shrink.assert_not_called()
+    values._shrink.assert_not_called()
 
 
 def test_cache_shrink_dispatches_to_value_storage_when_key_is_a_value():
@@ -77,11 +77,11 @@ def test_cache_shrink_dispatches_to_value_storage_when_key_is_a_value():
     values = Mock()
     calls.contains.return_value = False
     values.contains.return_value = True
-    values.shrink.return_value = Digest("beef")
+    values._shrink.return_value = (Digest("beef"),)
     cache = Cache(values, calls)
 
     assert cache.shrink("b" * 64) == "beef"
-    calls.shrink.assert_not_called()
+    calls._shrink.assert_not_called()
 
 
 def test_cache_shrink_missing_key_raises_keyerror():
@@ -94,8 +94,8 @@ def test_cache_shrink_missing_key_raises_keyerror():
 
     with pytest.raises(KeyError):
         cache.shrink("c" * 64)
-    calls.shrink.assert_not_called()
-    values.shrink.assert_not_called()
+    calls._shrink.assert_not_called()
+    values._shrink.assert_not_called()
 
 
 def test_cache_shrink_multiple_keys_returns_tuple_in_order():
@@ -127,13 +127,13 @@ def test_cache_shrink_batches_per_sub_storage():
     calls = Mock()
     values = Mock()
     calls.contains.return_value = True
-    calls.shrink.return_value = (Digest("aaaa"), Digest("bbbb"))
+    calls._shrink.return_value = (Digest("aaaa"), Digest("bbbb"))
     cache = Cache(values, calls)
 
     result = cache.shrink("a" * 64, "b" * 64)
     assert result == (Digest("aaaa"), Digest("bbbb"))
-    calls.shrink.assert_called_once_with("a" * 64, "b" * 64)
-    values.shrink.assert_not_called()
+    calls._shrink.assert_called_once_with("a" * 64, "b" * 64)
+    values._shrink.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -204,27 +204,27 @@ def test_cache_stack_shrink_returns_longest_across_layers():
     c2 = Mock()
     c1.contains.return_value = True
     c2.contains.return_value = True
-    c1.shrink.return_value = Digest("abcd")
-    c2.shrink.return_value = Digest("abcdef")
+    c1._shrink.return_value = (Digest("abcd"),)
+    c2._shrink.return_value = (Digest("abcdef"),)
     stack = CacheStack((c1, c2))
 
     assert stack.shrink("a" * 64) == "abcdef"
 
 
 def test_cache_stack_shrink_multiple_keys_batches_per_layer():
-    """``shrink(k1, k2)`` makes one batched ``shrink(*present)`` per layer."""
+    """``shrink(k1, k2)`` makes one batched ``_shrink(*present)`` per layer."""
     c1 = Mock()
     c2 = Mock()
     c1.contains.return_value = True
     c2.contains.return_value = True
-    c1.shrink.return_value = (Digest("aaaa"), Digest("bbbb"))
-    c2.shrink.return_value = (Digest("aaaaaa"), Digest("bbbbbb"))
+    c1._shrink.return_value = (Digest("aaaa"), Digest("bbbb"))
+    c2._shrink.return_value = (Digest("aaaaaa"), Digest("bbbbbb"))
     stack = CacheStack((c1, c2))
 
     out = stack.shrink("a" * 64, "b" * 64)
     assert out == (Digest("aaaaaa"), Digest("bbbbbb"))
-    c1.shrink.assert_called_once_with("a" * 64, "b" * 64)
-    c2.shrink.assert_called_once_with("a" * 64, "b" * 64)
+    c1._shrink.assert_called_once_with("a" * 64, "b" * 64)
+    c2._shrink.assert_called_once_with("a" * 64, "b" * 64)
 
 
 def test_cache_stack_shrink_multiple_keys_skips_layers_without_key():
@@ -234,14 +234,14 @@ def test_cache_stack_shrink_multiple_keys_skips_layers_without_key():
     # c1 has k1 only; c2 has k2 only.
     c1.contains.side_effect = lambda k: k == "a" * 64
     c2.contains.side_effect = lambda k: k == "b" * 64
-    c1.shrink.return_value = Digest("aaaa")
-    c2.shrink.return_value = Digest("bbbb")
+    c1._shrink.return_value = (Digest("aaaa"),)
+    c2._shrink.return_value = (Digest("bbbb"),)
     stack = CacheStack((c1, c2))
 
     out = stack.shrink("a" * 64, "b" * 64)
     assert out == (Digest("aaaa"), Digest("bbbb"))
-    c1.shrink.assert_called_once_with("a" * 64)
-    c2.shrink.assert_called_once_with("b" * 64)
+    c1._shrink.assert_called_once_with("a" * 64)
+    c2._shrink.assert_called_once_with("b" * 64)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #687.

## Problem

`Cache._shrink`, `CacheStack._shrink` (via `_MultiCache._shrink`), and `CacheWrapper._shrink` each recursively called the next layer's **public** `shrink(*keys)`, which unwraps its result to a bare `Digest` when called with exactly one key. Each caller then had to detect that case and re-wrap the result back into a tuple by hand:

```python
r = sub.shrink(*ks)
if len(ks) == 1:
    r = (r,)
```

This re-tuple was pure boilerplate repeated three times, and getting it wrong silently produces a `Digest` where a `tuple[Digest, ...]` is expected.

## Change

Each of the three implementations now calls the inner layer's **`_shrink`** directly instead of its public `shrink` — `_shrink` already returns a tuple unconditionally, so the re-tuple check disappears:

- `Cache._shrink` (`src/fleche/caches.py`): `sub._shrink(*ks)` instead of `sub.shrink(*ks)`.
- `_MultiCache._shrink` (shared by `CacheStack`/`CachePool`): `cache._shrink(*present)` instead of `cache.shrink(*present)`.
- `CacheWrapper._shrink`: `self.cache._shrink(*keys)` instead of the two-branch `shrink`/wrap.

`SshCache._shrink` is left as-is (updated only its explanatory comment): it dispatches over RPC to the remote's *public* `shrink()`, not to a local `_shrink`, so the wire boundary still needs its own wrap — this was the one exception the issue called out.

## Tests

Updated `tests/unit/caches/test_expand_shrink.py`'s mock-based tests to assert against `_shrink` instead of `shrink` (mocks previously asserted call args on the now-unused public method). No behavioral test changes — the round-trip (real-storage) tests are untouched and continue to cover both single-key and multi-key shrinks.

- `pytest tests/unit/caches/test_expand_shrink.py tests/unit/caches/test_cache_pool.py tests/unit/test_remote.py tests/unit/storage/test_mixins.py tests/unit/fleche/test_query_iterator.py tests/unit/digest/test_digest_methods.py -q` → 185 passed
- Full suite: `pytest tests/` → 1583 passed, 11 skipped
- `ty check src/` → all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WcgynDgQvkuQgLzHqmGnG

---
_Generated by [Claude Code](https://claude.ai/code/session_018WcgynDgQvkuQgLzHqmGnG)_