### PR TITLE
docs: add dedicated entry points page, call out fleche-ase

### DIFF
--- a/agents/USAGE.md
+++ b/agents/USAGE.md
@@ -150,6 +150,25 @@ Decorator kwargs on `@fleche(...)`:
 - Per-argument: `Ignored[T]` / `Required[T]` type annotations do the same
   thing as `ignore=`/`require=`, inline in the signature.
 
+## Digesting third-party / custom types
+
+Three mechanisms, in precedence order (highest first):
+
+1. `fleche.digest.add_hook((MyType, digest_fn))` — manual registration,
+   overrides everything else for that type.
+2. **Entry points** — installed packages register hooks in the `fleche`
+   entry-point group under the name `digest`; fleche loads them lazily the
+   first time `digest()` hits a value it can't handle. Notably,
+   [`fleche-ase`](https://pypi.org/project/fleche-ase/) ships hooks for
+   ASE's `Atoms`, `VibrationsData`, and `Calculator` types — `pip install
+   fleche-ase` and ASE objects digest correctly with no further setup, so
+   don't hand-roll digests for ASE types.
+3. A `__digest__` method on the class itself.
+
+Full details: `docs/digests/entry_points.rst` (the entry-point mechanism,
+fleche-ase, authoring your own plugin) and `docs/dev/custom_digests.rst`
+(writing good digest functions).
+
 Use `D(value)` (from `fleche`) to pass an existing digest/key as a lookup
 shortcut instead of the real value — the cache expands it back to the
 value before hashing. `D(value)` also accepts a stored value (returns its

--- a/docs/dev/custom_digests.rst
+++ b/docs/dev/custom_digests.rst
@@ -56,54 +56,6 @@ Hooks registered this way have the highest priority and will override any other 
 Registering Entry Points
 ------------------------
 
-For library authors who want to provide ``fleche`` support for their types without requiring users to manually call ``add_hook``, ``fleche`` supports Python entry points.
+Library authors who want to provide ``fleche`` support for their types without requiring users to manually call ``add_hook`` can register digest hooks through Python entry points, so that support loads automatically once their package is installed.
 
-You can register your digest hooks in the ``fleche`` entry point group with the name ``digest`` in your ``pyproject.toml`` (or equivalent).
-
-.. code-block:: toml
-
-   [project.entry-points."fleche"]
-   digest = "my_package.hooks:digest_hooks"
-
-The entry point must resolve to one of:
-
-* A single ``fleche.digest.Hook`` object.
-* A tuple of ``(Type, Callable)``.
-* A list containing any combination of the above.
-
-These must be **module-level objects**, not callables that return hooks.
-``fleche`` loads the entry point with ``importlib.metadata.EntryPoint.load()``,
-which returns the object at the given path directly — it does **not** call it.
-
-.. code-block:: pycon
-
-   >>> from fleche.digest import digest, Digest, Hook
-
-   >>> class TypeA:
-   ...     def __init__(self, field1, field2):
-   ...         self.field1 = field1
-   ...         self.field2 = field2
-
-   >>> class TypeB:
-   ...     def __init__(self, relevant_field):
-   ...         self.relevant_field = relevant_field
-
-   >>> def type_a_digest(obj: TypeA) -> Digest:
-   ...     return digest((type(obj).__name__, obj.field1, obj.field2))
-
-   >>> def type_b_digest(obj: TypeB) -> Digest:
-   ...     return digest((type(obj).__name__, obj.relevant_field))
-
-   >>> digest_hooks = [
-   ...     Hook(TypeA, type_a_digest),
-   ...     (TypeB, type_b_digest),
-   ... ]
-
-Lazy Loading and Retries
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-To avoid unnecessary overhead, ``fleche`` loads entry points lazily. If ``digest()`` encounters an object it doesn't know how to handle (an ``Indigestible`` error), it will:
-1. Load all registered entry points.
-2. Retry the digestion.
-
-If a manual hook (via ``add_hook``) exists for a type provided by an entry point, the manual hook takes precedence and an ``INFO`` message is logged. If multiple entry points provide hooks for the same type, the first one encountered is used.
+See :doc:`../digests/entry_points` for the full mechanism — the ``pyproject.toml`` declaration, lazy loading, precedence rules, and the ``fleche-ase`` plugin (digest hooks for ASE types) as a worked example.

--- a/docs/digests/entry_points.rst
+++ b/docs/digests/entry_points.rst
@@ -1,0 +1,127 @@
+.. _entry-points:
+
+Entry Points
+============
+
+``fleche`` is extensible through Python *entry points* (the standard
+:mod:`importlib.metadata` plugin mechanism): any installed package can
+register digest hooks for its types in the ``fleche`` entry point group under
+the name ``digest``.  Installing such a package is all it takes — no imports,
+no calls to :func:`~fleche.digest.add_hook`.  The first time
+:func:`~fleche.digest.digest` encounters a value it does not know how to
+handle, it loads all registered entry points and retries.
+
+Use entry points whenever digest support for a type should "just work" after
+a ``pip install``:
+
+* as a *plugin package* that adds ``fleche`` support for a third-party
+  library (see :ref:`fleche-ase` below), or
+* as a *library author* shipping ``fleche`` support for your own types
+  alongside your library.
+
+.. _fleche-ase:
+
+``fleche-ase``: ASE Support
+---------------------------
+
+`fleche-ase <https://pypi.org/project/fleche-ase/>`_ is the canonical entry
+point plugin.  It registers digest hooks for the core types of the `Atomic
+Simulation Environment (ASE) <https://wiki.fysik.dtu.dk/ase/>`_:
+
+* ``ase.Atoms`` — digested from the cell, the periodic boundary conditions
+  and all per-atom arrays (positions, atomic numbers, ...).
+* ``ase.vibrations.VibrationsData`` — digested from the underlying atoms,
+  the vibrational indices and the 2D Hessian.
+* ``ase.calculators.calculator.Calculator`` — digested from the calculator
+  class name and its ``todict()`` parameters; matches all calculator
+  subclasses.
+
+With it installed, ``@fleche()``-decorated functions can accept and return
+ASE objects with no further setup:
+
+.. code-block:: bash
+
+   pip install fleche-ase
+
+.. code-block:: python
+
+   from ase.build import bulk
+   from fleche import fleche
+
+   @fleche()
+   def relax(structure):  # an ase.Atoms — digested via fleche-ase
+       ...
+
+   relax(bulk("Al"))
+
+How Hooks Are Loaded
+--------------------
+
+Entry points are loaded *lazily*: to avoid import overhead, nothing happens
+until :func:`~fleche.digest.digest` raises
+:class:`~fleche.digest.Indigestible` for a value.  At that point ``fleche``:
+
+1. loads all entry points registered under the group ``fleche`` with the
+   name ``digest``, and
+2. retries the digestion.
+
+Hooks match with ``isinstance``, so a hook registered for a base class (like
+``fleche-ase``'s ``Calculator`` hook) also covers its subclasses.
+
+Precedence rules:
+
+* Hooks registered manually with :func:`~fleche.digest.add_hook` always take
+  priority over entry point hooks; an ``INFO`` message is logged when one
+  shadows the other.
+* If multiple entry points provide hooks for the same type, the first one
+  encountered wins.
+* An entry point that fails to load is logged as an ``ERROR`` (with
+  traceback) and skipped — it never breaks digestion of other values.
+
+Registering Your Own Entry Point
+--------------------------------
+
+Declare the entry point in the ``fleche`` group with the name ``digest`` in
+your ``pyproject.toml`` (or equivalent):
+
+.. code-block:: toml
+
+   [project.entry-points."fleche"]
+   digest = "my_package.hooks:digest_hooks"
+
+The entry point must resolve to one of:
+
+* a single :class:`~fleche.digest.Hook` object,
+* a tuple of ``(Type, Callable)``, or
+* a list containing any combination of the above.
+
+These must be **module-level objects**, not callables that return hooks.
+``fleche`` loads the entry point with ``importlib.metadata.EntryPoint.load()``,
+which returns the object at the given path directly — it does **not** call it.
+
+.. code-block:: pycon
+
+   >>> from fleche.digest import digest, Digest, Hook
+
+   >>> class TypeA:
+   ...     def __init__(self, field1, field2):
+   ...         self.field1 = field1
+   ...         self.field2 = field2
+
+   >>> class TypeB:
+   ...     def __init__(self, relevant_field):
+   ...         self.relevant_field = relevant_field
+
+   >>> def type_a_digest(obj: TypeA) -> Digest:
+   ...     return digest((type(obj).__name__, obj.field1, obj.field2))
+
+   >>> def type_b_digest(obj: TypeB) -> Digest:
+   ...     return digest((type(obj).__name__, obj.relevant_field))
+
+   >>> digest_hooks = [
+   ...     Hook(TypeA, type_a_digest),
+   ...     (TypeB, type_b_digest),
+   ... ]
+
+For guidance on writing the digest functions themselves (which fields to
+include, avoiding collisions), see :doc:`../dev/custom_digests`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Welcome to the **Fleche** library documentation.
 
    digests/digests_as_args
    digests/digest_equivalence
+   digests/entry_points
 
 .. toctree::
    :maxdepth: 2

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -81,6 +81,21 @@ brackets, e.g. ``pip install "fleche[sqlalchemy,ssh]"``.
    ``executorlib``, ``docs`` and ``tests`` extras are pip-only -- install
    ``executorlib`` from conda-forge separately if you need it.
 
+Companion packages
+------------------
+
+Digest support for third-party libraries ships as separate companion packages
+that register themselves via :doc:`entry points <digests/entry_points>` —
+installing them alongside ``fleche`` is all that is needed:
+
+* ``fleche-ase`` (`PyPI <https://pypi.org/project/fleche-ase/>`__) — digest
+  hooks for the Atomic Simulation Environment: ``ase.Atoms``,
+  ``VibrationsData`` and ``Calculator`` objects.
+
+.. code-block:: bash
+
+   pip install fleche-ase
+
 Installing documentation (optional)
 -----------------------------------
 


### PR DESCRIPTION
Entry point support was documented only at the bottom of `docs/dev/custom_digests.rst`, and the `fleche-ase` companion package wasn't mentioned anywhere in the repo — making the plugin mechanism easy to miss (for humans and agents alike).

## Changes

- **New `docs/digests/entry_points.rst`** — a dedicated page covering the plugin mechanism end to end: the `fleche`/`digest` entry point group, lazy loading on the first `Indigestible` value, `isinstance` matching, precedence rules (`add_hook` > entry points, first entry point wins per type, load failures are logged and skipped), and how to author your own entry point. Calls out [`fleche-ase`](https://pypi.org/project/fleche-ase/) explicitly as the canonical plugin, listing what it digests (`ase.Atoms` by cell/pbc/arrays, `VibrationsData`, `Calculator` incl. subclasses via `todict()`).
- **`docs/dev/custom_digests.rst`** — the "Registering Entry Points" section now points at the new page instead of duplicating the content.
- **`docs/index.rst`** — new page added to the *Digests* toctree.
- **`docs/installation.rst`** — new "Companion packages" section listing `fleche-ase`.
- **`agents/USAGE.md`** — new "Digesting third-party / custom types" section with the precedence order (`add_hook` > entry points > `__digest__`) and an explicit pointer to `fleche-ase`, so agents stop hand-rolling digests for ASE types.

## Verification

Built the docs locally with `sphinx-build -b html` (notebooks excluded — pandoc unavailable in this environment): build succeeds, the new page renders, all `:func:`/`:class:`/`:doc:` cross-references resolve to links, and no new warnings are introduced (the sole non-autoapi warning, in `usage/helpers.rst`, is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABYC12sWXrtNmhgJnzh7ki

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABYC12sWXrtNmhgJnzh7ki)_