### PR TITLE
test: pin metadata.keys schema; drop two redundant CacheStack tests

### DIFF
--- a/tests/unit/caches/test_cache_stack.py
+++ b/tests/unit/caches/test_cache_stack.py
@@ -31,14 +31,6 @@ def test_cache_stack_load_hit():
     assert result == call
 
 
-def test_cache_stack_load_miss():
-    c1 = Mock()
-    c1.load.side_effect = KeyError
-    c2 = Mock()
-    c2.load.side_effect = KeyError
-    CacheStack((c1, c2))
-
-
 def test_cachestack_query_bottom_to_top_and_dedupe():
     """CacheStack.query should query bottom-to-top and deduplicate results.
 
@@ -130,30 +122,6 @@ def test_cache_stack_load_transfers_call():
     assert res_call.result == "result"
 
     # Now c1 SHOULD have it due to automatic transfer
-    assert c1.contains(key)
-    assert c1.load(key).result == "result"
-
-
-def test_cache_stack_load_lazy_transfers_call():
-    """Verify that a load from a higher cache is transferred to the base cache."""
-    # Setup two caches
-    c1 = Cache(ValueMemory({}), CallMemory({}))
-    c2 = Cache(ValueMemory({}), CallMemory({}))
-
-    call = Call(name="test", arguments={"x": 1}, result="result")
-    key = call.to_lookup_key()
-
-    # Save call to c2 only
-    c2.save(call)
-
-    stack = CacheStack((c1, c2))
-
-    # Load from stack (always lazy now)
-    lazy_call = stack.load(key)
-
-    assert lazy_call.result == "result"
-
-    # Now c1 SHOULD have it
     assert c1.contains(key)
     assert c1.load(key).result == "result"
 

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -323,3 +323,51 @@ def test_configurable_decorator_registers_and_names():
 
 def test_tags_not_in_configurable():
     assert Tags not in CONFIGURABLE.values()
+
+
+@pytest.mark.parametrize(
+    "cls, expected_keys",
+    [
+        (Runtime, {"timestart": float, "timestop": float, "walltime": float}),
+        (
+            Environment,
+            {
+                "hostname": str,
+                "username": str,
+                "cwd": str,
+                "fleche_version": str,
+                "python_version": str,
+            },
+        ),
+        (Git, {"root": str, "commit": str, "branch": str, "dirty": bool}),
+    ],
+    ids=["runtime", "environment", "git"],
+)
+def test_builtin_metadata_keys_schema(cls, expected_keys):
+    """Zero-arg built-ins publish a fixed schema via the ``keys`` property.
+
+    Contract (``MetaData.keys`` docstring): "Defines the schema of the
+    metadata, mapping metadata keys to their expected types."  Downstream
+    consumers (e.g. Sql metadata pushdown, future column projection) rely on
+    this schema; PR #690 unified ``keys`` as a ``@property`` across every
+    built-in so subclass authors implement it exactly one way.  This pins
+    each built-in's published schema against its own docstring.
+    """
+    assert cls().keys == expected_keys
+
+
+def test_tags_keys_derives_from_tag_dict():
+    """``Tags.keys`` reflects the tag dict passed at construction time.
+
+    Unlike the ``@configurable`` built-ins (which return a fixed schema),
+    ``Tags`` takes a user-supplied ``tags`` dict and infers per-value types
+    via ``type(v)`` — an empty dict yields an empty schema, and mixed-type
+    values yield a mixed schema.  This is the only ``keys`` property in the
+    module that varies per instance rather than per class.
+    """
+    assert Tags(tags={}).keys == {}
+    assert Tags(tags={"user": "test", "n": 3, "on": True}).keys == {
+        "user": str,
+        "n": int,
+        "on": bool,
+    }


### PR DESCRIPTION
Coverage exercise on the test suite — one new contract test on the lowest-covered production module with real behaviour, then two knock-out-verified removals of redundant tests.

Branch has two commits, each independently landable.

---

## Commit 1 — `test(metadata): pin the .keys schema contract for each built-in`

`MetaData.keys` is the schema hook every built-in must publish (docstring: *"Defines the schema of the metadata, mapping metadata keys to their expected types"*), but the four concrete implementations — `Runtime.keys`, `Environment.keys`, `Git.keys`, `Tags.keys` — were the only lines in `metadata.py` never executed by the test suite. Every other metadata test exercises `pre()`/`post()` via the decorator round-trip and never touches `.keys`.

Added one parametrised test for the three zero-arg built-ins (`Runtime`/`Environment`/`Git`) plus one focused test for the dynamic `Tags.keys` derivation. PR #690 unified `keys` as a `@property` across every subclass; this pins the resulting schema so a silent shape change (renamed key, retyped column, missing entry) surfaces here instead of much later in downstream SQL metadata pushdown.

### Baseline coverage (before)

```
Name                                      Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%   5-6
src/fleche/__main__.py                       21      3      6      2    81%   52-53, 57
src/fleche/_attrs.py                         12      2      0      0    83%   14-15
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        356     20     92      6    94%   ...
src/fleche/call.py                          241      8     62      5    96%   ...
src/fleche/config.py                        205      6    100      4    97%   ...
src/fleche/digest.py                        176      7    100      8    95%   ...
src/fleche/executor.py                       38      2     12      0    96%   57-58
src/fleche/metadata.py                       74      6      4      0    92%   15-16, 117, 148, 201, 230
src/fleche/query.py                         127      0     50      1    99%   280->279
src/fleche/remote.py                        369     26     82     13    91%   ...
src/fleche/security.py                       57      3     26      2    94%   76, 145-146
src/fleche/state.py                          52      1     10      1    97%   75
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py     104      5     32      3    94%   ...
src/fleche/storage/base.py                  132      2     34      2    98%   166, 208
src/fleche/storage/destructuring.py         156      2     48      1    99%   99, 176, 341->340
src/fleche/storage/file.py                   54      0      4      0   100%
src/fleche/storage/memory.py                 32      0      2      0   100%
src/fleche/storage/pickle_file.py            74      2     12      0    98%   96-97
src/fleche/storage/sql.py                   246     10     88      6    95%   ...
src/fleche/storage/thread_safe.py            54      2      8      2    94%   90-91, 130->132
src/fleche/storage/void.py                   20      1      4      0    96%   27
src/fleche/wrapper.py                       199      3     50      1    98%   151, 246-247
-------------------------------------------------------------------------------------
TOTAL                                      2833    113    828     57    95%
1584 passed, 11 skipped in 413.12s
```

**How this module got picked** — sorted every module by coverage percentage. The three lowest-percentage modules are boilerplate: `__init__.py`'s `_version` `ImportError` fallback and `__main__.py`'s `__name__ == "__main__"` guard are unreachable from a normal install, and `_attrs.py`'s uncovered lines are the identical `ImportError` fallback for `attr`. That made `metadata.py` (92.3%) the first module with real behaviour on the uncovered lines — the four `keys` implementations, all documented, all part of the public contract.

### Coverage after commit 1

```
src/fleche/metadata.py                       74      2      4      0    97%   15-16
TOTAL                                      2833    111    828     57    95%
1588 passed, 11 skipped
```

- `metadata.py`: **92.3% → 97.4%** (6 missing lines → 2)
- The two remaining lines (15-16) are the `_version.py` `ImportError` fallback — only reachable outside an editable install.

---

## Commit 2 — `test(caches): drop two redundant CacheStack tests`

Ran knock-out experiments against `tests/unit/caches/test_cache.py`, `test_cache_stack.py`, and `test_expand_shrink.py` — deselected one test at a time and diffed the resulting JSON coverage report against baseline. Most zero-delta candidates turned out to be contract tests (shrink-returns-tuple-in-order, dispatch-per-substorage, `pop=True` behaviour on non-conflicting transfers, list-argument round-trip, ...) — kept per the task description.

Two survived as genuinely redundant:

**`test_cache_stack_load_miss`** — the body constructs `CacheStack((c1, c2))` and returns. It never calls `stack.load()` (or anything else on the stack), so the "load miss" contract implied by the name is not actually exercised. The "all layers miss → `KeyError`" invariant is still covered by `test_cache_stack_load_value_raises_keyerror_when_missing_everywhere` and `test_cache_stack_expand_unknown_raises_keyerror`.

**`test_cache_stack_load_lazy_transfers_call`** — near-duplicate of `test_cache_stack_load_transfers_call` in the same file: both build two empty `Cache`s, save a call to the upper layer only, wrap them in a stack, load through the stack, and assert the base back-filled. The only difference is a "always lazy now" comment and one missing `pytest.raises(KeyError)` sanity check the `_transfers_call` variant retains. The comment is a leftover from a lazy-vs-eager distinction that no longer exists.

### Knock-out verification

Full-suite coverage report shows `caches.py` **unchanged** at 94.20% (20 missing lines, 6 missing branches) between "after commit 1" and "after commit 2". Total lines went from 111 → 109 missing but that's noise on the hypothesis-driven `digest.py` NaN path, not related to the removals — verified in unit-only runs:

```
Baseline (tests/unit/, 1517 tests):        150 missing, 75 missing branches, 93.85%
Both tests deselected (tests/unit/, 1515): 150 missing, 75 missing branches, 93.85%
```

Byte-identical coverage before and after — every line and branch these tests nominally covered is covered by other tests in the same subset.

### Full-suite coverage after both commits

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        356     20     92      6    94%
src/fleche/call.py                          241      8     62      5    96%
src/fleche/config.py                        205      6    100      4    97%
src/fleche/digest.py                        176      7    100      8    95%
src/fleche/executor.py                       38      2     12      0    96%
src/fleche/metadata.py                       74      2      4      0    97%
src/fleche/query.py                         127      0     50      1    99%
src/fleche/remote.py                        369     26     82     13    91%
src/fleche/security.py                       57      3     26      2    94%
src/fleche/state.py                          52      1     10      1    97%
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py     104      5     32      3    94%
src/fleche/storage/base.py                  132      2     34      2    98%
src/fleche/storage/destructuring.py         156      2     48      1    99%
src/fleche/storage/file.py                   54      0      4      0   100%
src/fleche/storage/memory.py                 32      0      2      0   100%
src/fleche/storage/pickle_file.py            74      2     12      0    98%
src/fleche/storage/sql.py                   246     10     88      6    95%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/storage/void.py                   20      1      4      0    96%
src/fleche/wrapper.py                       199      3     50      1    98%
---------------------------------------------------------------------------
TOTAL                                      2833    109    828     57    95%
1586 passed, 11 skipped
```

## Test plan

- [x] `pytest tests/` — full suite green (1586 passed, 11 skipped) with `--cov-branch`
- [x] `pytest tests/unit/caches/test_cache_stack.py` — remaining 12 tests all pass
- [x] `pytest tests/unit/metadata/test_metadata.py` — 21 tests pass (17 pre-existing + 4 new)
- [x] Knock-out verification: `caches.py` coverage byte-identical before/after commit 2 (20 lines, 6 branches, 94.20%)
