### PR TITLE
test: consolidate TestLongestCommonPrefixLength to one test per branch

### DIFF
--- a/tests/unit/storage/test_short_digest.py
+++ b/tests/unit/storage/test_short_digest.py
@@ -61,20 +61,14 @@ def test_missing_digest():
 
 
 class TestLongestCommonPrefixLength:
-    def test_identical_strings(self):
+    # One test per branch of the helper: all-match, early-mismatch, empty zip.
+    # Other input variations collapse onto these same three arcs.
+
+    def test_full_match_falls_through(self):
         assert _longest_common_prefix_length("abcd", "abcd") == 4
 
-    def test_no_common_prefix(self):
-        assert _longest_common_prefix_length("abc", "xyz") == 0
-
-    def test_partial_common_prefix(self):
+    def test_mismatch_returns_early(self):
         assert _longest_common_prefix_length("abcX", "abcY") == 3
 
-    def test_one_is_prefix_of_other(self):
-        assert _longest_common_prefix_length("abc", "abcdef") == 3
-
-    def test_empty_strings(self):
-        assert _longest_common_prefix_length("", "") == 0
-
-    def test_one_empty(self):
+    def test_empty_input_skips_loop(self):
         assert _longest_common_prefix_length("", "abc") == 0


### PR DESCRIPTION
## Summary

Follow-up to #621. That PR added a new test for the lowest-covered module (`__main__.py`); this PR does the other half of the coverage audit — picking a small handful of random tests, checking whether removing them impacted total coverage, and consolidating the ones that were exact duplicates of caller-side coverage.

## Process

Ran the suite once with per-test coverage contexts (`coverage run --branch --dynamic-context=test_function`) so each test's exclusive line/branch contribution could be measured without re-running the suite per candidate. Picked ~20 random tests across three seeded shuffles and inspected each one's stats:

| Verdict | Count | Examples |
|---|---:|---|
| Contract / regression — keep | 15 | `test_ignored_hint_generic`, `test_sql_table_uniqueness`, `test_fleche_cache_stack`, `test_supported_values_digest_distinctly[…]`, `test_numpy_explicit_cases`, `test_cache_call_immediately_sets_cache` |
| Skipped by env | 1 | `test_executorlib_bound_wrapper` (optional dep) |
| Contract-ish but redundant with a sibling — leave alone | 3 | `test_{postgres,mysql}_url_passthrough{,_with_driver}` (three variants of one branch — a follow-up could parametrize, but each is arguably a distinct promise) |
| Non-contract redundant helper tests — **consolidate** | 3 | `TestLongestCommonPrefixLength.{test_partial_common_prefix, test_one_is_prefix_of_other, test_one_empty}` |

The random sweep confirms the suite is well-shaped: nearly every randomly-picked test was either a contract test worth keeping or a parametrization slice that shouldn't be dropped individually. The only clear-cut consolidation candidate came from `TestLongestCommonPrefixLength`.

## The change

`_longest_common_prefix_length` is a four-line, two-branch helper in `storage/base.py`. All six tests in `TestLongestCommonPrefixLength` had **zero** exclusive line/branch contribution — every arc of the helper was already covered by callers (`_apply_shrink`, `expand`, the sorted-arrangement code). The three distinct arcs are:

1. loop-enter + all matches → fall through to `return min(len)`
2. loop-enter + character mismatch → early `return i`
3. empty zip → loop body never entered → fall through

Reduced the class from six tests to one per arc, renamed after the branch each hits, and dropped a short comment explaining the shape. No coverage change — every arc of `_longest_common_prefix_length` is still recorded after the reduction.

## Coverage report

Before consolidation (`coverage run --branch -m pytest tests/`):
```
Name                         Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------
src/fleche/storage/base.py     132      2     34      2    98%
...
TOTAL                         2833    113    828     57    95%   (1584 tests)
```

After consolidation:
```
Name                         Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------
src/fleche/storage/base.py     132      2     34      2    98%
...
TOTAL                         2833    113    828     57    95%   (1581 tests)
```

Same 113 missed statements, same 57 partial branches, same 95% total. Three fewer tests.

## Test plan

- [x] `pytest tests/unit/storage/test_short_digest.py -v` — 7 passed (4 pre-existing outer tests + 3 new inner)
- [x] Full suite: 1581 passed, 11 skipped (was 1584 passed, 11 skipped)
- [x] Direct arc check on `_longest_common_prefix_length` via the coverage sqlite DB confirms all six arcs (loop-enter/skip, if-True/False, both returns) still hit


---
_Generated by [Claude Code](https://claude.ai/code/session_01HaB7qPdCF2HcNxLw6XtfVc)_