### PR TITLE
refactor(metadata): single-source built-in schema via _keys ClassVar

### DIFF
--- a/src/fleche/metadata.py
+++ b/src/fleche/metadata.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
 import getpass
 import os
@@ -6,7 +6,7 @@ import platform
 import socket
 import subprocess
 import time
-from typing import Any, TypeAlias
+from typing import Any, ClassVar, TypeAlias
 
 from .call import Call
 
@@ -54,8 +54,15 @@ class MetaData(ABC):
         """
         return {}
 
+    _keys: ClassVar[dict[str, type]] = {}
+    """Constant schema for subclasses whose keys don't depend on instance state.
+
+    Subclasses with a static schema declare this once instead of overriding
+    ``keys``; subclasses whose schema depends on instance state (e.g. ``Tags``)
+    override the ``keys`` property directly instead.
+    """
+
     @property
-    @abstractmethod
     def keys(self) -> dict[str, type]:
         """
         Defines the schema of the metadata, mapping metadata keys to their expected types.
@@ -63,7 +70,7 @@ class MetaData(ABC):
         Returns:
             dict[str, type]: A dictionary representing the metadata schema.
         """
-        ...
+        return self._keys
 
     name: str
     """The unique name of this metadata type."""
@@ -97,6 +104,12 @@ class Runtime(MetaData):
     Notes:
         Values are JSON-serializable.
     """
+    _keys: ClassVar[dict[str, type]] = {
+        'timestart': float,
+        'timestop': float,
+        'walltime': float,
+    }
+
     def pre(self, call: Call) -> dict[str, Any]:
         """
         Records the start time before function execution.
@@ -110,14 +123,6 @@ class Runtime(MetaData):
         return {
             'timestop': (t := time.time()),
             'walltime': t - pre['timestart'],
-        }
-
-    @property
-    def keys(self) -> dict[str, type]:
-        return {
-            'timestart': float,
-            'timestop': float,
-            'walltime': float,
         }
 
 
@@ -134,6 +139,14 @@ class Environment(MetaData):
             ``_version.py`` (e.g. an editable checkout without a build).
         python_version (str): The CPython runtime version (``platform.python_version()``).
     """
+    _keys: ClassVar[dict[str, type]] = {
+        'hostname': str,
+        'username': str,
+        'cwd': str,
+        'fleche_version': str,
+        'python_version': str,
+    }
+
     def pre(self, call: Call) -> dict[str, Any]:
         return {
             'hostname': socket.gethostname(),
@@ -141,16 +154,6 @@ class Environment(MetaData):
             'cwd': os.getcwd(),
             'fleche_version': _fleche_version,
             'python_version': platform.python_version(),
-        }
-
-    @property
-    def keys(self) -> dict[str, type]:
-        return {
-            'hostname': str,
-            'username': str,
-            'cwd': str,
-            'fleche_version': str,
-            'python_version': str,
         }
 
 
@@ -184,6 +187,13 @@ class Git(MetaData):
     All keys are ``None`` when not inside a git repository or when the ``git``
     executable is missing.
     """
+    _keys: ClassVar[dict[str, type]] = {
+        'root': str,
+        'commit': str,
+        'branch': str,
+        'dirty': bool,
+    }
+
     def pre(self, call: Call) -> dict[str, Any]:
         root = _git('rev-parse', '--show-toplevel')
         if root is None:
@@ -194,15 +204,6 @@ class Git(MetaData):
             'commit': _git('rev-parse', 'HEAD'),
             'branch': _git('rev-parse', '--abbrev-ref', 'HEAD'),
             'dirty': bool(status) if status is not None else None,
-        }
-
-    @property
-    def keys(self) -> dict[str, type]:
-        return {
-            'root': str,
-            'commit': str,
-            'branch': str,
-            'dirty': bool,
         }
 
 

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -356,6 +356,23 @@ def test_builtin_metadata_keys_schema(cls, expected_keys):
     assert cls().keys == expected_keys
 
 
+@pytest.mark.parametrize("cls", [Runtime, Environment, Git], ids=["runtime", "environment", "git"])
+def test_builtin_metadata_pre_post_keys_match_schema(cls):
+    """The keys ``pre``/``post`` actually emit must match the declared ``_keys`` schema.
+
+    Refs #738: before this, each built-in declared its schema twice — once as
+    the literal dict keys returned by ``pre``/``post``, once in the ``keys``
+    property — with nothing checking the two stayed in sync. Now ``keys``
+    reads the single ``_keys`` class attribute, but that only helps if a test
+    pins ``_keys`` against what ``pre``/``post`` emit at runtime.
+    """
+    instance = cls()
+    call = Call(name="test", arguments={})
+    pre = instance.pre(call)
+    post = instance.post(pre, call)
+    assert set(pre) | set(post) == set(cls._keys)
+
+
 def test_tags_keys_derives_from_tag_dict():
     """``Tags.keys`` reflects the tag dict passed at construction time.
 


### PR DESCRIPTION
Closes #738.

## Problem

`Runtime`, `Environment`, and `Git` each declared their metadata schema twice: once as the literal dict keys returned by `pre()`/`post()`, and again in the `keys` property. Nothing enforced the two stayed in sync — a future key added to `pre`/`post` without a matching edit to `keys` would silently break downstream schema consumers (e.g. Sql metadata pushdown) instead of failing at import time.

## Change

- `MetaData` (the ABC) gains a `_keys: ClassVar[dict[str, type]] = {}` class attribute and a concrete `keys` property that returns `self._keys`, replacing the abstract `keys` property.
- `Runtime`, `Environment`, `Git` each declare `_keys` once and drop their `keys` property override.
- `Tags` is unchanged — its schema is derived per-instance from the `tags` dict, so it keeps overriding `keys` directly, as called out in the issue.
- No behavior change: `keys` still returns the exact same dicts as before.

Per the issue, this takes the smaller/safer of the two suggested variants (class-attribute schema + a drift-guard test) rather than trying to infer `_keys` automatically from the `pre`/`post` literals, which the issue flags as fiddly around `Runtime`'s two-phase `pre`/`post` split and `Environment.pre`'s side effects.

## Tests

Added `test_builtin_metadata_pre_post_keys_match_schema`, parametrized over `Runtime`/`Environment`/`Git`, asserting `set(pre_output) | set(post_output) == set(cls._keys)` — the drift guard the prior duplication lacked.

- `uv run --extra tests pytest tests/unit/metadata/test_metadata.py -q` → 25 passed
- `uv run --extra tests pytest tests/ -q` → 1609 passed, 11 skipped (pre-existing skips, unrelated)
- `uv run ruff check src/fleche/metadata.py tests/unit/metadata/test_metadata.py` → clean
- `uv run --extra ty ty check src/fleche/metadata.py` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rzc8SMkoZyJpium8ZMGJ7m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzc8SMkoZyJpium8ZMGJ7m)_