### PR TITLE
docs(README): fix three factual errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A persistent caching solution for arbitrary Python functions - like `lru_cache` 
 - **Query Support**: Search and retrieve cached results with metadata filtering
 - **Configurable**: Control what gets hashed (version, module, code, arguments)
 - **Multiple Backends**: File (pickle, cloudpickle, dill), SQLAlchemy, Bagofholding, and more
-- **Thread-Safe**: Safe for concurrent use; see `isolate=True` caveat below
+- **Thread-Safe**: Safe for use in multi-threaded environments
 - **Type-Aware**: Works seamlessly with NumPy, Pandas, and custom types
 
 ## Installation
@@ -130,8 +130,6 @@ call = compute.call(5)
     hash_code=False,     # Include function code in cache key
     require=None,        # Required argument for caching
     ignore=None,         # Arguments to ignore in cache key
-    isolate=False,       # Run function in an isolated temporary working directory
-                         # (not thread-safe — uses os.chdir, a process-wide call)
 )
 def my_function(x):
     return x * 2

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A persistent caching solution for arbitrary Python functions - like `lru_cache` 
 - **Intelligent Hashing**: Automatically generates cache keys from function arguments
 - **Query Support**: Search and retrieve cached results with metadata filtering
 - **Configurable**: Control what gets hashed (version, module, code, arguments)
-- **Multiple Backends**: File (pickle, JSON), SQLAlchemy, Bagofholding, and more
-- **Thread-Safe**: Safe for use in multi-threaded environments
+- **Multiple Backends**: File (pickle, cloudpickle, dill), SQLAlchemy, Bagofholding, and more
+- **Thread-Safe**: Safe for concurrent use; see `isolate=True` caveat below
 - **Type-Aware**: Works seamlessly with NumPy, Pandas, and custom types
 
 ## Installation
@@ -130,7 +130,8 @@ call = compute.call(5)
     hash_code=False,     # Include function code in cache key
     require=None,        # Required argument for caching
     ignore=None,         # Arguments to ignore in cache key
-    isolate=False,       # Isolate cache by working directory
+    isolate=False,       # Run function in an isolated temporary working directory
+                         # (not thread-safe — uses os.chdir, a process-wide call)
 )
 def my_function(x):
     return x * 2
@@ -191,15 +192,15 @@ Find cached results matching specific criteria (only after issuing a correspondi
 ```python
 @fleche()
 def fetch_data(user_id, date):
-    return get_data(user_id, date)
+    return {"user": user_id, "date": date}
 
 # Issue a call to cache the result
 fetch_data(user_id=123, date='2024-01-01')
 
-# Get all cached results
+# Get all cached results for fetch_data
 all_results = list(fetch_data.query())
 
-# Get results matching specific arguments (None acts as wildcard)
+# Get results where user_id=123, any date (omitted arguments act as wildcards)
 results = list(fetch_data.query(user_id=123))
 
 # Inspect a result


### PR DESCRIPTION
## Summary

Three factual errors found by cross-referencing the README against source code:

1. **Non-existent JSON backend** — the features list claimed "File (pickle, JSON)" backends. No JSON storage backend exists; the file backends are `pickle`, `cloudpickle`, and `dill` only. Fixed to match what `config.py` actually maps.

2. **Wrong `isolate` description** — the decorator-options code block said `# Isolate cache by working directory`. `isolate=True` creates a temporary working directory for the *function call* via `os.chdir`; it does not affect the cache at all. Also added the thread-safety caveat (`os.chdir` is process-wide, so `isolate=True` is explicitly not safe with `ThreadPoolExecutor`).

3. **Unqualified "Thread-Safe" feature bullet** — the bullet said "Safe for use in multi-threaded environments" with no qualification, even though `isolate=True` is documented in `wrapper.py` as not thread-safe. Added pointer to the `isolate=True` caveat.

**Additional fixes:**
- Made the `fetch_data` query example self-contained (replaced undefined `get_data` call that would raise `NameError` if run literally)
- Fixed the inline comment on `fetch_data.query(user_id=123)` — omitted arguments act as wildcards, not arguments passed as `None`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_