### PR TITLE
docs(tldr): fix two wrong claims

### DIFF
--- a/docs/usage/tldr.rst
+++ b/docs/usage/tldr.rst
@@ -45,13 +45,15 @@ The essentials beyond that:
 
    from fleche import cache
 
-   cache("persistent")         # switch the active cache by config name
-   cache("void")               # turn caching off without touching code
+   # Cache switching — bare call is sticky (permanent); use as context manager for
+   # a temporary switch: `with cache("persistent"): ...`
+   cache("persistent")         # permanently switch the active cache by config name
+   cache("void")               # permanently turn caching off without touching code
 
    expensive.contains(1, 2)    # is this call cached?
    expensive.load(1, 2)        # fetch a result without executing (KeyError on miss)
    expensive.rerun(1, 2)       # force re-execution and overwrite the entry
-   expensive.query().table()   # all stored calls as a pandas DataFrame
+   expensive.query().table()   # stored calls for this function as a pandas DataFrame
 
 That is all you need for everyday use.  The rest of this section covers the
 helper methods in depth (:doc:`helpers`), lazy loading of large cached


### PR DESCRIPTION
## Summary

Two factual errors found by cross-referencing `docs/usage/tldr.rst` against `src/fleche/wrapper.py` and `src/fleche/state.py`:

1. **`expensive.query().table()` scope** — the comment said "all stored calls as a pandas DataFrame". `func.query()` with no arguments builds a `QueryCall` whose `name` and `module` fields are set to the function's qualified name and module (`QueryCall.from_call` in `call.py`). The query is scoped to that function — it returns only calls for `expensive`, not every call in the active cache. Fixed comment to say "stored calls for this function".

2. **`cache("persistent")` is sticky** — when the context manager returned by `cache(name)` is discarded (bare call, not used in a `with` block), the switch is permanent until changed again. The TL;DR showed only this form with a neutral comment "switch the active cache by config name", giving no indication that the switch is permanent or that `with cache("persistent"): ...` scopes it to a block. Added an inline comment and rewrote the comments to say "permanently".

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_