### PR TITLE
docs(helpers): fix two wrong claims in .call() and .bind()

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -11,7 +11,16 @@ The following methods are added to the decorated function:
 ``.call(*args, **kwargs)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Returns a ``Call`` object corresponding to the provided arguments. This object contains metadata about the call, such as the function name, arguments, and version, but does not execute the function.
+Returns a ``Call`` object representing the cache key for the given arguments.
+The object carries the function name, module, version, and the arguments that
+participate in the key — but it is **not** a complete record of the call:
+
+- Arguments annotated with :class:`~fleche.call.Ignored` are stripped from
+  ``call.arguments``.
+- ``version``, ``module``, and ``code_digest`` are set to ``None`` when the
+  corresponding ``hash_*`` flag is ``False``.
+
+The function is not executed.
 
 ``.digest(*args, **kwargs)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -75,11 +84,13 @@ Optionally pre-applies ``*args`` and ``**kwargs`` via :func:`functools.partial`.
    >>> result = bound(1, 2)
    >>> assert result == 3
 
-   >>> # Pre-apply arguments
+   >>> # Pre-apply arguments — bind inside the context, call outside it
    >>> with cache("memory"):
    ...     bound_partial = add.bind(1, 2)
-   ...     result = bound_partial()   # equivalent to add(1, 2) in the frozen context
-   ...     assert result == 3
+   ...
+   >>> # bound_partial carries the "memory" cache even though the context has exited
+   >>> result = bound_partial()   # equivalent to add(1, 2) in the frozen context
+   >>> assert result == 3
 
 See :class:`~fleche.state.BoundWrapper` for the full API, including pickling support.
 


### PR DESCRIPTION
## Summary

Two factual errors found by cross-referencing `docs/usage/helpers.rst` against `src/fleche/wrapper.py` and `src/fleche/state.py`:

1. **`.call()` implies completeness** — the doc said it "contains metadata about the call, such as the function name, arguments, and version." In reality, `make_get_call` (in `wrapper.py`) strips `Ignored`-annotated arguments from `call.arguments` and sets `version`, `module`, and `code_digest` to `None` when the corresponding `hash_*` flag is `False`. A user who calls `my_func.call(a, ignored_param)` expecting `ignored_param` in the result won't find it. Replaced with an accurate description of what the returned `Call` object holds and what may be absent.

2. **`.bind()` pre-applied example defeats its own purpose** — `bound_partial()` was called _inside_ the same `with cache("memory"):` block where it was created. The entire point of pre-applied `.bind()` is that the frozen callable can be called _outside_ the context (e.g. in a worker process). The example now calls `bound_partial()` after the `with` block exits, demonstrating that the frozen cache context travels with the callable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_