### PR TITLE
docs(digest_equivalence): fix wrong claim about Number type hashing

### DIFF
--- a/docs/digests/digest_equivalence.rst
+++ b/docs/digests/digest_equivalence.rst
@@ -9,12 +9,20 @@ hold the same numeric value, and ``digest((1, 2)) != digest([1, 2])`` because th
 container type matters.  This page documents the deliberate equivalences ``fleche``
 guarantees, and the boundaries you should keep in mind.
 
-The digest function is content-based: it walks each value, salts the running hash
-with ``type(value).__name__`` for type discrimination, and folds in a representation
-that is stable across processes and Python versions (where the underlying object's
-representation allows it).  When two values *of different concrete Python types* are
-considered equivalent at the value level (``1`` and ``1.0``, an ``int`` subclass with
-the same numeric value, ...), the digest reflects that.
+The digest function is content-based: it walks each value, typically salts the
+running hash with ``type(value).__name__`` for type discrimination, and folds in a
+representation that is stable across processes and Python versions (where the
+underlying object's representation allows it).
+
+Number types (``int``, ``float``, ``complex``, and subclasses) are an explicit
+exception: their digest is computed via Python's numeric hash protocol
+(``hash(value)``), which itself guarantees ``hash(1) == hash(1.0) == hash(1+0j)``.
+The type name is therefore **not** carried into the final digest for numbers, which is
+precisely why ``digest(1) == digest(1.0) == digest(1+0j)``.
+
+For all other types the type-name salt is applied normally, so
+``digest((1, 2)) != digest([1, 2])`` because "tuple" and "list" diverge before
+the elements are processed.
 
 Dataclasses and ``attrs`` classes
 ---------------------------------


### PR DESCRIPTION
## Summary

One factual error found by tracing `docs/digests/digest_equivalence.rst` through `src/fleche/digest.py`:

**Wrong universal claim about type-name salting** — the opening paragraph stated that the digest function "salts the running hash with `type(value).__name__` for type discrimination" as an invariant. This is wrong for `Number` types (`int`, `float`, `complex`, subclasses).

For a `float`, the code does:
```python
m = hashlib.sha256()
m.update(b"float")       # added to m …
match value:
    case Number():
        value = hash(value)     # hash(1.0) == 1
        return _digest_bytes(value)  # … but m is abandoned; new SHA256 from hash()
```

The `m` that received `b"float"` is silently discarded. The final bytes come from a fresh `_digest_bytes(hash(1.0))` which uses `"int"` as the type name (because `hash(1.0)` returns `1`, an `int`). The type name `"float"` never appears in the final digest.

This is exactly why `digest(1) == digest(1.0) == digest(1+0j)`: Python's numeric hash protocol guarantees `hash(1) == hash(1.0)`, and no type-name salt survives to distinguish them. The previous text implied the type name always ends up in the hash, which contradicted the numeric equivalences shown immediately after without explaining why.

The paragraph now:
- states the general rule (type-name salting)
- explicitly identifies Number types as the exception and explains the mechanism
- resolves the apparent contradiction between "type discrimination" and `digest(1) == digest(1.0)`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_