### PR TITLE
docs: fix func.digest() signature in digests_as_args

### DIFF
--- a/docs/digests/digests_as_args.rst
+++ b/docs/digests/digests_as_args.rst
@@ -32,7 +32,7 @@ You can use the convenience wrapper ``D`` to mark a string as a value digest:
     >>> result_b = func_b(D(value_digest))
     >>> assert result_b == 12
 
-Note the distinction between a **call lookup key** (returned by ``func.digest()``) and a **value digest** (the SHA256 of the Python object itself, obtained via ``fleche.digest.digest()``). ``D()`` works with value digests because it resolves arguments through the value storage.
+Note the distinction between a **call lookup key** (returned by ``func.digest(*args, **kwargs)``) and a **value digest** (the SHA256 of the Python object itself, obtained via ``fleche.digest.digest()``). ``D()`` works with value digests because it resolves arguments through the value storage.
 
 Behavior
 --------


### PR DESCRIPTION
## Summary

- `func.digest()` called with no arguments raises `TypeError` for any function with required parameters. The prose on line 35 used it as a no-arg example to illustrate "call lookup key". Changed to `func.digest(*args, **kwargs)` to make clear that the same arguments as the decorated function are required.

## Why this matters

A reader following the example and trying `func.digest()` on a function like `def func_b(y)` would immediately hit a `TypeError`. The corrected form mirrors what the surrounding code example already does correctly (`func_a(5)`, `func_b(D(value_digest))`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_