### PR TITLE
docs: clarify lock_timeout behavior for reads vs writes

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -218,8 +218,10 @@ Key descriptions
     (bool, default ``false``) — gzip-compress each stored file.
 
 ``lock_timeout``
-    (float, default ``1.0``) — maximum seconds to wait for a concurrent write lock
-    before attempting a read anyway.
+    (float, default ``1.0``) — maximum seconds to wait to acquire a file lock.
+    On reads, if the timeout expires the lock is skipped and the read proceeds
+    with a ``WARNING`` logged.  On writes, if the timeout expires
+    ``filelock.Timeout`` is raised.
 
 ``secret_key``
     (list of hex strings) — HMAC-SHA256 signing keys for tamper detection;


### PR DESCRIPTION
## Summary

- The `lock_timeout` key description in `docs/storage/configuration.rst` said "wait for a concurrent write lock before attempting a read anyway", which only described the read fallback path and omitted the write behavior entirely.

## What the code actually does

From `src/fleche/storage/file.py`:

- **Reads** (`get`): use `_file_read_lock_with_fallback` — on timeout, logs a `WARNING` and reads without the lock.
- **Writes** (`put`): use a plain `filelock.FileLock` — on timeout, `filelock.Timeout` is raised and propagated to the caller.

The new description covers both paths so users know what to expect when a write contends under load.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_