### PR TITLE
docs: fix hex key character class to include uppercase A-F

### DIFF
--- a/docs/storage/security.rst
+++ b/docs/storage/security.rst
@@ -16,7 +16,7 @@ Security can be enabled in two ways:
 
     export FLECHE_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_hex(32))')"
 
-The value must be a colon-separated list of hex-encoded byte strings (``[0-9a-f]+``).
+The value must be a colon-separated list of hex-encoded byte strings (``[0-9a-fA-F]+``).
 ``fleche`` decodes each segment to raw bytes before use.
 
 **Via config file** (``fleche.toml``):


### PR DESCRIPTION
## Summary

- `docs/storage/security.rst` documented the `FLECHE_SECRET_KEY` format as `[0-9a-f]+` (lowercase only).

## Why this is wrong

Python's `bytes.fromhex()` is case-insensitive and accepts both `a-f` and `A-F`. The lowercase-only pattern would mislead users into thinking `DEADBEEF` or `AABB1234` are invalid key strings when they are in fact accepted without error.

## Fix

Changed the character class to `[0-9a-fA-F]+` to accurately reflect what the runtime accepts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmvhzu4udySWtYVSoNuD2P)_