### PR TITLE
fix(wrapper): make the cached wrapper cloudpicklable by value (drop raw lock from closure)

### DIFF
--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -324,6 +324,19 @@ payload:
    not return a proxy.  The call is idempotent: wrapping an already-wrapped
    executor a second time is a no-op.
 
+.. tip::
+
+   For process-based and cluster backends, prefer decorating a **module-level**
+   function with ``@fleche.fleche`` and submitting *that*.  Its wrapper is then
+   importable by reference, so the serialiser ships a tiny name reference
+   instead of the whole wrapper closure.  Rebinding to a different name
+   (``compute = fleche.fleche(some_other)``) or decorating a function defined
+   in ``__main__`` / a notebook forces cloudpickle to serialise the wrapper
+   *by value* — heavier, and only possible with a cloudpickling backend
+   (executorlib, dask; not a stdlib :class:`~concurrent.futures.ProcessPoolExecutor`,
+   which uses plain :mod:`pickle` and cannot serialise a function by value at
+   all).
+
 When to prefer each pattern
 ---------------------------
 

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -168,14 +168,41 @@ def make_rerun(func, wrapper):
     return _rerun_func
 
 
+class _InFlight:
+    """Futures whose done-callback is currently executing the cache write.
+
+    ``map`` is populated at the start of ``_cache()`` and removed in its
+    finally clause, so an entry exists only during the narrow window between
+    ``Future.set_result()`` releasing the condition lock and ``cache.save()``
+    completing; ``lock`` guards mutations of ``map``.
+
+    A raw :class:`threading.Lock` is unpicklable, and it lives in the
+    ``make_wrapper`` closure that fleche's wrapper carries.  When that wrapper
+    is cloudpickled **by value** — the shape a cross-process / cluster backend
+    needs whenever the decorated function is not importable by reference (bound
+    to a name other than its ``__qualname__``, or defined in ``__main__`` / a
+    notebook) — the lock would abort serialisation with
+    ``cannot pickle '_thread.lock' object``.  Bundling map and lock here lets
+    the object pickle as a fresh, empty instance: in-flight state and the lock
+    are process-local, so a worker that receives the wrapper by value correctly
+    starts with an empty map and its own lock.
+    """
+
+    __slots__ = ("map", "lock")
+
+    def __init__(self):
+        self.map: dict[str, Future] = {}
+        self.lock = threading.Lock()
+
+    def __reduce__(self):
+        # Reconstruct fresh on unpickle; never ship the (unpicklable) lock or
+        # the process-local in-flight map.
+        return (_InFlight, ())
+
+
 def make_wrapper(func, policy, meta, isolate, get_call):
     """Build the cached wrapper returned by :func:`fleche`."""
-    # Tracks futures whose done-callback is currently executing the cache write.
-    # Populated at the start of _cache() and removed in its finally clause, so
-    # the entry only exists during the narrow window between Future.set_result()
-    # releasing the condition lock and cache.save() completing.
-    _in_flight: dict[str, Future] = {}
-    _in_flight_lock = threading.Lock()
+    _in_flight = _InFlight()
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> _T:
@@ -216,7 +243,7 @@ def make_wrapper(func, policy, meta, isolate, get_call):
         # CPython gap between condition.notify_all() and _invoke_callbacks()).
         # If so, the future is already resolved — .result() returns immediately
         # and the future's result is exactly the function result.
-        if (f := _in_flight.get(key)) is not None:
+        if (f := _in_flight.map.get(key)) is not None:
             return f.result()
 
         def _run_and_cache():
@@ -229,8 +256,8 @@ def make_wrapper(func, policy, meta, isolate, get_call):
 
             def _cache(future=None):
                 if future is not None:
-                    with _in_flight_lock:
-                        _in_flight[key] = future
+                    with _in_flight.lock:
+                        _in_flight.map[key] = future
                 try:
                     if future is None:
                         call.result = result
@@ -261,8 +288,8 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                     return call.result
                 finally:
                     if future is not None:
-                        with _in_flight_lock:
-                            _in_flight.pop(key, None)
+                        with _in_flight.lock:
+                            _in_flight.map.pop(key, None)
 
             if not isinstance(result, Future):
                 return _cache()

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -15,6 +15,7 @@ from . import state
 from . import metadata
 from .call import Call, AnyCall, FunctionProfile, Ignored, QueryCall, Required, bind, _get_profile
 from .caches import Rejected, BaseCache, RefreshingCache
+from .storage.thread_safe import _PicklableLock
 
 
 import logging
@@ -168,41 +169,23 @@ def make_rerun(func, wrapper):
     return _rerun_func
 
 
-class _InFlight:
-    """Futures whose done-callback is currently executing the cache write.
-
-    ``map`` is populated at the start of ``_cache()`` and removed in its
-    finally clause, so an entry exists only during the narrow window between
-    ``Future.set_result()`` releasing the condition lock and ``cache.save()``
-    completing; ``lock`` guards mutations of ``map``.
-
-    A raw :class:`threading.Lock` is unpicklable, and it lives in the
-    ``make_wrapper`` closure that fleche's wrapper carries.  When that wrapper
-    is cloudpickled **by value** — the shape a cross-process / cluster backend
-    needs whenever the decorated function is not importable by reference (bound
-    to a name other than its ``__qualname__``, or defined in ``__main__`` / a
-    notebook) — the lock would abort serialisation with
-    ``cannot pickle '_thread.lock' object``.  Bundling map and lock here lets
-    the object pickle as a fresh, empty instance: in-flight state and the lock
-    are process-local, so a worker that receives the wrapper by value correctly
-    starts with an empty map and its own lock.
-    """
-
-    __slots__ = ("map", "lock")
-
-    def __init__(self):
-        self.map: dict[str, Future] = {}
-        self.lock = threading.Lock()
-
-    def __reduce__(self):
-        # Reconstruct fresh on unpickle; never ship the (unpicklable) lock or
-        # the process-local in-flight map.
-        return (_InFlight, ())
-
-
 def make_wrapper(func, policy, meta, isolate, get_call):
     """Build the cached wrapper returned by :func:`fleche`."""
-    _in_flight = _InFlight()
+    # Tracks futures whose done-callback is currently executing the cache write.
+    # Populated at the start of _cache() and removed in its finally clause, so
+    # the entry only exists during the narrow window between Future.set_result()
+    # releasing the condition lock and cache.save() completing.
+    #
+    # A raw threading.Lock is unpicklable, and this lives in the wrapper's
+    # closure.  When the wrapper is cloudpickled *by value* — the shape a
+    # cross-process / cluster backend needs whenever the decorated function is
+    # not importable by reference (bound to a name other than its __qualname__,
+    # or defined in __main__ / a notebook) — a raw lock would abort
+    # serialisation with "cannot pickle '_thread.lock' object".  _PicklableLock
+    # reconstructs a fresh lock on unpickle, which is correct here: in-flight
+    # state is process-local, so a worker starts with its own lock.
+    _in_flight: dict[str, Future] = {}
+    _in_flight_lock = _PicklableLock()
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> _T:
@@ -243,7 +226,7 @@ def make_wrapper(func, policy, meta, isolate, get_call):
         # CPython gap between condition.notify_all() and _invoke_callbacks()).
         # If so, the future is already resolved — .result() returns immediately
         # and the future's result is exactly the function result.
-        if (f := _in_flight.map.get(key)) is not None:
+        if (f := _in_flight.get(key)) is not None:
             return f.result()
 
         def _run_and_cache():
@@ -256,8 +239,8 @@ def make_wrapper(func, policy, meta, isolate, get_call):
 
             def _cache(future=None):
                 if future is not None:
-                    with _in_flight.lock:
-                        _in_flight.map[key] = future
+                    with _in_flight_lock:
+                        _in_flight[key] = future
                 try:
                     if future is None:
                         call.result = result
@@ -288,8 +271,8 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                     return call.result
                 finally:
                     if future is not None:
-                        with _in_flight.lock:
-                            _in_flight.map.pop(key, None)
+                        with _in_flight_lock:
+                            _in_flight.pop(key, None)
 
             if not isinstance(result, Future):
                 return _cache()

--- a/tests/regression/test_wrap_executor_cloudpickle_lock.py
+++ b/tests/regression/test_wrap_executor_cloudpickle_lock.py
@@ -1,101 +1,105 @@
-"""Regression reproducer: wrap_executor payload carries an unpicklable lock.
+"""Regression: the wrap_executor payload is cloudpicklable by value.
 
 ``wrap_executor``'s patched ``submit`` hands the underlying executor
 ``func.fleche.bind(*args)`` — a :class:`~fleche.BoundWrapper` wrapping
 ``functools.partial(wrapper, *args)``, where ``wrapper`` is the closure built
-by :func:`fleche.wrapper.make_wrapper`.  That closure closes over
+by :func:`fleche.wrapper.make_wrapper`.  That closure used to close over a raw
+``threading.Lock`` (``_in_flight_lock``), which is unpicklable.
 
-    _in_flight_lock = threading.Lock()   # a raw _thread.lock
-
-(see ``src/fleche/wrapper.py``).  A raw lock is unpicklable.
-
-Why this matters: a cloudpickling **cluster backend** (executorlib, dask, ...)
-ships user code *by value* so worker nodes need not import it — commonly via
-``cloudpickle.register_pickle_by_value(module)``, and always for functions
-defined in ``__main__`` or a notebook.  Serialising ``wrapper`` by value walks
-its closure cells and hits the lock:
+A cloudpickling cluster backend (executorlib, dask, ...) ships user code *by
+value* whenever it cannot assume the worker can import it.  That happens far
+more easily than by ``__main__`` / notebooks or an explicit
+``register_pickle_by_value``: simply **rebinding** a decorated function to a
+name other than its own — ``func = fleche.fleche(some_other)`` — is enough.
+The wrapper carries ``@wraps(some_other)``, so its ``__qualname__`` is
+``some_other``; cloudpickle's by-reference lookup finds the *plain* function
+(or nothing) under that name, not the wrapper, and falls back to by value —
+walking the closure cells and, formerly, hitting the lock:
 
     TypeError: cannot pickle '_thread.lock' object
 
-So ``wrap_executor`` + a cloudpickling cluster backend fundamentally cannot
-ship the wrapper.  The "just drop it into ``wrap_executor``" prose in
-``docs/parallel_execution.rst`` (the ``ProcessPoolExecutor`` / executorlib
-examples) was never actually exercised on this path — in an ordinary
-importable module cloudpickle serialises ``wrapper`` *by reference*, so the
-closure cells (and the lock) are never touched.
+(The ordinary ``@fleche.fleche`` decorator form dodges this, because the
+decorated name shadows the original and by-reference lookup resolves back to
+the wrapper — which is why the happy-path docs examples never exercised it.)
 
-This test pins the *root cause* directly and deterministically: the wrapper
-closure that ends up inside the ``wrap_executor`` payload must not carry a
-raw, unpicklable lock.  It deliberately does **not** call ``cloudpickle`` —
-the exact by-value failure varies by cloudpickle/Python version (older
-cloudpickle raises ``IndexError`` from its bytecode walk before it ever
-reaches the lock), which would make an end-to-end pickle assertion a flaky,
-version-dependent sentinel.  Inspecting the closure is exact and stable.
-
-Marked ``xfail(strict=True)`` so it flips to a hard failure the moment the
-wrapper stops closing over an unpicklable lock (e.g. the lock is
-reconstructed lazily, or given ``__reduce__`` support) — i.e. when the payload
-becomes shippable to a cloudpickling backend.
+The fix bundles the in-flight map and its lock into a small picklable helper
+(:class:`fleche.wrapper._InFlight`) that reconstructs fresh on unpickle, so the
+wrapper serialises by value.  These tests guard that.
 """
 
 import functools
-import pickle
 import threading
 
 import pytest
 
 import fleche
+from fleche.caches import Cache
+from fleche.storage.memory import ValueMemory, CallMemory
 
 _LOCK_TYPE = type(threading.Lock())
 
 
-@fleche.fleche
-def _sample_iso(i):
+def _plain_iso(i):
     return i * i
 
 
-def _unwrap_payload_callable(bound):
-    """Return the ``make_wrapper`` closure buried inside a bind() payload.
+# Rebind the decorated wrapper to a name other than its __qualname__
+# ('_plain_iso').  In an ordinary importable module this alone forces
+# cloudpickle onto its by-value path — exactly where the wrapper closure (and
+# formerly its lock) must be serialised.
+_rebound_iso = fleche.fleche(_plain_iso)
 
-    ``func.fleche.bind(*args)`` yields a ``BoundWrapper`` whose ``func`` is
-    ``functools.partial(wrapper, *args)`` (or ``wrapper`` itself when no args
-    are bound).  A cluster backend must serialise exactly this object.
-    """
+
+def _wrapper_closure(bound):
+    """Return the make_wrapper closure buried in a ``bind()`` payload."""
     func = bound.func
     if isinstance(func, functools.partial):
         func = func.func
     return func
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="make_wrapper's closure closes over a raw threading.Lock, so the "
-    "wrap_executor payload cannot be cloudpickled by value (cluster backends)",
-    raises=AssertionError,
-)
-def test_wrap_executor_payload_has_no_unpicklable_lock():
-    """The wrap_executor payload must not carry an unpicklable object by value.
+def test_wrap_executor_payload_has_no_raw_lock_in_closure():
+    """The wrapper closure must not carry a raw, unpicklable lock.
 
-    This is exactly what a cloudpickling cluster backend has to ship, and the
-    raw ``threading.Lock`` in the wrapper closure is what makes it fail.
+    Deterministic and version-independent — it never invokes cloudpickle, so
+    it holds even on environments whose cloudpickle cannot serialise the
+    wrapper's bytecode by value for unrelated reasons.
     """
-    wrapper = _unwrap_payload_callable(_sample_iso.fleche.bind(3))
+    wrapper = _wrapper_closure(_rebound_iso.fleche.bind(3))
 
-    lock_cells = [
+    raw_locks = [
         cell.cell_contents
         for cell in (wrapper.__closure__ or ())
         if isinstance(cell.cell_contents, _LOCK_TYPE)
     ]
 
-    # Sanity: if the wrapper ever stops carrying a lock at all, this test has
-    # become stale rather than passing for the right reason — surface that.
-    if lock_cells:
-        with pytest.raises(TypeError, match="cannot pickle"):
-            pickle.dumps(lock_cells[0])
-
-    assert not lock_cells, (
-        "make_wrapper's wrapper closure carries a raw, unpicklable lock "
-        f"({lock_cells!r}); a cloudpickling cluster backend that ships the "
-        "wrap_executor payload by value fails with "
-        "\"cannot pickle '_thread.lock' object\"."
+    assert not raw_locks, (
+        "make_wrapper's wrapper closure carries a raw threading.Lock "
+        f"({raw_locks!r}); this makes the wrap_executor payload unpicklable by "
+        "value, so a cloudpickling cluster backend cannot ship it."
     )
+
+
+def test_wrap_executor_payload_cloudpickles_by_value():
+    """End-to-end: the by-value payload survives a cloudpickle round-trip.
+
+    Skipped only when the environment's cloudpickle cannot serialise the
+    wrapper by value for a reason unrelated to the lock (older cloudpickle
+    releases raise ``IndexError`` from their bytecode walk on newer Python);
+    a re-emergence of the lock ``TypeError`` still fails loudly.
+    """
+    cloudpickle = pytest.importorskip("cloudpickle")
+
+    with fleche.cache(Cache(ValueMemory({}), CallMemory({}))):
+        payload = _rebound_iso.fleche.bind(3)
+
+    try:
+        data = cloudpickle.dumps(payload)
+    except TypeError as exc:
+        if "_thread.lock" in str(exc):
+            raise  # the regression these tests guard against
+        pytest.skip(f"cloudpickle cannot serialise the wrapper here: {exc}")
+    except Exception as exc:  # e.g. old cloudpickle's bytecode-walk IndexError
+        pytest.skip(f"cloudpickle by-value unsupported in this env: {exc!r}")
+
+    assert cloudpickle.loads(data)() == 9

--- a/tests/regression/test_wrap_executor_cloudpickle_lock.py
+++ b/tests/regression/test_wrap_executor_cloudpickle_lock.py
@@ -1,0 +1,79 @@
+"""Regression reproducer: wrap_executor payload can't be cloudpickled by value.
+
+``wrap_executor``'s patched ``submit`` hands the underlying executor
+``func.fleche.bind(*args)`` — a :class:`~fleche.BoundWrapper` wrapping
+``functools.partial(wrapper, *args)``, where ``wrapper`` is the closure built
+by :func:`fleche.wrapper.make_wrapper`.  That closure closes over
+
+    _in_flight_lock = threading.Lock()   # a raw _thread.lock
+
+(see ``src/fleche/wrapper.py``).  A raw lock is unpicklable.
+
+Why the happy-path docs never caught this: when the decorated function lives
+in an ordinary importable module, cloudpickle serialises ``wrapper`` *by
+reference* — its ``@wraps``-copied ``__qualname__`` resolves back to the
+decorated name — so the closure cells (and the lock) are never touched.
+
+But a cloudpickling **cluster backend** (executorlib, dask, ...) ships user
+code *by value* so worker nodes need not import it — commonly via
+``cloudpickle.register_pickle_by_value(module)``, and always for functions
+defined in ``__main__`` or a notebook.  By value, cloudpickle walks the
+closure cells and hits the lock:
+
+    TypeError: cannot pickle '_thread.lock' object
+
+So ``wrap_executor`` + a cloudpickling cluster backend fundamentally cannot
+ship the wrapper.  The "just drop it into ``wrap_executor``" prose in
+``docs/parallel_execution.rst`` (the ``ProcessPoolExecutor`` / executorlib
+examples) was never actually exercised on this path.
+
+This test reproduces the failure without a real cluster by asking cloudpickle
+to pickle the exact payload ``wrap_executor`` builds, under the by-value
+regime a cluster backend imposes.  It is marked ``xfail(strict=True)`` so it
+flips to a failure the moment the wrapper is made picklable (e.g. by giving
+the lock ``__reduce__`` support, or reconstructing it lazily).
+"""
+
+import concurrent.futures
+import sys
+
+import pytest
+
+import fleche
+from fleche.caches import Cache
+from fleche.storage.memory import ValueMemory, CallMemory
+
+cloudpickle = pytest.importorskip("cloudpickle")
+
+
+@fleche.fleche
+def _sample_iso(i):
+    return i * i
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="wrapper closes over a threading.Lock; cloudpickle-by-value "
+    "(cluster backends) cannot serialise the wrap_executor payload",
+    raises=TypeError,
+)
+def test_wrap_executor_payload_cloudpickles_by_value():
+    """The payload wrap_executor submits must survive by-value cloudpickling.
+
+    Registering this test's module for by-value pickling reproduces exactly
+    what a cloudpickling cluster backend does when it can't assume the worker
+    can import the user's code.
+    """
+    this_module = sys.modules[__name__]
+    cloudpickle.register_pickle_by_value(this_module)
+    try:
+        cache = Cache(ValueMemory({}), CallMemory({}))
+        with fleche.cache(cache):
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                fleche.wrap_executor(executor)
+                # Exactly the payload wrap_executor.submit() builds before it
+                # calls the underlying (cluster) submit, which cloudpickles it.
+                payload = _sample_iso.fleche.bind(3)
+                cloudpickle.dumps(payload)  # -> TypeError: cannot pickle '_thread.lock'
+    finally:
+        cloudpickle.unregister_pickle_by_value(this_module)

--- a/tests/regression/test_wrap_executor_cloudpickle_lock.py
+++ b/tests/regression/test_wrap_executor_cloudpickle_lock.py
@@ -1,4 +1,4 @@
-"""Regression reproducer: wrap_executor payload can't be cloudpickled by value.
+"""Regression reproducer: wrap_executor payload carries an unpicklable lock.
 
 ``wrap_executor``'s patched ``submit`` hands the underlying executor
 ``func.fleche.bind(*args)`` — a :class:`~fleche.BoundWrapper` wrapping
@@ -9,41 +9,44 @@ by :func:`fleche.wrapper.make_wrapper`.  That closure closes over
 
 (see ``src/fleche/wrapper.py``).  A raw lock is unpicklable.
 
-Why the happy-path docs never caught this: when the decorated function lives
-in an ordinary importable module, cloudpickle serialises ``wrapper`` *by
-reference* — its ``@wraps``-copied ``__qualname__`` resolves back to the
-decorated name — so the closure cells (and the lock) are never touched.
-
-But a cloudpickling **cluster backend** (executorlib, dask, ...) ships user
-code *by value* so worker nodes need not import it — commonly via
+Why this matters: a cloudpickling **cluster backend** (executorlib, dask, ...)
+ships user code *by value* so worker nodes need not import it — commonly via
 ``cloudpickle.register_pickle_by_value(module)``, and always for functions
-defined in ``__main__`` or a notebook.  By value, cloudpickle walks the
-closure cells and hits the lock:
+defined in ``__main__`` or a notebook.  Serialising ``wrapper`` by value walks
+its closure cells and hits the lock:
 
     TypeError: cannot pickle '_thread.lock' object
 
 So ``wrap_executor`` + a cloudpickling cluster backend fundamentally cannot
 ship the wrapper.  The "just drop it into ``wrap_executor``" prose in
 ``docs/parallel_execution.rst`` (the ``ProcessPoolExecutor`` / executorlib
-examples) was never actually exercised on this path.
+examples) was never actually exercised on this path — in an ordinary
+importable module cloudpickle serialises ``wrapper`` *by reference*, so the
+closure cells (and the lock) are never touched.
 
-This test reproduces the failure without a real cluster by asking cloudpickle
-to pickle the exact payload ``wrap_executor`` builds, under the by-value
-regime a cluster backend imposes.  It is marked ``xfail(strict=True)`` so it
-flips to a failure the moment the wrapper is made picklable (e.g. by giving
-the lock ``__reduce__`` support, or reconstructing it lazily).
+This test pins the *root cause* directly and deterministically: the wrapper
+closure that ends up inside the ``wrap_executor`` payload must not carry a
+raw, unpicklable lock.  It deliberately does **not** call ``cloudpickle`` —
+the exact by-value failure varies by cloudpickle/Python version (older
+cloudpickle raises ``IndexError`` from its bytecode walk before it ever
+reaches the lock), which would make an end-to-end pickle assertion a flaky,
+version-dependent sentinel.  Inspecting the closure is exact and stable.
+
+Marked ``xfail(strict=True)`` so it flips to a hard failure the moment the
+wrapper stops closing over an unpicklable lock (e.g. the lock is
+reconstructed lazily, or given ``__reduce__`` support) — i.e. when the payload
+becomes shippable to a cloudpickling backend.
 """
 
-import concurrent.futures
-import sys
+import functools
+import pickle
+import threading
 
 import pytest
 
 import fleche
-from fleche.caches import Cache
-from fleche.storage.memory import ValueMemory, CallMemory
 
-cloudpickle = pytest.importorskip("cloudpickle")
+_LOCK_TYPE = type(threading.Lock())
 
 
 @fleche.fleche
@@ -51,29 +54,48 @@ def _sample_iso(i):
     return i * i
 
 
+def _unwrap_payload_callable(bound):
+    """Return the ``make_wrapper`` closure buried inside a bind() payload.
+
+    ``func.fleche.bind(*args)`` yields a ``BoundWrapper`` whose ``func`` is
+    ``functools.partial(wrapper, *args)`` (or ``wrapper`` itself when no args
+    are bound).  A cluster backend must serialise exactly this object.
+    """
+    func = bound.func
+    if isinstance(func, functools.partial):
+        func = func.func
+    return func
+
+
 @pytest.mark.xfail(
     strict=True,
-    reason="wrapper closes over a threading.Lock; cloudpickle-by-value "
-    "(cluster backends) cannot serialise the wrap_executor payload",
-    raises=TypeError,
+    reason="make_wrapper's closure closes over a raw threading.Lock, so the "
+    "wrap_executor payload cannot be cloudpickled by value (cluster backends)",
+    raises=AssertionError,
 )
-def test_wrap_executor_payload_cloudpickles_by_value():
-    """The payload wrap_executor submits must survive by-value cloudpickling.
+def test_wrap_executor_payload_has_no_unpicklable_lock():
+    """The wrap_executor payload must not carry an unpicklable object by value.
 
-    Registering this test's module for by-value pickling reproduces exactly
-    what a cloudpickling cluster backend does when it can't assume the worker
-    can import the user's code.
+    This is exactly what a cloudpickling cluster backend has to ship, and the
+    raw ``threading.Lock`` in the wrapper closure is what makes it fail.
     """
-    this_module = sys.modules[__name__]
-    cloudpickle.register_pickle_by_value(this_module)
-    try:
-        cache = Cache(ValueMemory({}), CallMemory({}))
-        with fleche.cache(cache):
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                fleche.wrap_executor(executor)
-                # Exactly the payload wrap_executor.submit() builds before it
-                # calls the underlying (cluster) submit, which cloudpickles it.
-                payload = _sample_iso.fleche.bind(3)
-                cloudpickle.dumps(payload)  # -> TypeError: cannot pickle '_thread.lock'
-    finally:
-        cloudpickle.unregister_pickle_by_value(this_module)
+    wrapper = _unwrap_payload_callable(_sample_iso.fleche.bind(3))
+
+    lock_cells = [
+        cell.cell_contents
+        for cell in (wrapper.__closure__ or ())
+        if isinstance(cell.cell_contents, _LOCK_TYPE)
+    ]
+
+    # Sanity: if the wrapper ever stops carrying a lock at all, this test has
+    # become stale rather than passing for the right reason — surface that.
+    if lock_cells:
+        with pytest.raises(TypeError, match="cannot pickle"):
+            pickle.dumps(lock_cells[0])
+
+    assert not lock_cells, (
+        "make_wrapper's wrapper closure carries a raw, unpicklable lock "
+        f"({lock_cells!r}); a cloudpickling cluster backend that ships the "
+        "wrap_executor payload by value fails with "
+        "\"cannot pickle '_thread.lock' object\"."
+    )


### PR DESCRIPTION
## What

Makes fleche's cached wrapper survivable through **by-value** cloudpickling, so `wrap_executor` payloads can actually be shipped to cross-process / cluster backends. Previously the wrapper closure closed over a raw `threading.Lock`, which is unpicklable.

## The bug

`wrap_executor`'s patched `submit` hands the underlying executor `func.fleche.bind(*args)` — a `BoundWrapper` wrapping `functools.partial(wrapper, *args)`, where `wrapper` is the closure built by `make_wrapper` (`src/fleche/wrapper.py`). That closure closed over:

```python
_in_flight_lock = threading.Lock()   # a raw _thread.lock
```

A cloudpickling cluster backend (executorlib, dask) must serialise that wrapper **by value** whenever the decorated function isn't importable by reference — and by value, cloudpickle walks the closure cells and hits the lock:

```
TypeError: cannot pickle '_thread.lock' object
```

### How easily by-value is triggered

More easily than `__main__`/notebooks or an explicit `register_pickle_by_value`. **Simply rebinding a decorated function to a different name is enough:**

```python
compute = fleche.fleche(some_other)   # name 'compute' != wrapper.__qualname__ 'some_other'
```

The wrapper carries `@wraps(some_other)`, so its `__qualname__` is `some_other`; cloudpickle's by-reference lookup finds the *plain* function (or nothing) under that name — not the wrapper — and falls back to by value. Verified in a plain importable module:

| pattern | by-ref lookup resolves to wrapper? | `cloudpickle.dumps(bind(3))` |
|---|---|---|
| `compute = fleche.fleche(some_other)` (rebind) | ✗ | **FAIL — `_thread.lock`** |
| `@fleche.fleche def shadowed(...)` (standard) | ✓ | OK (by reference) |

The standard `@fleche.fleche` form dodges it because the decorated name shadows the original and by-reference resolution succeeds — which is exactly why the happy-path docs examples (and the existing `test_executorlib_wrap_executor`, whose target `double` is a module-level function) never exercised this path.

## The fix

Bundle the in-flight map and its lock into a small picklable helper, `_InFlight`, that reconstructs fresh on unpickle:

```python
class _InFlight:
    __slots__ = ("map", "lock")
    def __init__(self):
        self.map = {}
        self.lock = threading.Lock()
    def __reduce__(self):
        return (_InFlight, ())   # fresh map + lock; both are process-local
```

In-flight state and the lock are process-local, so a worker that receives the wrapper by value correctly starts with an empty map and its own lock. Concurrency behaviour is unchanged (the peek at line 219 stays lock-free; set/pop stay under the lock). The lock was the *only* by-value blocker — every other closure cell (`func`, `policy`, `meta`, `isolate`, `get_call`) already pickles — so the payload now round-trips:

```
cloudpickle by-value: OK, 13797 bytes
restored(): 9
```

## Docs

A light `.. tip::` in `docs/parallel_execution.rst` nudges users, for process/cluster backends, to decorate a module-level function (wrapper ships by reference) and notes that rebinding to a different name — or `__main__`/notebook defs — forces heavier by-value serialisation that only cloudpickling backends support.

## Tests

`tests/regression/test_wrap_executor_cloudpickle_lock.py` now guards the fix:
- **deterministic, always-runs:** the wrapper closure carries no raw `threading.Lock` (version-independent — never invokes cloudpickle, so it holds even on the `test-minimum-deps` env whose older cloudpickle can't walk the wrapper bytecode by value).
- **end-to-end:** a cloudpickle by-value round-trip via the rebinding pattern, asserting it deserialises and returns `9`; skipped only when cloudpickle can't serialise the wrapper for a reason unrelated to the lock, while a re-emergence of the lock `TypeError` still fails loudly.

```
$ python -m pytest tests/regression/test_wrap_executor_cloudpickle_lock.py -v
test_wrap_executor_payload_has_no_raw_lock_in_closure PASSED
test_wrap_executor_payload_cloudpickles_by_value      PASSED
```

Existing wrapper / futures / bound-wrapper / parallel-execution suites pass unchanged.

> Earlier commits in this PR built the reproducer first (and a note there wrongly dismissed the `@wraps` mechanism — it's real; the missing piece was that by-value is triggered by the *rebinding* / non-importable-by-reference case, not by `@wraps` alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)