### PR TITLE
test(digest): skip test_attrs module when attrs is absent

### DIFF
--- a/tests/unit/digest/test_attrs.py
+++ b/tests/unit/digest/test_attrs.py
@@ -7,9 +7,13 @@ integration with the @fleche decorator and destructuring storage.
 
 from dataclasses import dataclass, make_dataclass
 
-import attr
-import attrs
 import pytest
+
+# ``attrs`` is an optional dependency.  Skip the whole module (rather than
+# erroring during collection) when it is absent -- e.g. in the packaged conda
+# test environment, where ``pytest -m smoke`` still imports every test module.
+attr = pytest.importorskip("attr")
+attrs = pytest.importorskip("attrs")
 
 from fleche import fleche, cache
 from fleche.caches import Cache


### PR DESCRIPTION
## What broke

The conda-forge feedstock test phase runs `pytest -m smoke`, and it failed with exit code 2:

```
_______________ ERROR collecting tests/unit/digest/test_attrs.py _______________
ImportError while importing test module '.../tests/unit/digest/test_attrs.py'.
tests/unit/digest/test_attrs.py:10: in <module>
    import attr
E   ModuleNotFoundError: No module named 'attr'
...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

## Root cause

`pytest -m smoke` still **imports every test module during collection** before deselecting by marker. `tests/unit/digest/test_attrs.py` was the only unit test that bare-imported the optional `attr`/`attrs` dependency at module scope (used by `@attrs.define` / `@attr.s` class decorators). In the packaged conda test environment, which does not install `attrs`, that import errored during collection and took down the entire `pytest -m smoke` run — even though no smoke test needs `attrs`.

## Fix

Guard the imports with `pytest.importorskip`, which returns the module and skips the whole module at collection time when it is absent:

```python
attr = pytest.importorskip("attr")
attrs = pytest.importorskip("attrs")
```

This matches the pattern already used by every other optional-dependency test in the suite (e.g. `tests/unit/storage/test_bagofholding_file.py`) and by `tests/smoke/test_optional_deps.py::test_attrs`. No shipped library code changes; the feedstock recipe is correct as-is since `attrs` is genuinely optional.

## Verification

Reproduced the conda environment locally (all extras installed **except** `attrs`):

- Before: `pytest -m smoke` → `1 error during collection`, exit 2.
- After: `pytest -m smoke` over the full suite → `4 passed, 2 skipped, 1597 deselected`; `test_attrs.py` skips cleanly.
- With `attrs` present: `test_attrs.py` → `18 passed` (normal path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiPkqdEXJhoP4NA3esUxpq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiPkqdEXJhoP4NA3esUxpq)_