### PR TITLE
refactor(state): extract sticky-set / hard-set ContextVar primitives

### DIFF
--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -1,7 +1,7 @@
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from typing import overload, Callable
+from typing import overload, Callable, Iterator
 
 from . import caches, config, metadata
 
@@ -30,6 +30,30 @@ class _StickyContext:
 
     def __exit__(self, *args: object) -> None:
         self._var.reset(self._token)
+
+
+def _sticky_set(var: ContextVar, value: object) -> _StickyContext:
+    """Set *var* to *value* immediately and return a sticky context manager.
+
+    Entering the returned context manager as a ``with``-block restores the previous
+    value on exit; discarding it leaves *value* active.
+    """
+    return _StickyContext(var, var.set(value))
+
+
+@contextmanager
+def _hard_set(pairs: list[tuple[ContextVar, object]]) -> Iterator[None]:
+    """Set every ``ContextVar`` in *pairs* immediately; reset in reverse order on exit.
+
+    Unlike :func:`_sticky_set`, this is a hard scope: the values are always reset when
+    the ``with``-block exits, regardless of how it exits.
+    """
+    tokens = [(var, var.set(value)) for var, value in pairs]
+    try:
+        yield
+    finally:
+        for var, token in reversed(tokens):
+            var.reset(token)
 
 
 @overload
@@ -80,8 +104,7 @@ def cache(
     if stack:
         new_cache = _CACHE.get().push(new_cache)
 
-    token = _CACHE.set(new_cache)
-    return _StickyContext(_CACHE, token)
+    return _sticky_set(_CACHE, new_cache)
 
 
 _METADATA: ContextVar[tuple[metadata.MetaData, ...]] = ContextVar(
@@ -110,8 +133,7 @@ def meta(
     if stack:
         new_metadata = _METADATA.get() + new_metadata
 
-    token = _METADATA.set(new_metadata)
-    return _StickyContext(_METADATA, token)
+    return _sticky_set(_METADATA, new_metadata)
 
 
 def tags(**kwargs):
@@ -167,10 +189,5 @@ class BoundWrapper:
         return cls(func, _CACHE.get(), _METADATA.get())
 
     def __call__(self, *args, **kwargs):
-        token_cache = _CACHE.set(self.cache)
-        token_meta = _METADATA.set(self.meta)
-        try:
+        with _hard_set([(_CACHE, self.cache), (_METADATA, self.meta)]):
             return self.func(*args, **kwargs)
-        finally:
-            _METADATA.reset(token_meta)
-            _CACHE.reset(token_cache)

--- a/tests/unit/test_cache_sticky.py
+++ b/tests/unit/test_cache_sticky.py
@@ -232,3 +232,83 @@ def test_project_with_block_restores():
     with project("temp"):
         assert _state._METADATA.get() != original
     assert _state._METADATA.get() == original
+
+
+# ---------------------------------------------------------------------------
+# _sticky_set / _hard_set primitives (issue #740)
+# ---------------------------------------------------------------------------
+
+
+def test_sticky_set_activates_immediately():
+    """_sticky_set(var, value) must set var without entering the with-block."""
+    var = _state.ContextVar("test_sticky_set_activates_immediately", default=None)
+    _state._sticky_set(var, "value")
+    assert var.get() == "value"
+
+
+def test_sticky_set_returns_sticky_context():
+    """_sticky_set must return a _StickyContext usable as a context manager."""
+    var = _state.ContextVar("test_sticky_set_returns_sticky_context", default=None)
+    cm = _state._sticky_set(var, "value")
+    assert isinstance(cm, _state._StickyContext)
+
+
+def test_sticky_set_with_block_restores_on_exit():
+    """with _sticky_set(var, value) must restore the previous value on exit."""
+    var = _state.ContextVar("test_sticky_set_with_block_restores_on_exit", default="original")
+    with _state._sticky_set(var, "value"):
+        assert var.get() == "value"
+    assert var.get() == "original"
+
+
+def test_sticky_set_discard_leaves_value_active():
+    """Discarding the returned context manager leaves value active permanently."""
+    var = _state.ContextVar("test_sticky_set_discard_leaves_value_active", default="original")
+    _state._sticky_set(var, "value")  # discarded
+    assert var.get() == "value"
+
+
+def test_hard_set_activates_every_var_immediately():
+    """_hard_set([(var, value), ...]) must set every var before the block starts."""
+    var_a = _state.ContextVar("test_hard_set_a", default="a0")
+    var_b = _state.ContextVar("test_hard_set_b", default="b0")
+    with _state._hard_set([(var_a, "a1"), (var_b, "b1")]):
+        assert var_a.get() == "a1"
+        assert var_b.get() == "b1"
+
+
+def test_hard_set_restores_all_on_normal_exit():
+    """_hard_set must reset every var to its previous value on exit."""
+    var_a = _state.ContextVar("test_hard_set_restores_a", default="a0")
+    var_b = _state.ContextVar("test_hard_set_restores_b", default="b0")
+    with _state._hard_set([(var_a, "a1"), (var_b, "b1")]):
+        pass
+    assert var_a.get() == "a0"
+    assert var_b.get() == "b0"
+
+
+def test_hard_set_restores_all_on_exception():
+    """_hard_set must reset every var even when the block raises."""
+    var_a = _state.ContextVar("test_hard_set_exc_a", default="a0")
+    var_b = _state.ContextVar("test_hard_set_exc_b", default="b0")
+    with pytest.raises(ValueError):
+        with _state._hard_set([(var_a, "a1"), (var_b, "b1")]):
+            raise ValueError("boom")
+    assert var_a.get() == "a0"
+    assert var_b.get() == "b0"
+
+
+def test_hard_set_resets_in_reverse_order():
+    """_hard_set must reset vars in reverse of the order they were set.
+
+    Mirrors BoundWrapper.__call__'s pre-refactor convention (metadata reset before
+    cache, i.e. the reverse of the set order) by observing reset order directly
+    against a single var re-set twice via two entries.
+    """
+    var = _state.ContextVar("test_hard_set_reverse_order", default="base")
+    var.set("outer")
+    with _state._hard_set([(var, "middle"), (var, "inner")]):
+        assert var.get() == "inner"
+    # after exit, the inner-most set (registered last) is undone first, unwinding
+    # back through "middle" to "outer" - net effect is full restoration to "outer".
+    assert var.get() == "outer"


### PR DESCRIPTION
Closes #740.

## What

`cache()` and `meta()` (`src/fleche/state.py`) each did the same
`token = VAR.set(value); return _StickyContext(VAR, token)` two-liner for
their own `ContextVar`. `BoundWrapper.__call__` did the analogous thing for
*two* vars at once, with a manual `try`/`finally` that resets `_METADATA`
before `_CACHE` (the reverse of set order) — a convention that wasn't
documented anywhere before this change.

This factors both shapes into two small primitives:

- `_sticky_set(var, value)` — sets `var` immediately and returns a
  `_StickyContext`; used by `cache()` and `meta()`.
- `_hard_set(pairs)` — a context manager that sets every `(var, value)` pair
  immediately and resets them in reverse order on exit, whether by return or
  exception; used by `BoundWrapper.__call__`.

No behaviour change: `cache()`/`meta()` still return the same sticky
semantics (enter/exit to restore, discard to keep), and `BoundWrapper.__call__`
still resets metadata before cache.

## Testing

- Added direct unit tests for `_sticky_set` and `_hard_set` in
  `tests/unit/test_cache_sticky.py` (immediate activation, with-block
  restore, discard-stays-active, multi-var set, restore on exception,
  reverse-order reset).
- `pytest tests/unit` — 1564 passed.
- `ruff check src/fleche/state.py tests/unit/test_cache_sticky.py` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qtJLNgbnGHk3ULcjWHqqC)_