### PR TITLE
feat(caches)!: seal call identity before the function body runs

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -48,46 +48,37 @@ class BaseCache(OperationContext):
         from . import config as _config
         return _config.cache_from_config(config)
 
-    @abstractmethod
-    def save_value(self, value: Any) -> "Digest":
-        """Store one value, returning its content digest.
-
-        The write-side counterpart of :meth:`load_value`; also the primitive
-        :meth:`prepare` runs argument and result values through.
-        """
-        ...
-
     def prepare(self, call: Call) -> PreparedCall:
-        """Admit *call* to this cache: store its arguments, seal its lookup key.
+        """Admit *call* to this cache: seal its lookup key before the body runs.
 
-        The first half of the two-phase save protocol.  Argument values go
-        through :meth:`save_value` *now* — before the function body runs — so
-        the recorded identity always describes the arguments as they were at
-        call time, even if the body later mutates them.  Because ``digest(x)
-        == save_value(x)`` for every storable value, the sealed key equals
-        ``call.to_lookup_key()``.
+        The first half of the two-phase save protocol.  Caches that own a
+        value storage (:class:`Cache`) override this to stash the argument
+        values *now* — before the function body runs — so the recorded
+        identity describes the arguments as they were at call time, even if
+        the body later mutates them.
+
+        This base implementation is the digest-only admission used by caches
+        that cannot (or must not) write ahead of the body — read-only views,
+        aggregates without their own value storage: the key is sealed, but
+        nothing is written and whether a record survives is decided by
+        :meth:`save` at commit time.  Because ``digest(x) == values.save(x)``
+        for every storable value, both forms seal the same key.
 
         Finish the returned :class:`~fleche.call.PreparedCall` with exactly
         one of :meth:`~fleche.call.PreparedCall.commit` (store the result,
         file the record) or :meth:`~fleche.call.PreparedCall.abandon`.
-
-        Argument values the storage refuses (``SaveError``) fall back to a
-        digest-only reference, as in :meth:`fleche.call.Call.stash`.
         """
-        digested = call._to_digested(self.save_value)
-        return PreparedCall(
-            call=call, digested=digested, key=digested.to_lookup_key(), cache=self
-        )
+        return PreparedCall(digested=call.digest(), cache=self)
 
     @abstractmethod
     def save(self, call: DigestedCall | Call) -> str:
         """File a call record.
 
-        The primary form takes a fully digested record whose values were
-        already stored — see :meth:`fleche.call.Call.prepare` for the
-        two-phase protocol that does both in the right order.  A live
-        :class:`Call` is also accepted as the degenerate one-shot form
-        (values static, stored on the spot)."""
+        Takes either a live :class:`Call` — values are stored on the spot, the
+        one-shot form — or a :class:`DigestedCall` whose argument values were
+        already stored by :meth:`prepare`, in which case only its result (if
+        any) still needs storing.  See :meth:`prepare` for the two-phase
+        protocol that does both in the right order."""
         ...
 
     @abstractmethod
@@ -332,37 +323,35 @@ class Cache(PerKeyLockMixin, BaseCache):
         with self._operation_context(key):
             return self.values.load(key)
 
-    def save_value(self, value: Any) -> Digest:
-        # No cache-level lock: the key is only known once the value storage
-        # has digested the value, and value storages carry their own per-key
-        # locking (PerKeyLockMixin) where they need it.
-        return self.values.save(value)
+    def prepare(self, call: Call) -> PreparedCall:
+        # Stash the arguments *now*, before the function body runs, so the
+        # record cannot end up keyed on post-mutation content.  ``stash``
+        # leaves the still-unknown result as ``None``; ``save`` below stores
+        # it once ``commit`` fills it in.  No cache-level lock: the keys are
+        # only known once the value storage has digested each value, and value
+        # storages carry their own per-key locking where they need it.
+        return PreparedCall(digested=call.stash(self.values), cache=self)
 
     def save(self, call: DigestedCall | Call) -> str:
-        # Record-only: argument and result values were already written to
-        # ``self.values`` by Call.prepare / PreparedCall.commit, whose digests
-        # this record carries.  Writing them here instead would re-read mutable
-        # values (e.g. Path contents) *after* the function body ran and file
-        # the record under post-mutation content — the incoherence the
-        # two-phase protocol exists to prevent.
-        #
-        # A live Call (values not yet stored) is still accepted as the
-        # degenerate one-shot form: with no function body between digesting
-        # and filing there is nothing to drift, so stash-then-file is
-        # equivalent to prepare/commit here.  Inlined rather than routed
-        # through prepare().commit() so one logical save does not re-enter
-        # subclass save() overrides a second time.  Wrappers and stacks need
-        # no own shim — every save path lands here.
-        if isinstance(call, Call):
-            key = call.to_lookup_key()
-            with self._operation_context(key):
-                try:
-                    digested = call.stash(self.values)
-                except storage.SaveError as e:
-                    raise Rejected(e)
-                return self.calls.save(digested)
         key = call.to_lookup_key()
         with self._operation_context(key):
+            try:
+                if isinstance(call, Call):
+                    # One-shot form: nothing was stored ahead of time.  With no
+                    # function body between digesting and filing there is
+                    # nothing to drift, so stash-then-file is equivalent to
+                    # prepare/commit here.
+                    call = call.stash(self.values)
+                elif call.result is not None and not isinstance(call.result, Digest):
+                    # Second half of the two-phase protocol: the arguments are
+                    # already digests (stored by ``prepare``), only the result
+                    # arrives live from ``PreparedCall.commit``.  Not re-saving
+                    # the arguments here is the point — reading them again
+                    # *after* the body ran would file the record under
+                    # post-mutation content.
+                    call = replace(call, result=self.values.save(call.result))
+            except storage.SaveError as e:
+                raise Rejected(e)
             return self.calls.save(call)
 
     def load(self, key: str) -> LazyCall:
@@ -530,8 +519,11 @@ class CacheWrapper(BaseCache):
 
     cache: BaseCache
 
-    def save_value(self, value: Any) -> Digest:
-        return self.cache.save_value(value)
+    def prepare(self, call: Call) -> PreparedCall:
+        # The inner cache decides how the arguments are stored; rebinding the
+        # cache makes the eventual commit go through *this* wrapper's ``save``,
+        # so wrapper policy (read-only, filtering, size limits) still applies.
+        return replace(self.cache.prepare(call), cache=self)
 
     def save(self, call: DigestedCall | Call) -> str:
         return self.cache.save(call)
@@ -589,18 +581,14 @@ class ReadOnlyMixin:
     def evict(self, key: str | Digest) -> None:
         raise Rejected("Cannot evict from a read-only cache", self, key)
 
-    def save_value(self, value: Any) -> Digest:
-        raise Rejected("Cannot save values to a read-only cache", self)
-
     def prepare(self, call: Call) -> "PreparedCall":
-        # Digest-only admission: a read-only cache stashes nothing, so the
-        # function body still runs with a correctly sealed key, and the
-        # eventual commit is rejected (save_value raises) — matching the
-        # behavior save() rejection produced before the two-phase protocol.
-        digested = call.digest()
-        return PreparedCall(
-            call=call, digested=digested, key=digested.to_lookup_key(), cache=self
-        )
+        # Digest-only admission (the BaseCache default, restated because this
+        # mixin is base-free and must beat CacheWrapper.prepare in the MRO): a
+        # read-only cache stashes nothing, so the function body still runs with
+        # a correctly sealed key and the eventual commit is rejected by
+        # ``save`` above — the behavior save() rejection produced before the
+        # two-phase protocol, minus the wasted writes.
+        return PreparedCall(digested=call.digest(), cache=self)
 
 
 @dataclass(frozen=True)
@@ -846,14 +834,16 @@ class CacheStack(PerKeyLockMixin, _MultiCache):
             if isinstance(c, CacheStack):
                 raise ValueError("CacheStack cannot be nested inside another CacheStack")
 
-    def save(self, call: DigestedCall | Call):
-        self.stack[0].save(call)
+    def save(self, call: DigestedCall | Call) -> str:
+        # Returning the key (rather than dropping it, as this used to) keeps
+        # the BaseCache contract that PreparedCall.commit hands back to callers.
+        return self.stack[0].save(call)
 
-    def save_value(self, value: Any) -> Digest:
-        # Writes always land on stack[0] (matching save); reads that need the
-        # full fan-out go through load_value, which _MultiCache spreads over
-        # every member.
-        return self.stack[0].save_value(value)
+    def prepare(self, call: Call) -> PreparedCall:
+        # Writes always land on stack[0] (matching save), so that is where the
+        # arguments are stashed; rebinding the cache routes the commit back
+        # through this stack's ``save``.
+        return replace(self.stack[0].prepare(call), cache=self)
 
     @contextlib.contextmanager
     def _operation_context(self, key, *, intent: Intent = Intent.WRITE):

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -13,7 +13,7 @@ from . import storage
 from .storage.base import _apply_shrink, _resolve_prefix, Intent, OperationContext
 from .storage.destructuring import HasChildDigests
 from .storage.thread_safe import PerKeyLockMixin, _PicklableRLock
-from .call import Call, DigestedCall, LazyCall, QueryCall
+from .call import Call, DigestedCall, LazyCall, PreparedCall, QueryCall
 from . import call
 from . import query
 
@@ -49,7 +49,45 @@ class BaseCache(OperationContext):
         return _config.cache_from_config(config)
 
     @abstractmethod
-    def save(self, call: Call) -> str:
+    def save_value(self, value: Any) -> "Digest":
+        """Store one value, returning its content digest.
+
+        The write-side counterpart of :meth:`load_value`; also the primitive
+        :meth:`prepare` runs argument and result values through.
+        """
+        ...
+
+    def prepare(self, call: Call) -> PreparedCall:
+        """Admit *call* to this cache: store its arguments, seal its lookup key.
+
+        The first half of the two-phase save protocol.  Argument values go
+        through :meth:`save_value` *now* — before the function body runs — so
+        the recorded identity always describes the arguments as they were at
+        call time, even if the body later mutates them.  Because ``digest(x)
+        == save_value(x)`` for every storable value, the sealed key equals
+        ``call.to_lookup_key()``.
+
+        Finish the returned :class:`~fleche.call.PreparedCall` with exactly
+        one of :meth:`~fleche.call.PreparedCall.commit` (store the result,
+        file the record) or :meth:`~fleche.call.PreparedCall.abandon`.
+
+        Argument values the storage refuses (``SaveError``) fall back to a
+        digest-only reference, as in :meth:`fleche.call.Call.stash`.
+        """
+        digested = call._to_digested(self.save_value)
+        return PreparedCall(
+            call=call, digested=digested, key=digested.to_lookup_key(), cache=self
+        )
+
+    @abstractmethod
+    def save(self, call: DigestedCall | Call) -> str:
+        """File a call record.
+
+        The primary form takes a fully digested record whose values were
+        already stored — see :meth:`fleche.call.Call.prepare` for the
+        two-phase protocol that does both in the right order.  A live
+        :class:`Call` is also accepted as the degenerate one-shot form
+        (values static, stored on the spot)."""
         ...
 
     @abstractmethod
@@ -294,14 +332,38 @@ class Cache(PerKeyLockMixin, BaseCache):
         with self._operation_context(key):
             return self.values.load(key)
 
-    def save(self, call: Call) -> str:
+    def save_value(self, value: Any) -> Digest:
+        # No cache-level lock: the key is only known once the value storage
+        # has digested the value, and value storages carry their own per-key
+        # locking (PerKeyLockMixin) where they need it.
+        return self.values.save(value)
+
+    def save(self, call: DigestedCall | Call) -> str:
+        # Record-only: argument and result values were already written to
+        # ``self.values`` by Call.prepare / PreparedCall.commit, whose digests
+        # this record carries.  Writing them here instead would re-read mutable
+        # values (e.g. Path contents) *after* the function body ran and file
+        # the record under post-mutation content — the incoherence the
+        # two-phase protocol exists to prevent.
+        #
+        # A live Call (values not yet stored) is still accepted as the
+        # degenerate one-shot form: with no function body between digesting
+        # and filing there is nothing to drift, so stash-then-file is
+        # equivalent to prepare/commit here.  Inlined rather than routed
+        # through prepare().commit() so one logical save does not re-enter
+        # subclass save() overrides a second time.  Wrappers and stacks need
+        # no own shim — every save path lands here.
+        if isinstance(call, Call):
+            key = call.to_lookup_key()
+            with self._operation_context(key):
+                try:
+                    digested = call.stash(self.values)
+                except storage.SaveError as e:
+                    raise Rejected(e)
+                return self.calls.save(digested)
         key = call.to_lookup_key()
         with self._operation_context(key):
-            try:
-                digested = call.stash(self.values)
-            except storage.SaveError as e:
-                raise Rejected(e)
-            return self.calls.save(digested)
+            return self.calls.save(call)
 
     def load(self, key: str) -> LazyCall:
         with self._operation_context(key):
@@ -392,8 +454,8 @@ class Cache(PerKeyLockMixin, BaseCache):
 
         This may take time depending on cache size."""
         for key in self.calls.list():
-            call = self.load(key).fetch()
-            new_key = call.to_lookup_key()
+            loaded = self.load(key).fetch()
+            new_key = loaded.to_lookup_key()
             if new_key == key:
                 continue
             # Hold the per-key locks for both the old and the new key so the
@@ -407,7 +469,7 @@ class Cache(PerKeyLockMixin, BaseCache):
             first, second = sorted((key, new_key))
             with self._operation_context(first), self._operation_context(second):
                 # instantiate values too
-                self.save(call)
+                self.save(loaded)
                 self.evict(key)
 
     def gc(self) -> set[Digest]:
@@ -468,7 +530,10 @@ class CacheWrapper(BaseCache):
 
     cache: BaseCache
 
-    def save(self, call: Call) -> str:
+    def save_value(self, value: Any) -> Digest:
+        return self.cache.save_value(value)
+
+    def save(self, call: DigestedCall | Call) -> str:
         return self.cache.save(call)
 
     def load(self, key: str) -> LazyCall:
@@ -518,11 +583,24 @@ class ReadOnlyMixin:
     short-circuits ``save``/``evict`` without a round-trip).
     """
 
-    def save(self, call: Call):
+    def save(self, call: DigestedCall | Call):
         raise Rejected(self, call)
 
     def evict(self, key: str | Digest) -> None:
         raise Rejected("Cannot evict from a read-only cache", self, key)
+
+    def save_value(self, value: Any) -> Digest:
+        raise Rejected("Cannot save values to a read-only cache", self)
+
+    def prepare(self, call: Call) -> "PreparedCall":
+        # Digest-only admission: a read-only cache stashes nothing, so the
+        # function body still runs with a correctly sealed key, and the
+        # eventual commit is rejected (save_value raises) — matching the
+        # behavior save() rejection produced before the two-phase protocol.
+        digested = call.digest()
+        return PreparedCall(
+            call=call, digested=digested, key=digested.to_lookup_key(), cache=self
+        )
 
 
 @dataclass(frozen=True)
@@ -768,8 +846,14 @@ class CacheStack(PerKeyLockMixin, _MultiCache):
             if isinstance(c, CacheStack):
                 raise ValueError("CacheStack cannot be nested inside another CacheStack")
 
-    def save(self, call: Call):
+    def save(self, call: DigestedCall | Call):
         self.stack[0].save(call)
+
+    def save_value(self, value: Any) -> Digest:
+        # Writes always land on stack[0] (matching save); reads that need the
+        # full fan-out go through load_value, which _MultiCache spreads over
+        # every member.
+        return self.stack[0].save_value(value)
 
     @contextlib.contextmanager
     def _operation_context(self, key, *, intent: Intent = Intent.WRITE):
@@ -923,7 +1007,7 @@ class SizeLimitedMixin(BaseCache):
                 target = self._pick_eviction_target(list(self._keys))
                 self.evict(target)
 
-    def save(self, call: call.Call) -> str:
+    def save(self, call: call.DigestedCall | call.Call) -> str:
         with self._lock:
             key = super().save(call)
             self._keys.add(key)

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -53,20 +53,16 @@ class BaseCache(OperationContext):
 
         The first half of the two-phase save protocol.  Caches that own a
         value storage (:class:`Cache`) override this to stash the argument
-        values *now* — before the function body runs — so the recorded
-        identity describes the arguments as they were at call time, even if
-        the body later mutates them.
-
-        This base implementation is the digest-only admission used by caches
-        that cannot (or must not) write ahead of the body — read-only views,
-        aggregates without their own value storage: the key is sealed, but
-        nothing is written and whether a record survives is decided by
-        :meth:`save` at commit time.  Because ``digest(x) == values.save(x)``
-        for every storable value, both forms seal the same key.
+        values now, so the recorded identity describes the arguments as they
+        were at call time, even if the body later mutates them.  This base
+        implementation is the digest-only admission for caches that cannot
+        (or must not) write ahead of the body — read-only views, aggregates
+        without their own storage; ``digest(x) == values.save(x)``, so both
+        forms seal the same key.
 
         Finish the returned :class:`~fleche.call.PreparedCall` with exactly
-        one of :meth:`~fleche.call.PreparedCall.commit` (store the result,
-        file the record) or :meth:`~fleche.call.PreparedCall.abandon`.
+        one of :meth:`~fleche.call.PreparedCall.commit` or
+        :meth:`~fleche.call.PreparedCall.abandon`.
         """
         return PreparedCall(digested=call.digest(), cache=self)
 
@@ -324,11 +320,9 @@ class Cache(PerKeyLockMixin, BaseCache):
 
     def prepare(self, call: Call) -> PreparedCall:
         # Stash the arguments *now*, before the function body runs, so the
-        # record cannot end up keyed on post-mutation content.  ``stash``
-        # leaves the still-unknown result as ``None``; ``save`` below stores
-        # it once ``commit`` fills it in.  No cache-level lock: the keys are
-        # only known once the value storage has digested each value, and value
-        # storages carry their own per-key locking where they need it.
+        # record cannot end up keyed on post-mutation content.  No cache-level
+        # lock: the keys are only known once the value storage has digested
+        # each value, and value storages carry their own per-key locking.
         return PreparedCall(digested=call.stash(self.values), cache=self)
 
     def save(self, call: PreparedCall | Call) -> str:
@@ -581,12 +575,10 @@ class ReadOnlyMixin:
         raise Rejected("Cannot evict from a read-only cache", self, key)
 
     def prepare(self, call: Call) -> "PreparedCall":
-        # Digest-only admission (the BaseCache default, restated because this
-        # mixin is base-free and must beat CacheWrapper.prepare in the MRO): a
-        # read-only cache stashes nothing, so the function body still runs with
-        # a correctly sealed key and the eventual commit is rejected by
-        # ``save`` above — the behavior save() rejection produced before the
-        # two-phase protocol, minus the wasted writes.
+        # Digest-only admission, restated from BaseCache because this mixin is
+        # base-free and must beat CacheWrapper.prepare in the MRO: nothing is
+        # stashed, the key is still sealed, and the commit is rejected by
+        # ``save`` above — the body runs and returns uncached.
         return PreparedCall(digested=call.digest(), cache=self)
 
 

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -13,7 +13,7 @@ from . import storage
 from .storage.base import _apply_shrink, _resolve_prefix, Intent, OperationContext
 from .storage.destructuring import HasChildDigests
 from .storage.thread_safe import PerKeyLockMixin, _PicklableRLock
-from .call import Call, DigestedCall, LazyCall, PreparedCall, QueryCall
+from .call import Call, LazyCall, PreparedCall, QueryCall
 from . import call
 from . import query
 
@@ -71,14 +71,13 @@ class BaseCache(OperationContext):
         return PreparedCall(digested=call.digest(), cache=self)
 
     @abstractmethod
-    def save(self, call: DigestedCall | Call) -> str:
+    def save(self, call: PreparedCall | Call) -> str:
         """File a call record.
 
         Takes either a live :class:`Call` — values are stored on the spot, the
-        one-shot form — or a :class:`DigestedCall` whose argument values were
-        already stored by :meth:`prepare`, in which case only its result (if
-        any) still needs storing.  See :meth:`prepare` for the two-phase
-        protocol that does both in the right order."""
+        one-shot form — or a :class:`~fleche.call.PreparedCall` whose argument
+        values were already stored by :meth:`prepare` and whose pending result
+        is stored now, as returned."""
         ...
 
     @abstractmethod
@@ -332,27 +331,33 @@ class Cache(PerKeyLockMixin, BaseCache):
         # storages carry their own per-key locking where they need it.
         return PreparedCall(digested=call.stash(self.values), cache=self)
 
-    def save(self, call: DigestedCall | Call) -> str:
+    def save(self, call: PreparedCall | Call) -> str:
         key = call.to_lookup_key()
         with self._operation_context(key):
             try:
                 if isinstance(call, Call):
-                    # One-shot form: nothing was stored ahead of time.  With no
-                    # function body between digesting and filing there is
-                    # nothing to drift, so stash-then-file is equivalent to
-                    # prepare/commit here.
-                    call = call.stash(self.values)
-                elif call.result is not None and not isinstance(call.result, Digest):
-                    # Second half of the two-phase protocol: the arguments are
-                    # already digests (stored by ``prepare``), only the result
-                    # arrives live from ``PreparedCall.commit``.  Not re-saving
-                    # the arguments here is the point — reading them again
-                    # *after* the body ran would file the record under
-                    # post-mutation content.
-                    call = replace(call, result=self.values.save(call.result))
+                    # One-shot form: nothing was stored ahead of time, and with
+                    # no function body between digesting and filing there is
+                    # nothing to drift.
+                    digested = call.stash(self.values)
+                elif isinstance(call, PreparedCall):
+                    # Committed result, stored as returned; the arguments must
+                    # NOT be re-saved here — reading them after the body ran is
+                    # exactly the post-mutation keying prepare exists to
+                    # prevent.
+                    digested = replace(
+                        call.digested,
+                        result=self.values.save(call._result),
+                        metadata=call.digested.metadata
+                        if call._metadata is None
+                        else call._metadata,
+                    )
+                else:
+                    # Already fully digested: file as-is.
+                    digested = call
             except storage.SaveError as e:
                 raise Rejected(e)
-            return self.calls.save(call)
+            return self.calls.save(digested)
 
     def load(self, key: str) -> LazyCall:
         with self._operation_context(key):
@@ -525,7 +530,7 @@ class CacheWrapper(BaseCache):
         # so wrapper policy (read-only, filtering, size limits) still applies.
         return replace(self.cache.prepare(call), cache=self)
 
-    def save(self, call: DigestedCall | Call) -> str:
+    def save(self, call: PreparedCall | Call) -> str:
         return self.cache.save(call)
 
     def load(self, key: str) -> LazyCall:
@@ -575,7 +580,7 @@ class ReadOnlyMixin:
     short-circuits ``save``/``evict`` without a round-trip).
     """
 
-    def save(self, call: DigestedCall | Call):
+    def save(self, call: PreparedCall | Call):
         raise Rejected(self, call)
 
     def evict(self, key: str | Digest) -> None:
@@ -834,9 +839,7 @@ class CacheStack(PerKeyLockMixin, _MultiCache):
             if isinstance(c, CacheStack):
                 raise ValueError("CacheStack cannot be nested inside another CacheStack")
 
-    def save(self, call: DigestedCall | Call) -> str:
-        # Returning the key (rather than dropping it, as this used to) keeps
-        # the BaseCache contract that PreparedCall.commit hands back to callers.
+    def save(self, call: PreparedCall | Call) -> str:
         return self.stack[0].save(call)
 
     def prepare(self, call: Call) -> PreparedCall:
@@ -997,7 +1000,7 @@ class SizeLimitedMixin(BaseCache):
                 target = self._pick_eviction_target(list(self._keys))
                 self.evict(target)
 
-    def save(self, call: call.DigestedCall | call.Call) -> str:
+    def save(self, call: call.PreparedCall | call.Call) -> str:
         with self._lock:
             key = super().save(call)
             self._keys.add(key)

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -830,9 +830,9 @@ class CacheStack(PerKeyLockMixin, _MultiCache):
 
     def prepare(self, call: Call) -> PreparedCall:
         # Writes always land on stack[0] (matching save), so that is where the
-        # arguments are stashed; rebinding the cache routes the commit back
-        # through this stack's ``save``.
-        return replace(self.stack[0].prepare(call), cache=self)
+        # arguments are stashed and where the commit files directly — this
+        # stack's own ``save`` is a pure forward to the same place.
+        return self.stack[0].prepare(call)
 
     @contextlib.contextmanager
     def _operation_context(self, key, *, intent: Intent = Intent.WRITE):

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -339,7 +339,7 @@ class Cache(PerKeyLockMixin, BaseCache):
                     # NOT be re-saved here — reading them after the body ran is
                     # exactly the post-mutation keying prepare exists to
                     # prevent.
-                    digested = call.resolve(self.values.save(call._result))
+                    digested = call.resolve(self.values)
                 else:
                     # Already fully digested: file as-is.
                     digested = call

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -345,13 +345,7 @@ class Cache(PerKeyLockMixin, BaseCache):
                     # NOT be re-saved here — reading them after the body ran is
                     # exactly the post-mutation keying prepare exists to
                     # prevent.
-                    digested = replace(
-                        call.digested,
-                        result=self.values.save(call._result),
-                        metadata=call.digested.metadata
-                        if call._metadata is None
-                        else call._metadata,
-                    )
+                    digested = call.resolve(self.values.save(call._result))
                 else:
                     # Already fully digested: file as-is.
                     digested = call

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -266,7 +266,11 @@ class DigestedCall:
 
     name: str
     arguments: dict[str, "digest.Digest"]
-    result: "digest.Digest | None" = None
+    # Normally a Digest pointer, or None while the result is still unknown
+    # (a record prepared before its function body ran).  Between
+    # :meth:`PreparedCall.commit` and the cache's ``save`` it briefly holds the
+    # live return value, which ``save`` stores and replaces with its Digest.
+    result: "digest.Digest | Any" = None
     metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
     module: str | None = None
     version: str | int | None = None
@@ -348,37 +352,30 @@ class PreparedCall:
             prepared.commit(func(...))       # skipped on exception -> abandoned
     """
 
-    call: Call
     digested: DigestedCall
-    key: Digest
     cache: Any
     _finished: bool = field(default=False, init=False, repr=False)
 
     def commit(self, result: Any, metadata: dict | None = None) -> Digest:
-        """Store *result*, attach *metadata*, and file the call record.
+        """Attach *result* and *metadata* to the record and file it.
 
-        The second half of the two-phase save protocol: the result is written to
-        ``cache.values`` (capturing its content *as returned* — including any
-        argument the body mutated and passed back out), and the completed
-        :class:`DigestedCall` is filed under :attr:`key`.
+        The second half of the two-phase save protocol.  The result is handed
+        to the cache live, so it is stored *as returned* — including any
+        argument the body mutated and passed back out — while the arguments
+        keep the digests sealed at prepare time.
 
         Args:
             result: The function's return value.
             metadata: Optional metadata mapping stored on the record.
 
         Returns:
-            Digest: the record key (equal to :attr:`key`).
+            Digest: the record key.
 
         Raises:
             fleche.caches.Rejected: if the result cannot be stored or the cache
                 refuses the record.
         """
-        from .storage.base import SaveError  # lazy import: storage.base depends on call
-        try:
-            self.digested.result = self.cache.save_value(result)
-        except SaveError as e:
-            from .caches import Rejected  # lazy import: caches depends on call
-            raise Rejected(e) from None
+        self.digested.result = result
         if metadata is not None:
             self.digested.metadata = metadata
         self._finished = True
@@ -388,9 +385,10 @@ class PreparedCall:
         """Release the call without recording it.
 
         Called when the function body raises or its result is not cacheable.
-        The default is a no-op: argument values stored by :meth:`Call.prepare`
-        are content-addressed orphans that a later garbage collection sweep
-        reclaims.  Subclasses may hook cleanup here.
+        The default is a no-op: argument values stored by
+        :meth:`~fleche.caches.BaseCache.prepare` are content-addressed orphans
+        that a later garbage collection sweep reclaims.  Subclasses may hook
+        cleanup here.
         """
         self._finished = True
 

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -389,13 +389,18 @@ class PreparedCall:
     def to_lookup_key(self) -> Digest:
         return self.digested.to_lookup_key()
 
-    def __getstate__(self) -> dict:
-        # The cache binding is process-local (it may hold live locks or an SSH
-        # connection); a PreparedCall on the wire carries only the record and
-        # the pending result.
-        state = self.__dict__.copy()
-        state["cache"] = None
-        return state
+    def resolve(self, result: Digest) -> DigestedCall:
+        """Return the final record with the pending result resolved to *result*.
+
+        The shared ending of the two-phase save: the cache stores
+        :attr:`_result` wherever its values live and hands the digest back
+        here; pending metadata is applied at the same time.
+        """
+        return replace(
+            self.digested,
+            result=result,
+            metadata=self.digested.metadata if self._metadata is None else self._metadata,
+        )
 
     def abandon(self) -> None:
         """Release the call without recording it.

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -199,8 +199,13 @@ class Call:
         return digest.digest(call)
 
     def _to_digested(self, save_fn: Callable[[Any], Digest]) -> "DigestedCall":
-        """Generic conversion to DigestedCall using *save_fn* to handle each value."""
-        result = save_fn(self.result)
+        """Generic conversion to DigestedCall using *save_fn* to handle each value.
+
+        A ``None`` result stays ``None`` (an incomplete record awaiting its
+        result — see :meth:`fleche.caches.BaseCache.prepare`) rather than being
+        run through *save_fn*.
+        """
+        result = None if self.result is None else save_fn(self.result)
         arguments: dict[str, Digest] = {}
         for k, v in self.arguments.items():
             if isinstance(v, Digest):
@@ -322,6 +327,80 @@ class DigestedCall:
             version=self.version,
             code_digest=self.code_digest,
         )
+
+
+@dataclass
+class PreparedCall:
+    """A call admitted to a cache: arguments stored, key sealed, result awaited.
+
+    The middle state of a call's lifecycle, between :class:`Call` (live values,
+    nothing stored) and :class:`DigestedCall` (fully recorded).  Created by
+    :meth:`fleche.caches.BaseCache.prepare`, which injects the cache whose
+    value storage received the arguments; finished by exactly one of
+    :meth:`commit` or :meth:`abandon`.
+
+    Also usable as a context manager in synchronous code: leaving the block
+    without having committed abandons the call.
+
+    .. code-block:: python
+
+        with cache.prepare(call) as prepared:
+            prepared.commit(func(...))       # skipped on exception -> abandoned
+    """
+
+    call: Call
+    digested: DigestedCall
+    key: Digest
+    cache: Any
+    _finished: bool = field(default=False, init=False, repr=False)
+
+    def commit(self, result: Any, metadata: dict | None = None) -> Digest:
+        """Store *result*, attach *metadata*, and file the call record.
+
+        The second half of the two-phase save protocol: the result is written to
+        ``cache.values`` (capturing its content *as returned* — including any
+        argument the body mutated and passed back out), and the completed
+        :class:`DigestedCall` is filed under :attr:`key`.
+
+        Args:
+            result: The function's return value.
+            metadata: Optional metadata mapping stored on the record.
+
+        Returns:
+            Digest: the record key (equal to :attr:`key`).
+
+        Raises:
+            fleche.caches.Rejected: if the result cannot be stored or the cache
+                refuses the record.
+        """
+        from .storage.base import SaveError  # lazy import: storage.base depends on call
+        try:
+            self.digested.result = self.cache.save_value(result)
+        except SaveError as e:
+            from .caches import Rejected  # lazy import: caches depends on call
+            raise Rejected(e) from None
+        if metadata is not None:
+            self.digested.metadata = metadata
+        self._finished = True
+        return self.cache.save(self.digested)
+
+    def abandon(self) -> None:
+        """Release the call without recording it.
+
+        Called when the function body raises or its result is not cacheable.
+        The default is a no-op: argument values stored by :meth:`Call.prepare`
+        are content-addressed orphans that a later garbage collection sweep
+        reclaims.  Subclasses may hook cleanup here.
+        """
+        self._finished = True
+
+    def __enter__(self) -> "PreparedCall":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if not self._finished:
+            self.abandon()
+        return False
 
 
 class LazyArguments(Mapping):

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -389,16 +389,16 @@ class PreparedCall:
     def to_lookup_key(self) -> Digest:
         return self.digested.to_lookup_key()
 
-    def resolve(self, result: Digest) -> DigestedCall:
-        """Return the final record with the pending result resolved to *result*.
+    def resolve(self, values) -> DigestedCall:
+        """Save the pending result into *values*, returning the final record.
 
-        The shared ending of the two-phase save: the cache stores
-        :attr:`_result` wherever its values live and hands the digest back
-        here; pending metadata is applied at the same time.
+        The shared ending of the two-phase save, mirroring :meth:`Call.stash`:
+        the cache hands in the value storage where its saves land; pending
+        metadata is applied at the same time.
         """
         return replace(
             self.digested,
-            result=result,
+            result=values.save(self._result),
             metadata=self.digested.metadata if self._metadata is None else self._metadata,
         )
 

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -266,11 +266,9 @@ class DigestedCall:
 
     name: str
     arguments: dict[str, "digest.Digest"]
-    # Normally a Digest pointer, or None while the result is still unknown
-    # (a record prepared before its function body ran).  Between
-    # :meth:`PreparedCall.commit` and the cache's ``save`` it briefly holds the
-    # live return value, which ``save`` stores and replaces with its Digest.
-    result: "digest.Digest | Any" = None
+    # None while the result is still unknown (a record prepared before its
+    # function body ran).
+    result: "digest.Digest | None" = None
     metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
     module: str | None = None
     version: str | int | None = None
@@ -355,6 +353,10 @@ class PreparedCall:
     digested: DigestedCall
     cache: Any
     _finished: bool = field(default=False, init=False, repr=False)
+    # The live result and metadata between commit and the cache's save;
+    # DigestedCall itself only ever holds digests.
+    _result: Any = field(default=None, init=False, repr=False)
+    _metadata: "dict | None" = field(default=None, init=False, repr=False)
 
     def commit(self, result: Any, metadata: dict | None = None) -> Digest:
         """Attach *result* and *metadata* to the record and file it.
@@ -379,12 +381,21 @@ class PreparedCall:
         if self._finished:
             raise RuntimeError("PreparedCall already committed or abandoned")
         self._finished = True
-        digested = replace(
-            self.digested,
-            result=result,
-            metadata=self.digested.metadata if metadata is None else metadata,
-        )
-        return self.cache.save(digested)
+        self._result = result
+        if metadata is not None:
+            self._metadata = metadata
+        return self.cache.save(self)
+
+    def to_lookup_key(self) -> Digest:
+        return self.digested.to_lookup_key()
+
+    def __getstate__(self) -> dict:
+        # The cache binding is process-local (it may hold live locks or an SSH
+        # connection); a PreparedCall on the wire carries only the record and
+        # the pending result.
+        state = self.__dict__.copy()
+        state["cache"] = None
+        return state
 
     def abandon(self) -> None:
         """Release the call without recording it.

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -374,12 +374,17 @@ class PreparedCall:
         Raises:
             fleche.caches.Rejected: if the result cannot be stored or the cache
                 refuses the record.
+            RuntimeError: if this call was already committed or abandoned.
         """
-        self.digested.result = result
-        if metadata is not None:
-            self.digested.metadata = metadata
+        if self._finished:
+            raise RuntimeError("PreparedCall already committed or abandoned")
         self._finished = True
-        return self.cache.save(self.digested)
+        digested = replace(
+            self.digested,
+            result=result,
+            metadata=self.digested.metadata if metadata is None else metadata,
+        )
+        return self.cache.save(digested)
 
     def abandon(self) -> None:
         """Release the call without recording it.
@@ -388,7 +393,7 @@ class PreparedCall:
         The default is a no-op: argument values stored by
         :meth:`~fleche.caches.BaseCache.prepare` are content-addressed orphans
         that a later garbage collection sweep reclaims.  Subclasses may hook
-        cleanup here.
+        cleanup here.  Idempotent; only :meth:`commit` is barred afterwards.
         """
         self._finished = True
 

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -57,7 +57,7 @@ from pyiron_snippets.import_alarm import ImportAlarm
 
 from . import call as _call
 from .caches import BaseCache, Rejected
-from .call import Call, DigestedCall, LazyCall, QueryCall
+from .call import DigestedCall, LazyCall, QueryCall
 from .digest import Digest
 
 logger = logging.getLogger("fleche.remote")
@@ -148,6 +148,7 @@ _REMOTE_METHODS: dict[str, _RemoteMethod] = {
     "save": _RemoteMethod(lambda cache, args: cache.save(*args)),
     "load": _RemoteMethod(lambda cache, args: _strip_cache(cache.load(*args))),
     "load_value": _RemoteMethod(lambda cache, args: cache.load_value(*args)),
+    "save_value": _RemoteMethod(lambda cache, args: cache.save_value(*args)),
     "evict": _RemoteMethod(lambda cache, args: cache.evict(*args), void=True),
     "contains": _RemoteMethod(lambda cache, args: cache.contains(*args)),
     "expand": _RemoteMethod(lambda cache, args: cache.expand(*args)),
@@ -680,6 +681,7 @@ _CLIENT_METHODS: dict[str, _ClientMethod] = {
     "save": _ClientMethod(write=True),
     "load": _ClientMethod(unwrap=_fetch_lazy_call),
     "load_value": _ClientMethod(),
+    "save_value": _ClientMethod(write=True),
     "evict": _ClientMethod(
         write=True, reject_message="Cannot evict from a read-only remote cache"
     ),
@@ -783,7 +785,7 @@ class SshCache(BaseCache):
             raise Rejected(self, *args)
         return spec.unwrap(self, self._conn.call(name, *args))
 
-    def save(self, call: Call) -> str:
+    def save(self, call: DigestedCall | _call.Call) -> str:
         return self._rpc("save", call)
 
     def load(self, key: str) -> LazyCall:
@@ -791,6 +793,13 @@ class SshCache(BaseCache):
 
     def load_value(self, key: str) -> Any:
         return self._rpc("load_value", key)
+
+    def save_value(self, value: Any) -> Digest:
+        # One round trip per value (no batching yet).  Values travel by
+        # cloudpickle, so a Path value ships its path *string*, not its
+        # content — the same limitation the previous ship-the-whole-Call
+        # protocol had; paths over SSH remain unsupported.
+        return self._rpc("save_value", value)
 
     def evict(self, key: str | Digest) -> None:
         self._rpc("evict", key)

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -141,6 +141,22 @@ def _query_result(cache: BaseCache, args: tuple) -> tuple[DigestedCall, ...]:
     return tuple(_strip_cache(lc) for lc in cache.query(template))
 
 
+def _save_value(cache: BaseCache, value: Any) -> Digest:
+    """Store a bare *value* in the served cache and return its digest.
+
+    The write-side counterpart of ``load_value``, existing only in the wire
+    protocol.  Routed through :meth:`~fleche.caches.BaseCache.prepare` with a
+    synthetic, never-committed call, so wrappers and stacks direct the value
+    to the same storage their saves use; the value is kept (content-addressed)
+    while no call record is ever filed.
+    """
+    prepared = cache.prepare(
+        _call.Call(name="fleche.remote:save_value", arguments={"value": value})
+    )
+    prepared.abandon()
+    return prepared.digested.arguments["value"]
+
+
 # Single inventory of every method `SshCache` forwards across the wire; the
 # client-side stubs near `SshCache` call these names via `self._conn.call(...)`.
 # Adding a new RPC-exposed cache method only requires one entry here.
@@ -148,9 +164,10 @@ _REMOTE_METHODS: dict[str, _RemoteMethod] = {
     "save": _RemoteMethod(lambda cache, args: cache.save(*args)),
     "load": _RemoteMethod(lambda cache, args: _strip_cache(cache.load(*args))),
     "load_value": _RemoteMethod(lambda cache, args: cache.load_value(*args)),
+    "save_value": _RemoteMethod(lambda cache, args: _save_value(cache, *args)),
     # Only the sealed record travels back; the server-side PreparedCall is
-    # dropped (abandon is a no-op) and the client finishes the protocol with a
-    # plain ``save`` once the body has run.
+    # dropped (abandon is a no-op) and the client finishes the protocol with
+    # ``save_value`` + ``save`` once the body has run.
     "prepare": _RemoteMethod(lambda cache, args: cache.prepare(*args).digested),
     "evict": _RemoteMethod(lambda cache, args: cache.evict(*args), void=True),
     "contains": _RemoteMethod(lambda cache, args: cache.contains(*args)),
@@ -684,6 +701,9 @@ _CLIENT_METHODS: dict[str, _ClientMethod] = {
     "save": _ClientMethod(write=True),
     "load": _ClientMethod(unwrap=_fetch_lazy_call),
     "load_value": _ClientMethod(),
+    # Write-gated so a commit against a read-only remote is rejected locally
+    # before the first trip.
+    "save_value": _ClientMethod(write=True),
     # Read-only remotes never reach this entry: `SshCache.prepare` short-circuits
     # to the local digest-only admission before dispatching.
     "prepare": _ClientMethod(),
@@ -791,10 +811,13 @@ class SshCache(BaseCache):
         return spec.unwrap(self, self._conn.call(name, *args))
 
     def save(self, call: PreparedCall | _call.Call) -> str:
-        # A PreparedCall pickles without its cache binding (see
-        # ``PreparedCall.__getstate__``), so only the sealed record and the
-        # pending result travel; the server's cache stores the result and files
-        # the record.
+        if isinstance(call, PreparedCall):
+            # Recreate Cache.save's ending in two trips: ship the result value,
+            # then file the plain digested record — a PreparedCall itself never
+            # goes over the wire.  A failure between the trips leaves the value
+            # as a content-addressed orphan for gc, like any abandoned call.
+            digested = call.resolve(self._rpc("save_value", call._result))
+            return self._rpc("save", digested)
         return self._rpc("save", call)
 
     def load(self, key: str) -> LazyCall:

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -831,7 +831,7 @@ class SshCache(BaseCache):
         # argument values before the body runs and seals the record, which
         # comes back for the client to complete with ``save``.  Values travel
         # by cloudpickle, so a Path argument ships its path *string*, not its
-        # content — paths over SSH remain unsupported, as before.
+        # content — paths over SSH are unsupported.
         self._ensure_handshake()
         if self._info_cache and self._info_cache.get("read_only", False):
             # Digest-only admission, as BaseCache: the body still runs, and the

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -790,7 +790,11 @@ class SshCache(BaseCache):
             raise Rejected(self, *args)
         return spec.unwrap(self, self._conn.call(name, *args))
 
-    def save(self, call: DigestedCall | _call.Call) -> str:
+    def save(self, call: PreparedCall | _call.Call) -> str:
+        # A PreparedCall pickles without its cache binding (see
+        # ``PreparedCall.__getstate__``), so only the sealed record and the
+        # pending result travel; the server's cache stores the result and files
+        # the record.
         return self._rpc("save", call)
 
     def load(self, key: str) -> LazyCall:

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -57,7 +57,7 @@ from pyiron_snippets.import_alarm import ImportAlarm
 
 from . import call as _call
 from .caches import BaseCache, Rejected
-from .call import DigestedCall, LazyCall, QueryCall
+from .call import DigestedCall, LazyCall, PreparedCall, QueryCall
 from .digest import Digest
 
 logger = logging.getLogger("fleche.remote")
@@ -148,7 +148,10 @@ _REMOTE_METHODS: dict[str, _RemoteMethod] = {
     "save": _RemoteMethod(lambda cache, args: cache.save(*args)),
     "load": _RemoteMethod(lambda cache, args: _strip_cache(cache.load(*args))),
     "load_value": _RemoteMethod(lambda cache, args: cache.load_value(*args)),
-    "save_value": _RemoteMethod(lambda cache, args: cache.save_value(*args)),
+    # Only the sealed record travels back; the server-side PreparedCall is
+    # dropped (abandon is a no-op) and the client finishes the protocol with a
+    # plain ``save`` once the body has run.
+    "prepare": _RemoteMethod(lambda cache, args: cache.prepare(*args).digested),
     "evict": _RemoteMethod(lambda cache, args: cache.evict(*args), void=True),
     "contains": _RemoteMethod(lambda cache, args: cache.contains(*args)),
     "expand": _RemoteMethod(lambda cache, args: cache.expand(*args)),
@@ -681,7 +684,9 @@ _CLIENT_METHODS: dict[str, _ClientMethod] = {
     "save": _ClientMethod(write=True),
     "load": _ClientMethod(unwrap=_fetch_lazy_call),
     "load_value": _ClientMethod(),
-    "save_value": _ClientMethod(write=True),
+    # Read-only remotes never reach this entry: `SshCache.prepare` short-circuits
+    # to the local digest-only admission before dispatching.
+    "prepare": _ClientMethod(),
     "evict": _ClientMethod(
         write=True, reject_message="Cannot evict from a read-only remote cache"
     ),
@@ -794,12 +799,18 @@ class SshCache(BaseCache):
     def load_value(self, key: str) -> Any:
         return self._rpc("load_value", key)
 
-    def save_value(self, value: Any) -> Digest:
-        # One round trip per value (no batching yet).  Values travel by
-        # cloudpickle, so a Path value ships its path *string*, not its
-        # content — the same limitation the previous ship-the-whole-Call
-        # protocol had; paths over SSH remain unsupported.
-        return self._rpc("save_value", value)
+    def prepare(self, call: _call.Call) -> PreparedCall:
+        # One round trip: the whole call goes over so the remote stashes the
+        # argument values before the body runs and seals the record, which
+        # comes back for the client to complete with ``save``.  Values travel
+        # by cloudpickle, so a Path argument ships its path *string*, not its
+        # content — paths over SSH remain unsupported, as before.
+        self._ensure_handshake()
+        if self._info_cache and self._info_cache.get("read_only", False):
+            # Digest-only admission, as BaseCache: the body still runs, and the
+            # commit's ``save`` is rejected locally without a round trip.
+            return super().prepare(call)
+        return PreparedCall(digested=self._rpc("prepare", call), cache=self)
 
     def evict(self, key: str | Digest) -> None:
         self._rpc("evict", key)

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -59,6 +59,7 @@ from . import call as _call
 from .caches import BaseCache, Rejected
 from .call import DigestedCall, LazyCall, PreparedCall, QueryCall
 from .digest import Digest
+from .storage.base import SaveError
 
 logger = logging.getLogger("fleche.remote")
 
@@ -147,14 +148,28 @@ def _save_value(cache: BaseCache, value: Any) -> Digest:
     The write-side counterpart of ``load_value``, existing only in the wire
     protocol.  Routed through :meth:`~fleche.caches.BaseCache.prepare` with a
     synthetic, never-committed call, so wrappers and stacks direct the value
-    to the same storage their saves use; the value is kept (content-addressed)
-    while no call record is ever filed.
+    to the same storage their saves use.  The value rides in the *result*
+    position for its strict save semantics: a refused value must reject the
+    commit (as in ``Cache.save``), where the argument position would fall
+    back to a digest-only reference and file a record with a dangling
+    result.  ``None`` — the one result the stash skips — rides as an
+    argument instead; storing ``None`` cannot fail.
     """
-    prepared = cache.prepare(
-        _call.Call(name="fleche.remote:save_value", arguments={"value": value})
-    )
+    if value is None:
+        prepared = cache.prepare(
+            _call.Call(name="fleche.remote:save_value", arguments={"value": None})
+        )
+        prepared.abandon()
+        return prepared.digested.arguments["value"]
+    try:
+        prepared = cache.prepare(
+            _call.Call(name="fleche.remote:save_value", arguments={}, result=value)
+        )
+    except SaveError as e:
+        raise Rejected(e)
     prepared.abandon()
-    return prepared.digested.arguments["value"]
+    assert prepared.digested.result is not None  # value is not None here
+    return prepared.digested.result
 
 
 # Single inventory of every method `SshCache` forwards across the wire; the
@@ -685,6 +700,21 @@ class _ClientMethod:
     reject_message: str | None = None
 
 
+@dataclass(frozen=True)
+class _RemoteValues:
+    """The slice of the value-storage write surface a remote commit needs.
+
+    Lets :meth:`SshCache.save` hand :meth:`~fleche.call.PreparedCall.resolve`
+    a values object, in parity with the local ``Cache.save``; ``save`` is one
+    ``save_value`` round trip.
+    """
+
+    _cache: "SshCache"
+
+    def save(self, value: Any) -> Digest:
+        return self._cache._rpc("save_value", value)
+
+
 def _fetch_lazy_call(sc: "SshCache", dc: DigestedCall) -> LazyCall:
     return dc.fetch(sc)
 
@@ -816,7 +846,7 @@ class SshCache(BaseCache):
             # then file the plain digested record — a PreparedCall itself never
             # goes over the wire.  A failure between the trips leaves the value
             # as a content-addressed orphan for gc, like any abandoned call.
-            digested = call.resolve(self._rpc("save_value", call._result))
+            digested = call.resolve(_RemoteValues(self))
             return self._rpc("save", digested)
         return self._rpc("save", call)
 

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -235,7 +235,20 @@ def make_wrapper(func, policy, meta, isolate, get_call):
             for m in active_meta:
                 metadata[m.name] |= m.pre(replace(call, metadata={}))
 
-            result: _T = func(*args, **kwargs)
+            # Two-phase save: argument values are stored and the record's key
+            # sealed *before* the body runs, so the recorded identity is the
+            # arguments as passed — even if the body mutates them (e.g. writes
+            # into a directory it received).  A read-only cache stashes
+            # nothing here (digest-only prepare) and rejects at commit time,
+            # so the call still runs and returns uncached, as it previously
+            # did when the post-body save was rejected.
+            prepared = cache.prepare(call)
+
+            try:
+                result: _T = func(*args, **kwargs)
+            except BaseException:
+                prepared.abandon()
+                raise
 
             def _cache(future=None):
                 if future is not None:
@@ -245,7 +258,11 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                     if future is None:
                         call.result = result
                     else:
-                        call.result = future.result()
+                        try:
+                            call.result = future.result()
+                        except BaseException:
+                            prepared.abandon()
+                            raise
                     if call.result is None:
                         if isinstance(cache, RefreshingCache):
                             try:
@@ -257,6 +274,7 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                                 logger.warning("Cache rejected evict: %s", e.args)
                         else:
                             logger.warning("Function returned None, not caching")
+                        prepared.abandon()
                         return None
                     for m in active_meta:
                         metadata[m.name] |= m.post(
@@ -265,7 +283,7 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                     try:
                         call.metadata = metadata
                         logger.debug("Saving result for %s with key %s", call.name, key)
-                        cache.save(call)
+                        prepared.commit(call.result, metadata)
                     except Rejected as e:
                         logger.warning("Cache rejected save: %s", e.args)
                     return call.result

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -235,14 +235,16 @@ def make_wrapper(func, policy, meta, isolate, get_call):
             for m in active_meta:
                 metadata[m.name] |= m.pre(replace(call, metadata={}))
 
-            # Two-phase save: argument values are stored and the record's key
-            # sealed *before* the body runs, so the recorded identity is the
-            # arguments as passed — even if the body mutates them (e.g. writes
-            # into a directory it received).  A read-only cache stashes
-            # nothing here (digest-only prepare) and rejects at commit time,
-            # so the call still runs and returns uncached, as it previously
-            # did when the post-body save was rejected.
-            prepared = cache.prepare(call)
+            # Seal the call's identity (and stash its argument values) before
+            # the body runs, so mutations the body makes to its arguments
+            # cannot leak into the recorded key.  A read-only cache seals
+            # without writing and rejects at commit; the call still runs and
+            # returns uncached.
+            try:
+                prepared = cache.prepare(call)
+            except Rejected as e:
+                logger.warning("Cache rejected prepare: %s", e.args)
+                return func(*args, **kwargs)
 
             try:
                 result: _T = func(*args, **kwargs)

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -245,6 +245,12 @@ def make_wrapper(func, policy, meta, isolate, get_call):
             except Rejected as e:
                 logger.warning("Cache rejected prepare: %s", e.args)
                 return func(*args, **kwargs)
+            except Exception:
+                # Not a policy rejection but an actual error (storage fault,
+                # lost connection, ...): still prefer running the call uncached
+                # over failing before the body ever ran.
+                logger.warning("Cache failed to prepare call", exc_info=True)
+                return func(*args, **kwargs)
 
             try:
                 result: _T = func(*args, **kwargs)
@@ -283,7 +289,6 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                             metadata[m.name], replace(call, metadata={})
                         )
                     try:
-                        call.metadata = metadata
                         logger.debug("Saving result for %s with key %s", call.name, key)
                         prepared.commit(call.result, metadata)
                     except Rejected as e:

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -201,6 +201,30 @@ def test_no_mislabeled_entry_for_mutated_state(cache):
     assert len(runs) == 2
 
 
+@pytest.mark.parametrize("exc", [Rejected("no admission"), OSError("storage down")])
+def test_prepare_failure_degrades_to_uncached(exc):
+    """A prepare that fails — policy rejection or actual error — must not stop
+    the call: the body runs and the result comes back uncached."""
+
+    class Broken(Cache):
+        def prepare(self, call):
+            raise exc
+
+    broken = Broken(ValueMemory({}), CallMemory({}))
+    runs = []
+
+    @fleche
+    def f(x):
+        runs.append(1)
+        return x + 1
+
+    with fl.cache(broken):
+        assert f(1) == 2
+        assert f(1) == 2
+    assert len(runs) == 2  # never cached: prepare fails on every call
+    assert list(broken.calls.list()) == []
+
+
 def test_body_exception_leaves_no_record(cache):
     runs = []
 

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -92,6 +92,27 @@ def test_context_manager_does_not_swallow_exceptions(cache):
     assert not cache.contains(call.to_lookup_key())
 
 
+def test_commit_is_exactly_once(cache):
+    prepared = cache.prepare(make_call(x=1))
+    prepared.commit(1)
+    with pytest.raises(RuntimeError):
+        prepared.commit(2)
+
+
+def test_abandon_is_idempotent_but_bars_commit(cache):
+    prepared = cache.prepare(make_call(x=1))
+    prepared.abandon()
+    prepared.abandon()
+    with pytest.raises(RuntimeError):
+        prepared.commit(1)
+
+
+def test_commit_does_not_mutate_the_prepared_record(cache):
+    prepared = cache.prepare(make_call(x=1))
+    prepared.commit("r")
+    assert prepared.digested.result is None
+
+
 def test_readonly_prepare_is_digest_only_and_commit_rejects(cache):
     """A read-only cache admits the call without writing anything; the
     rejection lands at commit time, after the body would have run."""
@@ -145,10 +166,9 @@ def test_wrapper_prepare_commits_through_the_wrapper(cache):
 # ---- end-to-end: argument mutation no longer corrupts identity ----
 
 
-def test_mutating_consumer_hits_on_honest_repeat():
+def test_mutating_consumer_hits_on_honest_repeat(cache):
     """A function that mutates its argument is keyed on the *pre-call* state:
     a repeat call with the same initial state is a hit."""
-    fl.cache("memory")
     runs = []
 
     @fleche
@@ -157,16 +177,16 @@ def test_mutating_consumer_hits_on_honest_repeat():
         xs.append(99)
         return sum(xs)
 
-    assert consume([1, 2]) == 102
-    assert consume([1, 2]) == 102
+    with fl.cache(cache):
+        assert consume([1, 2]) == 102
+        assert consume([1, 2]) == 102
     assert len(runs) == 1
 
 
-def test_no_mislabeled_entry_for_mutated_state():
+def test_no_mislabeled_entry_for_mutated_state(cache):
     """The post-mutation argument state is a *different* call and recomputes —
     the old behavior filed the first call under this state (a false hit that
     returned a result computed from different input)."""
-    fl.cache("memory")
     runs = []
 
     @fleche
@@ -175,13 +195,13 @@ def test_no_mislabeled_entry_for_mutated_state():
         xs.append(99)
         return len(xs)
 
-    assert consume([1, 2]) == 3
-    assert consume([1, 2, 99]) == 4      # miss: its own honest computation
+    with fl.cache(cache):
+        assert consume([1, 2]) == 3
+        assert consume([1, 2, 99]) == 4  # miss: its own honest computation
     assert len(runs) == 2
 
 
-def test_body_exception_leaves_no_record():
-    fl.cache("memory")
+def test_body_exception_leaves_no_record(cache):
     runs = []
 
     @fleche
@@ -189,8 +209,9 @@ def test_body_exception_leaves_no_record():
         runs.append(1)
         raise ValueError("no")
 
-    for _ in range(2):
-        with pytest.raises(ValueError):
-            boom(1)
-    assert len(runs) == 2                # nothing cached, body ran twice
-    assert not boom.contains(1)
+    with fl.cache(cache):
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                boom(1)
+        assert len(runs) == 2            # nothing cached, body ran twice
+        assert not boom.contains(1)

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -1,0 +1,166 @@
+"""Two-phase save protocol: Call.prepare / PreparedCall.commit / abandon.
+
+The protocol exists to fix one incoherence: the wrapper digests arguments
+*before* the function body runs (the lookup key), but the old save path
+re-digested them from their live values *after* — so a function that mutated
+an argument was recorded under post-mutation content and could never be found
+by an honest repeat call.  Under the two-phase protocol the recorded identity
+is sealed at prepare time.
+"""
+import pytest
+
+from fleche import fleche
+import fleche as fl
+from fleche.call import Call
+from fleche.caches import Cache, Rejected
+from fleche.digest import digest
+from fleche.storage.memory import ValueMemory, CallMemory
+
+
+@pytest.fixture
+def cache():
+    return Cache(ValueMemory({}), CallMemory({}))
+
+
+def make_call(**arguments):
+    return Call(name="f", arguments=arguments, module="m", version="1")
+
+
+# ---- PreparedCall lifecycle ----
+
+
+def test_prepare_seals_lookup_key(cache):
+    call = make_call(x=1, y="a")
+    prepared = cache.prepare(call)
+    assert prepared.key == call.to_lookup_key()
+
+
+def test_prepare_stores_arguments_before_commit(cache):
+    call = make_call(x=[1, 2])
+    cache.prepare(call)
+    assert cache.values.load(digest([1, 2])) == [1, 2]
+
+
+def test_commit_files_record_under_sealed_key(cache):
+    call = make_call(x=1)
+    prepared = cache.prepare(call)
+    key = prepared.commit("result", {"meta": {"k": "v"}})
+    assert key == prepared.key
+    loaded = cache.load(key)
+    assert loaded.result == "result"
+    assert loaded.metadata == {"meta": {"k": "v"}}
+
+
+def test_commit_captures_result_at_commit_time(cache):
+    """A mutated argument passed back out is stored in its *final* state."""
+    xs = [1, 2]
+    call = make_call(x=xs)
+    prepared = cache.prepare(call)
+    xs.append(3)                     # the "function body" mutates the argument
+    key = prepared.commit(xs)
+    loaded = cache.load(key)
+    assert loaded.result == [1, 2, 3]           # result: final state
+    assert loaded.arguments["x"] == [1, 2]      # argument: initial state
+
+
+def test_abandon_leaves_no_record(cache):
+    call = make_call(x=1)
+    prepared = cache.prepare(call)
+    prepared.abandon()
+    assert not cache.contains(prepared.key)
+
+
+def test_context_manager_abandons_without_commit(cache):
+    call = make_call(x=1)
+    with cache.prepare(call) as prepared:
+        pass
+    assert not cache.contains(prepared.key)
+
+
+def test_context_manager_commit_sticks(cache):
+    call = make_call(x=1)
+    with cache.prepare(call) as prepared:
+        prepared.commit(42)
+    assert cache.load(prepared.key).result == 42
+
+
+def test_context_manager_does_not_swallow_exceptions(cache):
+    call = make_call(x=1)
+    with pytest.raises(RuntimeError):
+        with cache.prepare(call) as prepared:
+            raise RuntimeError("body failed")
+    assert not cache.contains(prepared.key)
+
+
+def test_readonly_prepare_is_digest_only_and_commit_rejects(cache):
+    """A read-only cache admits the call without writing anything; the
+    rejection lands at commit time, after the body would have run."""
+    call = make_call(x=[1, 2])
+    prepared = cache.readonly().prepare(call)
+    assert prepared.key == call.to_lookup_key()
+    assert list(cache.values.list()) == []          # nothing was stashed
+    with pytest.raises(Rejected):
+        prepared.commit(42)
+    assert not cache.contains(prepared.key)
+
+
+def test_key_matches_one_shot_save(cache):
+    """prepare/commit and the legacy one-shot save file under the same key."""
+    call = make_call(x={"a": 1})
+    call.result = "r"
+    one_shot = Cache(ValueMemory({}), CallMemory({}))
+    assert cache.prepare(call).commit("r") == one_shot.save(call)
+
+
+# ---- end-to-end: argument mutation no longer corrupts identity ----
+
+
+def test_mutating_consumer_hits_on_honest_repeat():
+    """A function that mutates its argument is keyed on the *pre-call* state:
+    a repeat call with the same initial state is a hit."""
+    fl.cache("memory")
+    runs = []
+
+    @fleche
+    def consume(xs: list):
+        runs.append(1)
+        xs.append(99)
+        return sum(xs)
+
+    assert consume([1, 2]) == 102
+    assert consume([1, 2]) == 102
+    assert len(runs) == 1
+
+
+def test_no_mislabeled_entry_for_mutated_state():
+    """The post-mutation argument state is a *different* call and recomputes —
+    the old behavior filed the first call under this state (a false hit that
+    returned a result computed from different input)."""
+    fl.cache("memory")
+    runs = []
+
+    @fleche
+    def consume(xs: list):
+        runs.append(1)
+        xs.append(99)
+        return len(xs)
+
+    assert consume([1, 2]) == 3
+    assert consume([1, 2, 99]) == 4      # miss: its own honest computation
+    assert len(runs) == 2
+
+
+def test_body_exception_leaves_no_record():
+    fl.cache("memory")
+    runs = []
+
+    @fleche
+    def boom(x):
+        runs.append(1)
+        raise ValueError("no")
+
+    for _ in range(2):
+        with pytest.raises(ValueError):
+            boom(1)
+    assert len(runs) == 2                # nothing cached, body ran twice
+    assert not boom.contains(1)

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -1,4 +1,4 @@
-"""Two-phase save protocol: Call.prepare / PreparedCall.commit / abandon.
+"""Two-phase save protocol: Cache.prepare / PreparedCall.commit / abandon.
 
 The protocol exists to fix one incoherence: the wrapper digests arguments
 *before* the function body runs (the lookup key), but the old save path
@@ -12,7 +12,7 @@ import pytest
 from fleche import fleche
 import fleche as fl
 from fleche.call import Call
-from fleche.caches import Cache, Rejected
+from fleche.caches import Cache, CacheStack, RefreshingCache, Rejected
 from fleche.digest import digest
 from fleche.storage.memory import ValueMemory, CallMemory
 
@@ -32,7 +32,7 @@ def make_call(**arguments):
 def test_prepare_seals_lookup_key(cache):
     call = make_call(x=1, y="a")
     prepared = cache.prepare(call)
-    assert prepared.key == call.to_lookup_key()
+    assert prepared.digested.to_lookup_key() == call.to_lookup_key()
 
 
 def test_prepare_stores_arguments_before_commit(cache):
@@ -45,7 +45,7 @@ def test_commit_files_record_under_sealed_key(cache):
     call = make_call(x=1)
     prepared = cache.prepare(call)
     key = prepared.commit("result", {"meta": {"k": "v"}})
-    assert key == prepared.key
+    assert key == call.to_lookup_key()
     loaded = cache.load(key)
     assert loaded.result == "result"
     assert loaded.metadata == {"meta": {"k": "v"}}
@@ -67,29 +67,29 @@ def test_abandon_leaves_no_record(cache):
     call = make_call(x=1)
     prepared = cache.prepare(call)
     prepared.abandon()
-    assert not cache.contains(prepared.key)
+    assert not cache.contains(call.to_lookup_key())
 
 
 def test_context_manager_abandons_without_commit(cache):
     call = make_call(x=1)
     with cache.prepare(call) as prepared:
         pass
-    assert not cache.contains(prepared.key)
+    assert not cache.contains(call.to_lookup_key())
 
 
 def test_context_manager_commit_sticks(cache):
     call = make_call(x=1)
     with cache.prepare(call) as prepared:
         prepared.commit(42)
-    assert cache.load(prepared.key).result == 42
+    assert cache.load(call.to_lookup_key()).result == 42
 
 
 def test_context_manager_does_not_swallow_exceptions(cache):
     call = make_call(x=1)
     with pytest.raises(RuntimeError):
-        with cache.prepare(call) as prepared:
+        with cache.prepare(call):
             raise RuntimeError("body failed")
-    assert not cache.contains(prepared.key)
+    assert not cache.contains(call.to_lookup_key())
 
 
 def test_readonly_prepare_is_digest_only_and_commit_rejects(cache):
@@ -97,11 +97,11 @@ def test_readonly_prepare_is_digest_only_and_commit_rejects(cache):
     rejection lands at commit time, after the body would have run."""
     call = make_call(x=[1, 2])
     prepared = cache.readonly().prepare(call)
-    assert prepared.key == call.to_lookup_key()
+    assert prepared.digested.to_lookup_key() == call.to_lookup_key()
     assert list(cache.values.list()) == []          # nothing was stashed
     with pytest.raises(Rejected):
         prepared.commit(42)
-    assert not cache.contains(prepared.key)
+    assert not cache.contains(call.to_lookup_key())
 
 
 def test_key_matches_one_shot_save(cache):
@@ -110,6 +110,36 @@ def test_key_matches_one_shot_save(cache):
     call.result = "r"
     one_shot = Cache(ValueMemory({}), CallMemory({}))
     assert cache.prepare(call).commit("r") == one_shot.save(call)
+
+
+# ---- wrappers and stacks: storage from the inner cache, policy from the outer ----
+
+
+def test_stack_prepares_on_stack0_and_commits_through_the_stack(cache):
+    """Arguments are stashed where the stack's saves land; the commit still
+    goes through the stack itself (its ``save`` policy, not stack[0]'s)."""
+    second = Cache(ValueMemory({}), CallMemory({}))
+    stack = CacheStack([cache, second])
+    call = make_call(x=[1, 2])
+    prepared = stack.prepare(call)
+    assert prepared.cache is stack
+    key = prepared.commit([1, 2, 3])
+    assert key == call.to_lookup_key()
+    assert cache.load(key).result == [1, 2, 3]
+    assert cache.load(key).arguments["x"] == [1, 2]
+    assert not second.contains(key)
+
+
+def test_wrapper_prepare_commits_through_the_wrapper(cache):
+    """A wrapper delegates storage to its inner cache but keeps its own save
+    policy on the commit — here the refresh wrapper's write-through."""
+    wrapper = RefreshingCache(cache)
+    call = make_call(x=[1, 2])
+    prepared = wrapper.prepare(call)
+    assert prepared.cache is wrapper
+    key = prepared.commit("r")
+    assert cache.load(key).result == "r"
+    assert cache.load(key).arguments["x"] == [1, 2]
 
 
 # ---- end-to-end: argument mutation no longer corrupts identity ----

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -136,14 +136,15 @@ def test_key_matches_one_shot_save(cache):
 # ---- wrappers and stacks: storage from the inner cache, policy from the outer ----
 
 
-def test_stack_prepares_on_stack0_and_commits_through_the_stack(cache):
-    """Arguments are stashed where the stack's saves land; the commit still
-    goes through the stack itself (its ``save`` policy, not stack[0]'s)."""
+def test_stack_prepares_and_commits_on_stack0(cache):
+    """Arguments and commit both land on stack[0], where the stack's saves go;
+    the stack's own ``save`` is a pure forward, so prepare binds stack[0]
+    directly."""
     second = Cache(ValueMemory({}), CallMemory({}))
     stack = CacheStack([cache, second])
     call = make_call(x=[1, 2])
     prepared = stack.prepare(call)
-    assert prepared.cache is stack
+    assert prepared.cache is cache
     key = prepared.commit([1, 2, 3])
     assert key == call.to_lookup_key()
     assert cache.load(key).result == [1, 2, 3]

--- a/tests/unit/config/test_cache_to_config.py
+++ b/tests/unit/config/test_cache_to_config.py
@@ -112,9 +112,6 @@ def test_cache_to_config_unknown_raises():
         def load_value(self, key):
             raise KeyError(key)
 
-        def save_value(self, value):
-            return ""
-
         def evict(self, key):
             pass
 

--- a/tests/unit/config/test_cache_to_config.py
+++ b/tests/unit/config/test_cache_to_config.py
@@ -112,6 +112,9 @@ def test_cache_to_config_unknown_raises():
         def load_value(self, key):
             raise KeyError(key)
 
+        def save_value(self, value):
+            return ""
+
         def evict(self, key):
             pass
 

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -229,6 +229,7 @@ def test_dispatch_covers_every_registered_method():
         "save",
         "load",
         "load_value",
+        "save_value",
         "prepare",
         "evict",
         "contains",
@@ -310,7 +311,19 @@ def test_read_only_false_for_writable_remote(remote):
 
 def test_prepare_commit_round_trip(remote, server_cache):
     """`prepare` stashes the arguments server-side before the body runs;
-    `commit` ships the live result and files the record under the sealed key."""
+    `commit` ships the result value and then the plain digested record —
+    a PreparedCall itself never goes over the wire."""
+    from fleche.call import PreparedCall
+
+    shipped = []
+    original_call = remote._conn.call
+
+    def spy(method, *args, **kwargs):
+        shipped.append((method, args))
+        return original_call(method, *args, **kwargs)
+
+    remote._conn.call = spy  # type: ignore[method-assign]
+
     xs = [1, 2]
     c = Call(name="f", arguments={"xs": xs}, module="m", version="1")
     sealed = c.to_lookup_key()
@@ -322,6 +335,12 @@ def test_prepare_commit_round_trip(remote, server_cache):
     xs.append(3)  # the "function body" mutates the argument
     key = prepared.commit(xs)
     assert key == sealed  # NOT c.to_lookup_key(): that drifted with the mutation
+    # The commit took two trips (result value, then the record), and nothing
+    # PreparedCall-shaped ever crossed the wire.
+    assert [m for m, _ in shipped if m in ("save_value", "save")] == ["save_value", "save"]
+    assert not any(
+        isinstance(a, PreparedCall) for _, args in shipped for a in args
+    )
     lc = remote.load(key)
     assert lc.result == [1, 2, 3]  # result: as returned
     assert lc.arguments["xs"] == [1, 2]  # argument: as passed

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -30,6 +30,7 @@ from fleche.remote import (
     serve,
 )
 from fleche.storage import CallMemory, ValueMemory
+from fleche.storage.base import SaveError
 
 
 class _PipeConnection(_Connection):
@@ -344,6 +345,36 @@ def test_prepare_commit_round_trip(remote, server_cache):
     lc = remote.load(key)
     assert lc.result == [1, 2, 3]  # result: as returned
     assert lc.arguments["xs"] == [1, 2]  # argument: as passed
+
+
+def test_unstorable_result_rejects_like_local_save():
+    """A result the server's value storage refuses must reject the commit —
+    not degrade to a digest-only reference that files a dangling record."""
+
+    class PickyValues(ValueMemory):
+        __hash__ = object.__hash__
+
+        def save(self, value, key=None):
+            if value == "REFUSE_ME":
+                raise SaveError("refused")
+            return super().save(value, key)
+
+    server = Cache(PickyValues({}), CallMemory({}))
+    sc = _make_remote(server)
+    try:
+        c = Call(name="f", arguments={"x": 1}, module="m", version="1")
+        prepared = sc.prepare(c)
+        with pytest.raises(Rejected):
+            prepared.commit("REFUSE_ME")
+        assert not server.contains(c.to_lookup_key())
+    finally:
+        sc.close()
+
+
+def test_commit_none_result_round_trips(remote, server_cache):
+    c = Call(name="f", arguments={"x": 1}, module="m", version="1")
+    key = remote.prepare(c).commit(None)
+    assert remote.load(key).result is None
 
 
 def test_read_only_prepare_is_local_and_commit_rejects():

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -229,6 +229,7 @@ def test_dispatch_covers_every_registered_method():
         "save",
         "load",
         "load_value",
+        "save_value",
         "evict",
         "contains",
         "expand",

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -17,7 +17,7 @@ import fleche.state as _state
 from fleche.call import Call, QueryCall
 from fleche.caches import Cache, Rejected
 from fleche.config import cache_to_config, load_cache_config
-from fleche.digest import Digest
+from fleche.digest import Digest, digest
 from fleche.remote import (
     RemoteConnectionError,
     SshCache,
@@ -301,6 +301,59 @@ def test_read_only_short_circuits_save_and_evict():
 def test_read_only_false_for_writable_remote(remote):
     """A normal remote cache reports `read_only == False`."""
     assert remote.read_only is False
+
+
+# ---------------------------------------------------------------------------
+# Two-phase save protocol over the wire
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_commit_round_trip(remote, server_cache):
+    """`prepare` stashes the arguments server-side before the body runs;
+    `commit` ships the live result and files the record under the sealed key."""
+    xs = [1, 2]
+    c = Call(name="f", arguments={"xs": xs}, module="m", version="1")
+    sealed = c.to_lookup_key()
+    prepared = remote.prepare(c)
+    assert prepared.cache is remote
+    assert prepared.digested.to_lookup_key() == sealed
+    # The argument value is already on the server before any commit.
+    assert server_cache.values.load(digest([1, 2])) == [1, 2]
+    xs.append(3)  # the "function body" mutates the argument
+    key = prepared.commit(xs)
+    assert key == sealed  # NOT c.to_lookup_key(): that drifted with the mutation
+    lc = remote.load(key)
+    assert lc.result == [1, 2, 3]  # result: as returned
+    assert lc.arguments["xs"] == [1, 2]  # argument: as passed
+
+
+def test_read_only_prepare_is_local_and_commit_rejects():
+    """`prepare` against a read-only remote seals the key locally — no RPC,
+    nothing stashed — and the commit's `save` is rejected without a round trip."""
+    server = Cache(ValueMemory({}), CallMemory({})).readonly()
+    sc = _make_remote(server)
+    try:
+        # Trigger the info fetch once so the read_only flag is cached.
+        assert sc.read_only is True
+
+        rpc_calls = []
+        original_call = sc._conn.call
+
+        def spy(method, *args, **kwargs):
+            rpc_calls.append(method)
+            return original_call(method, *args, **kwargs)
+
+        sc._conn.call = spy  # type: ignore[method-assign]
+
+        c = Call(name="f", arguments={"xs": [1, 2]}, module="m", version="1")
+        prepared = sc.prepare(c)
+        assert prepared.digested.to_lookup_key() == c.to_lookup_key()
+        assert list(server.cache.values.list()) == []  # nothing stashed
+        with pytest.raises(Rejected):
+            prepared.commit(42)
+        assert rpc_calls == [], f"unexpected RPCs: {rpc_calls}"
+    finally:
+        sc.close()
 
 
 def test_reconnect_invalidates_info_cache(remote, server_cache):

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -229,7 +229,7 @@ def test_dispatch_covers_every_registered_method():
         "save",
         "load",
         "load_value",
-        "save_value",
+        "prepare",
         "evict",
         "contains",
         "expand",


### PR DESCRIPTION
## Problem

The wrapper digests arguments twice from live state: once before the function body runs (the lookup key, `wrapper.py`) and once after (when `Cache.save` re-stashed the call via `Call.stash`). A function that mutates an argument — appends to a received list, writes an output file into a directory it received — was therefore recorded under the **post-mutation** content:

- honest repeat calls with the original input could never hit (the function silently re-executes forever), and
- a call passing the *mutated* state would **false-hit** a result computed from different input.

## Design

fleche commits pure functions: the recorded identity of a call is the arguments **as passed**. This lands as a two-phase save protocol with a hybrid interface — the entry point on the cache, the lifecycle state in `call.py`:

- **`cache.prepare(call) -> PreparedCall`** — stores argument values and seals the lookup key *before* the body runs. Because `digest(x) == values.save(x)`, the sealed key always equals `to_lookup_key()`; lookup and record cannot drift. The `BaseCache` implementation is a digest-only admission (nothing written); `Cache` overrides it to stash into its value storage, wrappers delegate to their inner cache, and `CacheStack` prepares directly on `stack[0]`, where its saves land.
- **`PreparedCall.commit(result, metadata)`** — single-shot: hands the `PreparedCall` back to the cache's `save`, which stores the result *as returned* (a mutated argument passed back out is captured in its final state) and files the record. A second `commit`, or a `commit` after `abandon`, raises `RuntimeError`.
- **`PreparedCall.abandon()`** — releases without recording (body raised, or result uncacheable). Idempotent no-op by default; stored argument values are content-addressed orphans for GC (#826 tracks the gc-vs-in-flight race). `PreparedCall` is also a context manager that abandons when the block exits uncommitted (sync convenience; the wrapper's `Future` path calls the methods directly).

`Call → PreparedCall → DigestedCall` is one state progression in one module, and `DigestedCall` only ever holds digests: the pending result rides privately on `PreparedCall` until the cache's `save` stores it via `PreparedCall.resolve(values)` — the mirror of `Call.stash(values)`.

## Interface changes

- **`BaseCache.save` takes `PreparedCall | Call`.** A live `Call` is the degenerate one-shot form (values static, nothing to drift), so post-hoc saving — transfers, `redigest`, external callers, existing tests — keeps working unchanged; a bare `DigestedCall` still files as-is.
- **The wrapper degrades to uncached execution when `prepare` fails**: `Rejected` logs a policy warning, any other exception logs with traceback — the body runs either way, matching the existing save-side handling.
- **Remote protocol**: a `PreparedCall` never crosses the wire. `SshCache.prepare` is one round trip (the server stashes the arguments and returns the sealed record); a commit is two — a wire-only, write-gated `save_value` RPC stores the result value (strict: a storage-refused value rejects the commit, as locally), then the plain `DigestedCall` is filed. Read-only remotes admit digest-only locally and reject the commit without a round trip. `Path` values over SSH remain unsupported. A uniform `.values` facade was considered and deliberately deferred; `_RemoteValues` is its seed.
- **Read-only caches admit digest-only**: `ReadOnlyMixin.prepare` seals the key without writing anything; the commit after the body is rejected, so the call runs and returns uncached — the same observable behavior as the previous post-body save rejection.

## Behavior change

**BREAKING**: calls of argument-mutating functions are now recorded under the pre-call argument state. Such functions start hitting on honest repeats — and their side effect on the input consequently happens on cold calls only (it is neither recorded nor replayed). Caches populated under the old keying re-execute once and re-record correctly.

## Testing

- `tests/unit/call/test_prepared_call.py`: prepare/commit/abandon lifecycle, key sealing, single-shot commit guards, context-manager semantics, read-only rejection, one-shot-save key equality, prepare-failure degradation, and end-to-end mutation coherence (mutating consumer hits; mutated state is a distinct call; body exceptions leave no record).
- `tests/unit/test_remote.py` additions: prepare/commit wire round trip (sealed key survives argument mutation; nothing `PreparedCall`-shaped crosses the wire), read-only local admission with zero RPCs, unstorable-result rejection, `None`-result round trip.
- Full suite: 1661 passed, 11 skipped. `ty check src/` clean.
- Follow-up on the `temppath` branch (stacked on this PR): path-level integration tests and the `file_semantics.rst` rewrite for the new mutation semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)