### PR TITLE
docs: correct mechanistic description of number digesting

### DIFF
--- a/docs/digests/digest_equivalence.rst
+++ b/docs/digests/digest_equivalence.rst
@@ -15,9 +15,13 @@ representation that is stable across processes and Python versions (where the
 underlying object's representation allows it).
 
 Number types (``int``, ``float``, ``complex``, and subclasses) are an explicit
-exception: their digest is computed via Python's numeric hash protocol
-(``hash(value)``), which itself guarantees ``hash(1) == hash(1.0) == hash(1+0j)``.
-The type name is therefore **not** carried into the final digest for numbers, which is
+exception designed to make ``digest(1) == digest(1.0) == digest(1+0j)`` hold.
+Integers are encoded directly from their binary value; floats and complex numbers
+are first reduced to an equivalent integer via Python's numeric hash protocol
+(``hash(value)``), which guarantees ``hash(1) == hash(1.0) == hash(1+0j)``, and
+then follow the integer path.  As a consequence the concrete type name
+(``"float"``, ``"complex"``) is **not** carried into the final digest — all three
+collapse to the same ``"int"``-prefixed hash of the underlying integer — which is
 precisely why ``digest(1) == digest(1.0) == digest(1+0j)``.
 
 For all other types the type-name salt is applied normally, so


### PR DESCRIPTION
## What changed

`docs/digests/digest_equivalence.rst` described the number-digest mechanism incorrectly in two ways:

1. **Wrong algorithm for integers.** The text said "their digest is computed via Python's numeric hash protocol (`hash(value)`)" for all number types. In reality, integers bypass `hash()` entirely and are encoded directly via `int.to_bytes()` (a stable little-endian two's-complement representation). Only `float` and `complex` go through `hash()` to reduce to an equivalent integer first.

2. **Misleading type-name claim.** The text said "The type name is therefore **not** carried into the final digest for numbers." In reality the `"int"` type name *is* folded into every number digest — for `int` directly, and for `float`/`complex` via the recursive integer path they fall through to. What is *not* carried is the concrete `"float"` or `"complex"` type name, because the early `return _digest_bytes(hash(value))` discards the hash object that had already received those bytes.

The observable behaviour described (``digest(1) == digest(1.0) == digest(1+0j)`` and ``digest((1,2)) != digest([1,2])``) is and remains correct. This PR fixes only the prose explanation.

### Before (inaccurate)

> Number types (`int`, `float`, `complex`, and subclasses) are an explicit exception: their digest is computed via Python's numeric hash protocol (`hash(value)`), which itself guarantees `hash(1) == hash(1.0) == hash(1+0j)`. The type name is therefore **not** carried into the final digest for numbers …

### After (accurate)

> Number types (`int`, `float`, `complex`, and subclasses) are an explicit exception designed to make `digest(1) == digest(1.0) == digest(1+0j)` hold. Integers are encoded directly from their binary value; floats and complex numbers are first reduced to an equivalent integer via Python's numeric hash protocol (`hash(value)`), which guarantees `hash(1) == hash(1.0) == hash(1+0j)`, and then follow the integer path. As a consequence the concrete type name (`"float"`, `"complex"`) is **not** carried into the final digest — all three collapse to the same `"int"`-prefixed hash of the underlying integer …

### Code reference

`src/fleche/digest.py`, `_digest_bytes()`:
```python
m.update(t.__name__.encode())   # runs for ALL types including int
match value:
    case int():
        m.update(value.to_bytes(...))   # direct encoding, no hash()
    case Number():
        value = hash(value)             # float/complex → int
        return _digest_bytes(value)     # recursive; hits int arm above
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011NVfBtaWNSNouAVqh9z7aD)_