### PR TITLE
docs: clarify .query() return type as QueryIterator in helpers.rst

### DIFF
--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -40,7 +40,7 @@ Returns ``True`` if the result for the given call is already present in the cach
 ``.query(*args, metadata={}, **kwargs)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Returns matching cached calls from the active cache. Any argument passed as ``None`` acts as a wildcard, matching any stored value for that parameter. The ``metadata`` keyword argument accepts a dictionary of metadata tags to further filter results (e.g., ``metadata={"tags": {"project": "alpha"}}``).
+Returns a :class:`~fleche.query.QueryIterator` over matching cached calls from the active cache. Any argument passed as ``None`` acts as a wildcard, matching any stored value for that parameter. The ``metadata`` keyword argument accepts a dictionary of metadata tags to further filter results (e.g., ``metadata={"tags": {"project": "alpha"}}``). The iterator supports chainable methods such as ``.filter()``, ``.table()``, ``.count()``, ``.results()``, ``.evict()``, and more.
 
 .. warning::
 


### PR DESCRIPTION
## What changed

`docs/usage/helpers.rst` described `.query()` as:

> Returns matching cached calls from the active cache.

The actual return type is `fleche.query.QueryIterator`, a chainable lazy iterator with methods like `.filter()`, `.table()`, `.count()`, `.results()`, `.evict()`, `.transfer()`, `.sorted()`, `.unique()`, `.groupby()`, `.take()`, `.skip()`, `.only()`, `.empty()`, `.latest()`, `.oldest()`, and more. The vague description gave no indication that callers get back a rich object rather than a plain iterable of calls.

Updated the sentence to name the return type with a cross-reference to `QueryIterator` and list a representative subset of the chainable methods, making the API more discoverable. The existing pointer to `See :doc:`query` for a detailed guide` is unchanged.

### Before

> Returns matching cached calls from the active cache. Any argument passed as `None` acts as a wildcard …

### After

> Returns a `QueryIterator` over matching cached calls from the active cache. Any argument passed as `None` acts as a wildcard … The iterator supports chainable methods such as `.filter()`, `.table()`, `.count()`, `.results()`, `.evict()`, and more.

### Code reference

`src/fleche/wrapper.py`, `make_query()`:
```python
def make_query(func, policy):
    def _query_func(*args, metadata={}, **kwargs) -> Iterable[AnyCall]:
        ...
        return state._CACHE.get().query(call)   # returns QueryIterator
```

`src/fleche/query.py` line 30:
```python
class QueryIterator(Iterable[call.LazyCall]):
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011NVfBtaWNSNouAVqh9z7aD)_