### PR TITLE
test(security): close coverage gaps in get_secret_key and SignedBytes.loads

### DIFF
--- a/tests/unit/storage/test_secure_storage.py
+++ b/tests/unit/storage/test_secure_storage.py
@@ -1,7 +1,12 @@
 import pickle
 import pytest
 from fleche.storage.pickle_file import ValuePickleFile as PickleFile
-from fleche.security import normalize_secret_key
+from fleche.security import (
+    SignatureError,
+    SignedBytes,
+    get_secret_key,
+    normalize_secret_key,
+)
 
 
 def test_secure_storage_tampering(tmp_path):
@@ -179,3 +184,30 @@ def test_normalize_empty_list_returns_empty():
 def test_normalize_short_bytes_allowed():
     # HMAC has no minimum key length requirement
     assert normalize_secret_key(b"short") == [b"short"]
+
+
+# --- get_secret_key tests ---
+
+def test_get_secret_key_reads_env_var(monkeypatch):
+    # FLECHE_SECRET_KEY carries the same colon-separated hex format that
+    # normalize_secret_key accepts; get_secret_key must route through it so a
+    # value set in the environment produces the same keys as the programmatic
+    # secret_key= argument.
+    k1, k2 = "ab" * 16, "cd" * 16
+    monkeypatch.setenv("FLECHE_SECRET_KEY", f"{k1}:{k2}")
+    assert get_secret_key() == [bytes.fromhex(k1), bytes.fromhex(k2)]
+
+
+# --- SignedBytes.loads corruption paths ---
+
+def test_signed_bytes_loads_raises_on_missing_stop_opcode():
+    # loads() locates the signature boundary by rfind(pickle.STOP); a payload
+    # that never contains the STOP opcode is either corruption or a wire
+    # format the signer never produced. It must surface as SignatureError so
+    # PickleFileBackend._from_file can translate it to KeyError (cache miss)
+    # rather than crashing with an out-of-band exception.
+    signer = SignedBytes(keys=[b"K" * 32])
+    payload_without_stop = b"garbage bytes with no dot"
+    assert pickle.STOP not in payload_without_stop
+    with pytest.raises(SignatureError, match="No STOP opcode found"):
+        signer.loads(payload_without_stop)


### PR DESCRIPTION
## Motivation

Baseline branch coverage on `main`:

```
Name                            Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------
src/fleche/security.py             57      3     26      2    94%   76, 145-146
```

`security.py` was the smallest module with real, testable coverage gaps
(everything below it was either a minority-branch import-fallback
— `_attrs.py` needs `attrs` uninstalled, `__init__.py:5-6` needs
`_version.py` missing — or dead-code past `parser.error` in
`__main__.py`). Two branches in `security.py` were unexercised:

- **`get_secret_key` line 76 (branch [75, 76]).** No test set
  `FLECHE_SECRET_KEY`, so the True side of `if env_key:` was never
  taken. Consequence: the contract that the env var and the programmatic
  `secret_key=` argument accept the same colon-separated hex format
  (both routing through `normalize_secret_key`) was implicit rather
  than pinned.
- **`SignedBytes.loads` lines 145-146 (branch [144, 145]).** `loads()`
  has two corruption paths: an empty-signature branch and a
  missing-STOP-opcode branch. The empty-signature side was covered by
  `test_secure_storage_unsigned_data_fails_when_auth_enabled` (unsigned
  pickle bytes still contain a STOP), but no test fed `loads()` bytes
  without any STOP opcode at all. That is the exact shape a truncated
  or non-pickle payload would take, and `PickleFileBackend._from_file`
  relies on it surfacing as `SignatureError` so it can be translated to
  a `KeyError` (cache miss) rather than crashing with an out-of-band
  exception.

## Change

Two new tests in `tests/unit/storage/test_secure_storage.py`, one per
gap. They are direct unit tests against `fleche.security` — no routing
through `PickleFile` — so they stay orthogonal to the existing
integration tests in the same file:

- `test_get_secret_key_reads_env_var` — `monkeypatch.setenv` a
  colon-separated hex value, assert the decoded key list.
- `test_signed_bytes_loads_raises_on_missing_stop_opcode` — feed
  `loads()` bytes that contain no `pickle.STOP` (asserted inline), assert
  `SignatureError("No STOP opcode found")`.

## Coverage report

Full-suite `pytest tests/ --cov=src/fleche --cov-branch` before and after this PR:

| Module            | Before | After |
|-------------------|--------|-------|
| `security.py`     | 94%    | **100%** |
| TOTAL statements  | 96%    | 96%    |
| TOTAL branches    | 93%    | 93%    |
| Missing stmts     | 109    | **106** |
| Missing branches  | 59     | **57**  |
| Tests passed      | 1656   | 1658   |

Per-module table on this PR (unchanged rows collapsed for space):

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        360     20     92      6    94%
src/fleche/call.py                          241      8     62      5    96%
src/fleche/config.py                        198      3     88      2    98%
src/fleche/digest.py                        176      7    100      8    95%
src/fleche/executor.py                       38      0     12      0   100%
src/fleche/metadata.py                       70      2      4      0    97%
src/fleche/query.py                         127      0     50      1    99%
src/fleche/remote.py                        369     26     82     13    91%
src/fleche/security.py                       57      0     26      0   100%
src/fleche/state.py                          70      1     16      1    98%
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py     169      7     58      4    95%
src/fleche/storage/base.py                  146      2     34      2    98%
src/fleche/storage/destructuring.py         178      2     46      1    99%
src/fleche/storage/file.py                   54      0      4      0   100%
src/fleche/storage/memory.py                 41      0      2      0   100%
src/fleche/storage/pickle_file.py            96      5     16      3    93%
src/fleche/storage/sql.py                   249     10     88      6    95%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/storage/void.py                   26      1      0      0    96%
src/fleche/wrapper.py                       200      3     50      1    98%
---------------------------------------------------------------------------
TOTAL                                      2986    106    846     57    96%
1658 passed, 11 skipped in 377.05s
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnN8AhtojncTetENptVqJ4)_