### PR TITLE
refactor(storage): share expand's prefix-candidate lookup between KeyManagement and Sql

### DIFF
--- a/src/fleche/storage/base.py
+++ b/src/fleche/storage/base.py
@@ -240,8 +240,17 @@ class KeyManagement(OperationContext):
             if len(key) < 4:
                 raise KeyError(key)
 
-            candidates = sorted(k for k in self.list() if k.startswith(key))
-            return _resolve_prefix(str(key), candidates[:2])
+            return _resolve_prefix(str(key), self._prefix_candidates(str(key)))
+
+    def _prefix_candidates(self, prefix: str) -> "Iterable[Digest]":
+        """Return at most the two lexicographically smallest keys starting with *prefix*.
+
+        Default: a Python-side filter over :meth:`list`. Override for a
+        backend that can push the prefix scan down (e.g. SQL ``LIKE ... LIMIT
+        2``); :meth:`expand` only needs the two smallest candidates to decide
+        between a unique match and an :class:`AmbiguousDigestError`.
+        """
+        return sorted(k for k in self.list() if k.startswith(prefix))[:2]
 
     @overload
     def shrink(self, key: Digest | str, /) -> Digest: ...

--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -5,7 +5,7 @@ import threading
 from typing import Iterable, Any, List
 from pathlib import Path
 from dataclasses import dataclass, field
-from .base import Intent, KeyManagement, CallStorage, _resolve_prefix, register_storage
+from .base import Intent, KeyManagement, CallStorage, register_storage
 from .thread_safe import PerKeyLockMixin
 from ..call import DigestedCall, QueryCall
 from ..digest import Digest, DIGEST_LENGTH, digest
@@ -298,21 +298,14 @@ class Sql(PerKeyLockMixin, CallStorage):
         with self._session_context():
             return [Digest(row[0]) for row in self._local.session.execute(select(CallModel.key))]
 
-    def expand(self, key: Digest | str) -> Digest:
-        with self._operation_context(key):
-            if len(key) >= DIGEST_LENGTH:
-                return Digest(str(key))
-            if len(key) < 4:
-                raise KeyError(key)
-
-            prefix = str(key)
-            rows = self._local.session.execute(
-                select(CallModel.key)
-                .where(CallModel.key.like(f"{prefix}%"))
-                .order_by(CallModel.key)
-                .limit(2)
-            ).all()
-            return _resolve_prefix(prefix, [Digest(r[0]) for r in rows])
+    def _prefix_candidates(self, prefix: str) -> Iterable[Digest]:
+        rows = self._local.session.execute(
+            select(CallModel.key)
+            .where(CallModel.key.like(f"{prefix}%"))
+            .order_by(CallModel.key)
+            .limit(2)
+        ).all()
+        return [Digest(r[0]) for r in rows]
 
     def _evict(self, key: Digest) -> None:
         session = self._local.session

--- a/tests/unit/storage/test_short_digest.py
+++ b/tests/unit/storage/test_short_digest.py
@@ -1,6 +1,8 @@
 import pytest
 from fleche.storage import AmbiguousDigestError, ValueMemory
 from fleche.storage.base import _longest_common_prefix_length
+from fleche.storage.sql import Sql
+from fleche.call import DigestedCall
 from fleche.digest import DIGEST_LENGTH
 
 
@@ -58,6 +60,41 @@ def test_missing_digest():
 
     with pytest.raises(KeyError):
         store.expand("ffff")
+
+
+class TestPrefixCandidates:
+    # Direct tests for the `_prefix_candidates` hook extracted from `expand`
+    # (issue #759) — the base Python-side filter vs. Sql's SQL `LIKE ... LIMIT
+    # 2` pushdown. Called directly (bypassing `expand`'s length guard) so the
+    # candidate-fetching strategy is pinned in isolation.
+
+    def test_default_returns_two_smallest_matching_prefix(self):
+        store = ValueMemory({})
+        store.save("v1", "a" * 10 + "3" + "a" * 53)
+        store.save("v2", "a" * 10 + "1" + "a" * 53)
+        store.save("v3", "a" * 10 + "2" + "a" * 53)
+        store.save("v4", "b" * 64)
+
+        assert store._prefix_candidates("a" * 10) == sorted(
+            k for k in store.list() if k.startswith("a" * 10)
+        )[:2]
+
+    def test_default_returns_single_match(self):
+        store = ValueMemory({})
+        store.save("v1", "b" * 64)
+        store.save("v2", "c" * 64)
+
+        assert store._prefix_candidates("b") == ["b" * 64]
+
+    def test_sql_prefix_candidates_pushes_down_to_sql(self, tmp_path):
+        store = Sql(tmp_path / "calls.db")
+        keys = sorted(
+            store.save(DigestedCall(name=f"f{i}", arguments={}))
+            for i in range(3)
+        )
+
+        with store._operation_context(""):
+            assert store._prefix_candidates("") == [keys[0], keys[1]]
 
 
 class TestLongestCommonPrefixLength:


### PR DESCRIPTION
Closes #759.

## What

`KeyManagement.expand` (`src/fleche/storage/base.py`) and `Sql.expand`
(`src/fleche/storage/sql.py`) duplicated the `_operation_context` entry, the
two length guards, and the `_resolve_prefix` call — the only real difference
was how each backend fetched candidate keys:

```python
# KeyManagement.expand — Python-side filter over list()
candidates = sorted(k for k in self.list() if k.startswith(key))
return _resolve_prefix(str(key), candidates[:2])

# Sql.expand — SQL LIKE … LIMIT 2 pushdown
rows = self._local.session.execute(
    select(CallModel.key).where(CallModel.key.like(f"{prefix}%"))
    .order_by(CallModel.key).limit(2)
).all()
return _resolve_prefix(prefix, [Digest(r[0]) for r in rows])
```

Extracted the differing piece into an overridable
`_prefix_candidates(prefix) -> Iterable[Digest]` hook on `KeyManagement`;
`expand()` is now defined once, calling the hook after its length guards.
`Sql` only implements `_prefix_candidates` (its SQL pushdown) and no longer
overrides `expand` at all. Mirrors the `_apply_shrink` split PR #742 landed
for `shrink()`.

## Testing

- Added direct tests for the extracted hook in
  `tests/unit/storage/test_short_digest.py`: the base default (`ValueMemory`)
  and the `Sql` SQL-pushdown override, alongside the existing `expand()`-level
  integration coverage (which is unchanged and still passes).
- `pytest tests/unit tests/regression -q` — 1617 passed, 7 skipped.
- `ruff check src/fleche/storage/base.py src/fleche/storage/sql.py tests/unit/storage/test_short_digest.py` — clean (one pre-existing unrelated `F401` on `sql.py`'s unused `KeyManagement` import predates this change).

Behavior-preserving; no change to `expand`'s observable semantics on any backend.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KP5rF68T9C6F3HoWVk3ERD)_