### PR TITLE
fix(benchmarks): don't measure hit-phase timing against evicted keys

### DIFF
--- a/benchmarks/benchmark_integration.py
+++ b/benchmarks/benchmark_integration.py
@@ -107,6 +107,19 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         }
     )
 
+    # SizeLimitedCache evicts uniformly at random (see
+    # SizeLimitedMixin._pick_eviction_target), so populating a cache smaller
+    # than ``iterations`` with unique keys does not guarantee any particular
+    # subset of them survives. The "hit"-style phases below must only reuse
+    # args that are actually still resident, otherwise they silently
+    # re-measure misses (and re-inserts) for the evicted ones.
+    resident_args = []
+    with cache(cache_obj):
+        for i in range(iterations):
+            arg = args[i] if isinstance(args, list) else i
+            if func.contains(arg):
+                resident_args.append(arg)
+
     # 2. Contains (Cache Check - Miss)
     contains_miss_times = []
     for i in range(iterations):
@@ -133,8 +146,7 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
 
     # 3. Contains (Cache Check - Hit)
     contains_hit_times = []
-    for i in range(iterations):
-        arg = args[i] if isinstance(args, list) else i
+    for arg in resident_args:
         # Use .contains method exposed by @fleche to get the key and pass to contains
         start = time.perf_counter()
         with cache(cache_obj):
@@ -146,17 +158,15 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         {
             "benchmark": "integration_contains_hit",
             "name": name,
-            "iterations": iterations,
+            "iterations": len(resident_args),
             "time": min(contains_hit_times),
         }
     )
 
-    # 4. Second Call (Hit)
+    # 4. Second Call (Hit). Only args still resident after the miss phase
+    # (see ``resident_args`` above) are reused here.
     hit_times = []
-    # Reuse the same args from above, they are now in cache
-    for i in range(iterations):
-        arg = args[i] if isinstance(args, list) else i
-
+    for arg in resident_args:
         start = time.perf_counter()
         with cache(cache_obj):
             func(arg)
@@ -167,7 +177,7 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         {
             "benchmark": "integration_hit",
             "name": name,
-            "iterations": iterations,
+            "iterations": len(resident_args),
             "time": min(hit_times),
         }
     )

--- a/benchmarks/benchmark_integration.py
+++ b/benchmarks/benchmark_integration.py
@@ -107,19 +107,6 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         }
     )
 
-    # SizeLimitedCache evicts uniformly at random (see
-    # SizeLimitedMixin._pick_eviction_target), so populating a cache smaller
-    # than ``iterations`` with unique keys does not guarantee any particular
-    # subset of them survives. The "hit"-style phases below must only reuse
-    # args that are actually still resident, otherwise they silently
-    # re-measure misses (and re-inserts) for the evicted ones.
-    resident_args = []
-    with cache(cache_obj):
-        for i in range(iterations):
-            arg = args[i] if isinstance(args, list) else i
-            if func.contains(arg):
-                resident_args.append(arg)
-
     # 2. Contains (Cache Check - Miss)
     contains_miss_times = []
     for i in range(iterations):
@@ -146,7 +133,8 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
 
     # 3. Contains (Cache Check - Hit)
     contains_hit_times = []
-    for arg in resident_args:
+    for i in range(iterations):
+        arg = args[i] if isinstance(args, list) else i
         # Use .contains method exposed by @fleche to get the key and pass to contains
         start = time.perf_counter()
         with cache(cache_obj):
@@ -158,15 +146,17 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         {
             "benchmark": "integration_contains_hit",
             "name": name,
-            "iterations": len(resident_args),
+            "iterations": iterations,
             "time": min(contains_hit_times),
         }
     )
 
-    # 4. Second Call (Hit). Only args still resident after the miss phase
-    # (see ``resident_args`` above) are reused here.
+    # 4. Second Call (Hit)
     hit_times = []
-    for arg in resident_args:
+    # Reuse the same args from above, they are now in cache
+    for i in range(iterations):
+        arg = args[i] if isinstance(args, list) else i
+
         start = time.perf_counter()
         with cache(cache_obj):
             func(arg)
@@ -177,7 +167,7 @@ def benchmark_integration(name, cache_obj, func, args, iterations=10):
         {
             "benchmark": "integration_hit",
             "name": name,
-            "iterations": len(resident_args),
+            "iterations": iterations,
             "time": min(hit_times),
         }
     )
@@ -211,12 +201,13 @@ def main():
                     Sql(f"sqlite:///{tmp_dir}/db_h5.sqlite"),
                 ),
             ),
-            # SizeLimitedCache: max_size smaller than iterations → evictions occur
-            (
-                "SizeLimitedCache(Memory,max=10)",
-                SizeLimitedCache(ValueMemory({}), CallMemory({}), max_size=10),
-            ),
-            # SizeLimitedCache: max_size larger than iterations → no evictions
+            # SizeLimitedCache. ``max_size`` must stay above the total number
+            # of calls this config accumulates — the instance is shared by all
+            # three functions below, so it ends up holding
+            # 3 * iterations == 60 call records. Anything smaller triggers
+            # evictions, and because SizeLimitedMixin._pick_eviction_target
+            # evicts uniformly at random there is no way to tell which keys
+            # survive; the hit phases would then silently re-measure misses.
             (
                 "SizeLimitedCache(Memory,max=100)",
                 SizeLimitedCache(ValueMemory({}), CallMemory({}), max_size=100),


### PR DESCRIPTION
## Summary

`SizeLimitedMixin._pick_eviction_target` evicts **uniformly at random**, and `max_size` caps call records for the whole cache instance — `main()`'s `SizeLimitedCache` configs are shared across all three benchmarked functions (`lightweight`/`compute_heavy`/`data_heavy`), so a config accumulates `3 * iterations = 60` call records over its lifetime. The old `SizeLimitedCache(Memory,max=10)` config therefore held only 10 of those 60 keys at any time, and the "contains hit"/"hit" phases blindly reused all 20 args per function assuming they were still resident — most of those calls were silently re-measuring **misses** (recompute + re-save), corrupting the reported hit-phase timing.

Per @pmrv's review feedback, fixed by removing the undersized config rather than adding residency-tracking logic: dropped `SizeLimitedCache(Memory,max=10)` and kept only `SizeLimitedCache(Memory,max=100)`, whose capacity (100) exceeds the 60 records this config ever accumulates, so no eviction occurs and every "hit"-phase call is a genuine hit. The measurement loop itself is unchanged — the whole diff is in the config list.

Any `max_size` large enough to stop evicting (≥ 60) would make a second entry a duplicate of the existing `max=100` config, so a differently-sized "with evictions" variant wasn't reintroduced.

## Test plan
- [x] `python benchmarks/benchmark_integration.py` runs end-to-end, valid JSON, 72 results (was 84 with the extra config)
- [x] `SizeLimitedCache` hit-phase results now report `iterations: 20` (genuine hits) for all three functions
- [x] `ruff check` / `ruff format --check` pass on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzs4Bw7dsBUC4bXhhjWmoQ