### PR TITLE
docs: standardise decorator examples to @fleche() across all docs

### DIFF
--- a/docs/digests/digests_as_args.rst
+++ b/docs/digests/digests_as_args.rst
@@ -15,11 +15,11 @@ You can use the convenience wrapper ``D`` to mark a string as a value digest:
     >>> from fleche import fleche, D
     >>> from fleche.digest import digest
 
-    >>> @fleche
+    >>> @fleche()
     ... def func_a(x):
     ...     return x + 1
 
-    >>> @fleche
+    >>> @fleche()
     ... def func_b(y):
     ...     return y * 2
 
@@ -57,7 +57,7 @@ storage without importing ``fleche.digest.digest`` yourself.
 
      >>> from fleche import fleche, cache, D
 
-     >>> @fleche
+     >>> @fleche()
      ... def compute(x):
      ...     return x * 2
 

--- a/docs/storage/cache_stack.rst
+++ b/docs/storage/cache_stack.rst
@@ -25,7 +25,7 @@ Example
     >>> local_cache = Cache(ValueMemory({}), CallMemory({}))
     >>> remote_cache = Cache(ValueMemory({}), CallMemory({}))
 
-    >>> @fleche
+    >>> @fleche()
     ... def my_function(x):
     ...     return x * 2
 

--- a/docs/usage/helpers.rst
+++ b/docs/usage/helpers.rst
@@ -73,7 +73,7 @@ Optionally pre-applies ``*args`` and ``**kwargs`` via :func:`functools.partial`.
 
    >>> from fleche import fleche, cache
 
-   >>> @fleche
+   >>> @fleche()
    ... def add(a, b):
    ...     return a + b
 
@@ -125,7 +125,7 @@ The original, undecorated function is always accessible via the ``.__wrapped__``
 
 .. code-block:: pycon
 
-   >>> @fleche
+   >>> @fleche()
    ... def my_func(x):
    ...     return x * 2
 
@@ -213,7 +213,7 @@ Usage with Decorated Methods
       ...     def __digest__(self) -> Digest:
       ...         return digest((type(self).__name__, self.id))
       ...
-      ...     @fleche
+      ...     @fleche()
       ...     def compute(self, x):
       ...         return x ** 2
 

--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -19,7 +19,7 @@ The wrapper-based API builds the correct Call template for you.
 
    >>> from fleche import fleche, cache, tags
 
-   >>> @fleche
+   >>> @fleche()
    ... def add(a, b):
    ...     return a + b
 


### PR DESCRIPTION
## Summary

Several code examples used `@fleche` (without parentheses) while the
introductory TL;DR and the majority of the documentation used `@fleche()`.
Both forms are functionally identical — the decorator's `_func` parameter
accepts a callable directly — but mixing them without explanation leaves
readers wondering whether there is a distinction.

This PR standardises all example code blocks to `@fleche()` to match the
form shown in `docs/usage/tldr.rst` (the first entry point for new users).

## Files changed

| File | Occurrences fixed |
|---|---|
| `docs/usage/helpers.rst` | 3 (`.bind()` example, `.__wrapped__` example, decorated-method example) |
| `docs/storage/cache_stack.rst` | 1 (CacheStack usage example) |
| `docs/digests/digests_as_args.rst` | 3 (`func_a`, `func_b`, and `compute` function definitions) |
| `docs/usage/query.rst` | 1 (wrapper query example) |

No behaviour changes — purely documentation consistency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcbUnF2dPVsJEedAsvbQmD)_