### PR TITLE
fix(config): resolve relative fleche.toml paths against the file's own directory

### DIFF
--- a/agents/USAGE.md
+++ b/agents/USAGE.md
@@ -78,6 +78,12 @@ So a project-local `./fleche.toml` overrides `~/fleche.toml`, which
 overrides the XDG fallback. If no file is found anywhere, fleche silently
 falls back to an in-memory-only cache — no error is raised.
 
+A relative `root`/`url` inside a `fleche.toml` resolves against **the
+directory containing that file**, not the CWD the process happens to run
+from — so the same config file resolves to the same cache location
+regardless of which subdirectory the walk found it from. Absolute and
+`~`-prefixed paths are unaffected.
+
 To stop that upward inheritance, set `root = true` in a file's `[default]`
 table. The walk halts at the closest `root` file: files farther up the tree
 (and the XDG fallback) are ignored, so only that file and any closer to the

--- a/src/fleche/config.py
+++ b/src/fleche/config.py
@@ -206,6 +206,20 @@ All discovered files are **shallow-merged** at the top level: files closer
 to the CWD win, and a closer file's top-level table fully replaces the
 same key in a farther file (tables are *not* recursively merged).
 
+Relative paths
+--------------
+
+A relative ``root`` (storage/template) or ``url`` (``sql`` calls) is
+resolved against the directory containing the ``fleche.toml`` that declared
+it, not against the process's current working directory.  This is what
+makes a checked-in, machine-portable config file resolve to the *same*
+cache location no matter which subdirectory it is read from during the
+walk above.  Absolute paths and ``~``-prefixed paths are unaffected.  This
+resolution only happens for paths read from a config file — a ``root``/
+``url`` passed directly to :func:`cache_from_config` or
+:func:`storage_from_config` still resolves against the CWD, as it always
+has.
+
 Stopping the walk
 -----------------
 
@@ -236,13 +250,82 @@ logger = logging.getLogger("fleche.config")
 _live_caches: dict[str | None, caches.BaseCache] = {}
 
 
+def _rebase_relative_path(value: str, base: Path) -> str:
+    """Anchor a relative ``root``-style path onto *base*.
+
+    Absolute paths and ``~``-prefixed paths already mean the same thing
+    regardless of where the declaring file lives, so they pass through
+    unchanged.
+    """
+    if value.startswith("~"):
+        return value
+    path = Path(value)
+    if path.is_absolute():
+        return value
+    return str(base / path)
+
+
+def _rebase_url(value: str, base: Path) -> str:
+    """Anchor the ``calls.url`` key onto *base*.
+
+    ``url`` may be a bare filesystem path (same handling as ``root``) or a
+    SQLAlchemy URL. Only a relative ``sqlite:///<path>`` URL needs rebasing;
+    ``:memory:``, an absolute sqlite URL (``sqlite:////...``), a
+    ``~``-prefixed path, and non-sqlite dialects (``postgresql://``, ...)
+    are left untouched.
+    """
+    prefix = "sqlite:///"
+    if value.startswith(prefix):
+        db_path = value[len(prefix):]
+        if not db_path or db_path == ":memory:" or db_path.startswith(("/", "~")):
+            return value
+        return prefix + str(base / Path(db_path))
+    if "://" in value or value.startswith("sqlite:"):
+        return value
+    return _rebase_relative_path(value, base)
+
+
+def _rebase_value(value: Any, base: Path) -> Any:
+    """Recurse through a parsed TOML value, rebasing ``root``/``url`` strings."""
+    if isinstance(value, dict):
+        return _rebase_config(value, base)
+    if isinstance(value, list):
+        return [_rebase_value(v, base) for v in value]
+    return value
+
+
+def _rebase_config(config: dict[str, Any], base: Path) -> dict[str, Any]:
+    """Rewrite relative ``root``/``url`` path values in *config* onto *base*.
+
+    Applied to a config file's parsed content right after loading, so a
+    relative path in ``fleche.toml`` means "relative to the file that
+    declared it" instead of "relative to whatever directory the process
+    happens to run from" (#810) — the config-discovery walk means the same
+    file can otherwise be read from many different working directories.
+    ``root`` (values/calls storage, templates) and ``url`` (``sql`` call
+    storage) are the only path-bearing keys; everything else — including
+    the unrelated boolean ``[default].root`` marker and remote-side keys
+    like ``workdir`` on an ``ssh`` entry — passes through untouched.
+    """
+    rebased: dict[str, Any] = {}
+    for key, value in config.items():
+        if key == "root" and isinstance(value, str):
+            rebased[key] = _rebase_relative_path(value, base)
+        elif key == "url" and isinstance(value, str):
+            rebased[key] = _rebase_url(value, base)
+        else:
+            rebased[key] = _rebase_value(value, base)
+    return rebased
+
+
 def _load_config(path: Path) -> dict[str, Any]:
     try:
         with open(path, "rb") as f:
-            return tomllib.load(f)
+            config = tomllib.load(f)
     except Exception as e:
         logger.error("Failed to load configuration from %s: %s", path, e, exc_info=True)
         return {}
+    return _rebase_config(config, path.parent)
 
 
 def _collect_config_paths() -> list[Path]:

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -5,7 +5,15 @@ import pytest
 from dataclasses import dataclass
 
 from fleche import state, storage, cache
-from fleche.config import load_cache_config, load_default_metadata, _live_caches
+from fleche.config import (
+    load_cache_config,
+    load_default_metadata,
+    _live_caches,
+    _load_merged_config,
+    _rebase_config,
+    _rebase_relative_path,
+    _rebase_url,
+)
 from fleche.caches import Cache, BaseCache, SizeLimitedCache, ReadOnlyCache, CacheStack
 from fleche.metadata import Runtime
 
@@ -134,9 +142,11 @@ def test_load_cache_config_specific(monkeypatch, config_file):
 
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.ValuePickleFile)
-    assert cache_obj.values.root == Path(".fleche/values").absolute()
+    # Relative `root` resolves against the declaring file's directory
+    # ($XDG_CONFIG_HOME/fleche/cache.toml here), not the CWD (#810).
+    assert cache_obj.values.root == Path(config_file) / "fleche" / ".fleche/values"
     assert isinstance(cache_obj.calls, storage.CallPickleFile)
-    assert cache_obj.calls.root == Path(".fleche/calls").absolute()
+    assert cache_obj.calls.root == Path(config_file) / "fleche" / ".fleche/calls"
 
 
 def test_load_cache_config_no_file(monkeypatch):
@@ -840,3 +850,252 @@ def test_walk_root_false_still_merges(home_and_project):
     """)
     # root = false → farther file still merged → 'home_only' resolves (void).
     assert isinstance(load_cache_config().values, storage.ValueVoid)
+
+
+# ---------------------------------------------------------------------------
+# Relative path resolution against the declaring file, not the CWD (#810)
+# ---------------------------------------------------------------------------
+
+
+def test_relative_root_resolves_against_config_dir_not_cwd(monkeypatch, home_and_project):
+    """A relative `root` anchors to the config file's directory, not the CWD."""
+    home, project = home_and_project
+    nested = project / "nested" / "deeper"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    _write_config(project, """
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "cloudpickle"
+        values.root = "fleche/values"
+        calls.type = "cloudpickle"
+        calls.root = "fleche/calls"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.values.root == project / "fleche" / "values"
+    assert cache_obj.calls.root == project / "fleche" / "calls"
+    # In particular, NOT anchored to the CWD it happened to be read from.
+    assert cache_obj.values.root != nested / "fleche" / "values"
+
+
+def test_same_config_shares_cache_across_different_cwds(monkeypatch, home_and_project):
+    """Reproduces the #810 scenario: one config, read from two CWDs, one cache.
+
+    Before the fix, each CWD resolved the relative `root` against itself,
+    silently splitting a single project cache into one private cache per
+    working directory.
+    """
+    home, project = home_and_project
+    _write_config(project, """
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "cloudpickle"
+        values.root = "fleche/values"
+        calls.type = "cloudpickle"
+        calls.root = "fleche/calls"
+    """)
+
+    monkeypatch.chdir(project)
+    root_from_project = load_cache_config().values.root
+
+    _live_caches.clear()
+    state._DEFAULTS.clear()
+    deeper = project / "sub" / "deeper"
+    deeper.mkdir(parents=True)
+    monkeypatch.chdir(deeper)
+    root_from_deeper = load_cache_config().values.root
+
+    assert root_from_project == root_from_deeper == project / "fleche" / "values"
+
+
+def test_relative_root_in_home_file_anchors_to_home_not_project(monkeypatch, home_and_project):
+    """A farther ($HOME) file's own relative paths anchor to $HOME, not the CWD."""
+    home, project = home_and_project
+    _write_config(home, """
+        [homecache]
+        values.type = "cloudpickle"
+        values.root = "fleche/values"
+        calls.type = "cloudpickle"
+        calls.root = "fleche/calls"
+    """)
+    _write_config(project, """
+        [default]
+        cache = "homecache"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.values.root == home / "fleche" / "values"
+
+
+def test_absolute_root_unaffected(monkeypatch, home_and_project, tmp_path):
+    """An absolute `root` is untouched by the rebase."""
+    _, project = home_and_project
+    elsewhere = tmp_path / "elsewhere"
+    _write_config(project, f"""
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "memory"
+        calls.type = "memory"
+
+        [abs]
+        values.type = "cloudpickle"
+        values.root = "{elsewhere / "values"}"
+        calls.type = "cloudpickle"
+        calls.root = "{elsewhere / "calls"}"
+    """)
+
+    cache_obj = load_cache_config("abs")
+    assert cache_obj.values.root == elsewhere / "values"
+
+
+def test_home_prefixed_root_unaffected(home_and_project):
+    """A `~`-prefixed `root` still expands to the user's home, not the config dir."""
+    _, project = home_and_project
+    _write_config(project, """
+        [default]
+        cache = "tilde"
+
+        [tilde]
+        values.type = "cloudpickle"
+        values.root = "~/.fleche/values"
+        calls.type = "cloudpickle"
+        calls.root = "~/.fleche/calls"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.values.root == Path("~/.fleche/values").expanduser()
+
+
+def test_relative_sql_url_bare_path_resolves_against_config_dir(home_and_project):
+    """A bare relative `calls.url` (sql) anchors to the config file's directory."""
+    _, project = home_and_project
+    _write_config(project, """
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "memory"
+        calls.type = "sql"
+        calls.url = "fleche/calls.db"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.calls.url == f"sqlite:///{project / 'fleche' / 'calls.db'}"
+
+
+def test_relative_sql_url_scheme_resolves_against_config_dir(home_and_project):
+    """A `sqlite:///<relative path>` `calls.url` anchors to the config file's directory."""
+    _, project = home_and_project
+    _write_config(project, """
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "memory"
+        calls.type = "sql"
+        calls.url = "sqlite:///fleche/calls.db"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.calls.url == f"sqlite:///{project / 'fleche' / 'calls.db'}"
+
+
+def test_absolute_sql_url_unaffected(home_and_project, tmp_path):
+    """An absolute `sqlite:////...` `calls.url` is untouched by the rebase."""
+    _, project = home_and_project
+    db_path = tmp_path / "elsewhere" / "calls.db"
+    _write_config(project, f"""
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "memory"
+        calls.type = "sql"
+        calls.url = "sqlite:///{db_path}"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.calls.url == f"sqlite:///{db_path}"
+
+
+def test_memory_sql_url_unaffected(home_and_project):
+    """`sqlite:///:memory:` is untouched by the rebase."""
+    _, project = home_and_project
+    _write_config(project, """
+        [default]
+        cache = "local"
+
+        [local]
+        values.type = "memory"
+        calls.type = "sql"
+        calls.url = "sqlite:///:memory:"
+    """)
+
+    cache_obj = load_cache_config()
+    assert cache_obj.calls.url == "sqlite:///:memory:"
+
+
+def test_ssh_workdir_not_rebased(home_and_project):
+    """`workdir` on an `ssh` cache entry names a path on the *remote* host.
+
+    It must not be rewritten as though it were local to the config file —
+    only `root`/`url` are treated as local filesystem paths.
+    """
+    _, project = home_and_project
+    _write_config(project, """
+        [[shared]]
+        values.type = "memory"
+        calls.type = "memory"
+
+        [[shared]]
+        type = "ssh"
+        host = "user@example.com"
+        workdir = "relative/remote/dir"
+    """)
+
+    config = _load_merged_config()
+    ssh_entry = config["shared"][1]
+    assert ssh_entry["workdir"] == "relative/remote/dir"
+
+
+def test_rebase_config_leaves_default_root_boolean_alone():
+    """The unrelated boolean `[default].root = true` marker is not a path."""
+    base = Path("/some/config/dir")
+    config = {"default": {"cache": "x", "root": True}}
+    assert _rebase_config(config, base) == {"default": {"cache": "x", "root": True}}
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("fleche/values", "/base/fleche/values"),
+        ("./fleche/values", "/base/fleche/values"),
+        ("/abs/fleche/values", "/abs/fleche/values"),
+        ("~/.fleche/values", "~/.fleche/values"),
+    ],
+)
+def test_rebase_relative_path(value, expected):
+    assert _rebase_relative_path(value, Path("/base")) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("fleche/calls.db", "/base/fleche/calls.db"),
+        ("sqlite:///fleche/calls.db", "sqlite:////base/fleche/calls.db"),
+        ("sqlite:////abs/calls.db", "sqlite:////abs/calls.db"),
+        ("sqlite:///:memory:", "sqlite:///:memory:"),
+        ("sqlite:///~/.fleche/calls.db", "sqlite:///~/.fleche/calls.db"),
+        ("postgresql://user@host/db", "postgresql://user@host/db"),
+    ],
+)
+def test_rebase_url(value, expected):
+    assert _rebase_url(value, Path("/base")) == expected


### PR DESCRIPTION
## Summary

Closes #810.

A relative `root` (`values.root`/`calls.root`, storage templates) or `url`
(`sql` call storage) in `fleche.toml` was resolved against the process's
current working directory instead of the directory containing the
`fleche.toml` that declared it. Since config discovery walks upward from
the CWD, the *same* config file yielded a different, empty cache for every
directory it happened to be read from — silently, with no error.

## Fix

Rebase `root`/`url` string values onto the declaring file's parent
directory at parse time, in `config._load_config`, before the shallow
merge across discovered files. A new `_rebase_config` (+ `_rebase_value`,
`_rebase_relative_path`, `_rebase_url` helpers) recursively walks the
parsed TOML looking only for `root`/`url` keys:

- Absolute paths and `~`-prefixed paths are left untouched (already mean
  the same thing regardless of the declaring file's location).
- `sql`'s `url` is handled specially since it can be a bare path, a
  `sqlite:///<relative path>` URL, an absolute `sqlite:////...` URL,
  `sqlite:///:memory:`, or a non-sqlite dialect URL — only the genuinely
  relative forms are rebased.
- Unrelated keys that happen to share the name `root` (the boolean
  `[default].root = true` walk-stop marker) or look path-like but are
  remote-side (`workdir` on an `ssh` cache entry) are left alone — only
  literal `root`/`url` keys with string values are touched.
- `root`/`url` passed directly to `cache_from_config`/`storage_from_config`
  (bypassing a config file entirely) are unaffected and still resolve
  against the CWD, as before.

Verified against the exact reproducer in #810 (two runs from different
CWDs against the same project `fleche.toml` now share one cache directory
instead of creating two).

## Test plan

- [x] New tests in `tests/unit/config/test_config.py`: relative `root`
  anchors to the config file's directory (not the CWD it's read from);
  the same config read from two different CWDs shares one cache
  (the #810 reproduction); a farther (`$HOME`) file's relative paths
  anchor to `$HOME`, not the project directory; absolute and
  `~`-prefixed `root` are unaffected; bare-path and `sqlite:///`-form
  relative `calls.url` both rebase correctly; absolute and
  `sqlite:///:memory:` `calls.url` are unaffected; `ssh` cache entries'
  `workdir` is left alone; direct unit tests of the new `_rebase_config`/
  `_rebase_relative_path`/`_rebase_url` helpers.
- [x] Updated `test_load_cache_config_specific`, whose old assertion
  encoded the buggy CWD-relative behavior.
- [x] `pytest tests/` — 1682 passed, 11 skipped.
- [x] `ty check src/` — all checks passed.
- [x] Updated the `config.py` module docstring and `agents/USAGE.md` to
  document the new resolution rule.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PQ39tpZZTSrzjydkSz4SyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ39tpZZTSrzjydkSz4SyA)_