### PR TITLE
test(caches): pin corrupt-cache silent-skip contract in Cache._query

### DIFF
--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -350,6 +350,57 @@ def test_cache_query_kwargs_and_template_raises():
         c.query(QueryCall(), name="foo")
 
 
+def test_cache_query_logs_and_skips_calls_that_fail_to_fetch(caplog):
+    """A ``DigestedCall`` whose ``fetch(cache)`` raises must be logged and skipped,
+    not abort iteration.
+
+    ``Cache._query`` wraps ``yield c.fetch(self)`` in a try/except that logs
+    ``"Indicates corrupt cache."`` and continues to the next candidate.  This
+    pins that reliability contract: one broken entry in the call store cannot
+    break a whole query.
+    """
+    import logging
+    from fleche.storage.memory import ValueMemory, CallMemory
+
+    class ExplodingDigestedCall:
+        def fetch(self, cache):
+            raise ValueError("simulated corruption")
+
+        def to_lookup_key(self):
+            return Digest("dead" + "0" * 60)
+
+    class BustedCalls:
+        """Wraps a real ``CallMemory`` but prepends one exploding fake to each query."""
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def query(self, template):
+            yield ExplodingDigestedCall()
+            yield from self._inner.query(template)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    values = ValueMemory({})
+    inner_calls = CallMemory({})
+    Cache(values, inner_calls).save(Call(name="f", arguments={"x": 1}, result=2))
+    cache = Cache(values, BustedCalls(inner_calls))
+
+    with caplog.at_level(logging.ERROR, logger="fleche.cache"):
+        results = list(cache.query(QueryCall(name="f")))
+
+    assert len(results) == 1
+    assert results[0].name == "f"
+    assert results[0].arguments["x"] == 1
+    assert results[0].result == 2
+    assert any(
+        "Indicates corrupt cache" in rec.getMessage()
+        and rec.levelno == logging.ERROR
+        for rec in caplog.records
+    )
+
+
 def test_load_value_plain_string_key():
     """load_value should accept a plain hex string without requiring D() wrapping."""
     from fleche.storage.memory import ValueMemory, CallMemory

--- a/tests/unit/caches/test_cache.py
+++ b/tests/unit/caches/test_cache.py
@@ -350,7 +350,7 @@ def test_cache_query_kwargs_and_template_raises():
         c.query(QueryCall(), name="foo")
 
 
-def test_cache_query_logs_and_skips_calls_that_fail_to_fetch(caplog):
+def test_cache_query_logs_and_skips_calls_that_fail_to_fetch(clean_cache, caplog):
     """A ``DigestedCall`` whose ``fetch(cache)`` raises must be logged and skipped,
     not abort iteration.
 
@@ -360,7 +360,6 @@ def test_cache_query_logs_and_skips_calls_that_fail_to_fetch(caplog):
     break a whole query.
     """
     import logging
-    from fleche.storage.memory import ValueMemory, CallMemory
 
     class ExplodingDigestedCall:
         def fetch(self, cache):
@@ -382,10 +381,8 @@ def test_cache_query_logs_and_skips_calls_that_fail_to_fetch(caplog):
         def __getattr__(self, name):
             return getattr(self._inner, name)
 
-    values = ValueMemory({})
-    inner_calls = CallMemory({})
-    Cache(values, inner_calls).save(Call(name="f", arguments={"x": 1}, result=2))
-    cache = Cache(values, BustedCalls(inner_calls))
+    clean_cache.save(Call(name="f", arguments={"x": 1}, result=2))
+    cache = Cache(clean_cache.values, BustedCalls(clean_cache.calls))
 
     with caplog.at_level(logging.ERROR, logger="fleche.cache"):
         results = list(cache.query(QueryCall(name="f")))


### PR DESCRIPTION
## Summary

`Cache._query` wraps `yield c.fetch(self)` in a `try/except` that logs `"Indicates corrupt cache."` and continues to the next candidate, so one broken `DigestedCall` in the call store cannot abort iteration over an otherwise-valid query (`src/fleche/caches.py:375-384`). This was the only reliability contract in `caches.py` with no direct test coverage — a regression that dropped the `except` handler would only surface as a hard failure in production.

The new unit test wraps a real `CallMemory` in a stub whose `query()` yields one `ExplodingDigestedCall` (`fetch()` raises `ValueError`) before the real hits, then asserts the good call still comes back decoded and an `ERROR` is logged on `fleche.cache`.

## Coverage

I ran `pytest tests/ --cov=src/fleche --cov-branch` on `main` and after the new test, skipping `tests/integration/test_notebooks.py` and `tests/integration/test_remote.py` (both need ssh/notebook infra unavailable in the coverage harness). Overall:

| Metric | Before | After |
|---|---|---|
| statements missed | 105 | 103 |
| statement coverage | 96.48 % | 96.54 % |
| branch coverage | 93.23 % | 93.23 % |

The new test closes `src/fleche/caches.py:379` (the `logger.error(...)` inside the corrupt-cache except handler). Full per-file report:

```
Name                                      Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/_version.py                       11      0      0      0   100%
src/fleche/caches.py                        360     19     92      6    94%
src/fleche/call.py                          241      8     62      5    96%
src/fleche/config.py                        198      3     88      2    98%
src/fleche/digest.py                        176      7    100      8    95%
src/fleche/executor.py                       38      0     12      0   100%
src/fleche/metadata.py                       70      2      4      0    97%
src/fleche/query.py                         127      0     50      1    99%
src/fleche/remote.py                        369     26     82     13    91%
src/fleche/security.py                       57      0     26      0   100%
src/fleche/state.py                          70      1     16      1    98%
src/fleche/storage/__init__.py               10      0      0      0   100%
src/fleche/storage/bagofholding_file.py     169      7     58      4    95%
src/fleche/storage/base.py                  147      2     34      2    98%
src/fleche/storage/destructuring.py         178      2     46      1    99%
src/fleche/storage/file.py                   54      0      4      0   100%
src/fleche/storage/memory.py                 41      0      2      0   100%
src/fleche/storage/pickle_file.py            96      5     16      3    93%
src/fleche/storage/sql.py                   243      8     84      4    96%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/storage/void.py                   26      1      0      0    96%
src/fleche/wrapper.py                       200      3     50      1    98%
---------------------------------------------------------------------------
TOTAL                                      2981    103    842     55    96%
```

Missing lines in `caches.py` that remain (all defensive/rare paths):
`67-71` (`BaseCache.contains` load-fallback), `284` (`_combine_shrink` empty-results, unreachable via current callers), `363` (`_query.maybe_expand` Digest-typed template argument), `430-431 / 444-445 / 456-457` (`gc` `except KeyError: continue` races), `478 / 487` (`CacheWrapper.load_value / expand`), `742-743` (`_MultiCache._foreach` swallow), `819` (`CacheStack._backfill` under-lock dedup — hit by `tests/regression/test_issue_217.py` but only in threads coverage.py's default tracer does not follow), `895` (`SizeLimitedMixin.__post_init__` super-`__post_init__` branch).

## Test plan
- [x] `pytest tests/unit/caches/test_cache.py::test_cache_query_logs_and_skips_calls_that_fail_to_fetch` — PASSED
- [x] `pytest tests/ --cov=src/fleche --cov-branch --ignore=tests/integration/test_remote.py --ignore=tests/integration/test_notebooks.py` — 1654 passed, 11 skipped (was 1653 passed)
- [x] Confirmed `src/fleche/caches.py:379` moved from missed to covered

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhyUnHa8jiL3XmzEsEqbhv)_