### PR TITLE
fix(sql): disable WAL journal mode on network filesystems

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import logging
+import sys
 import threading
 from typing import Iterable, Any, List
 from pathlib import Path
@@ -138,10 +139,54 @@ def _coerce_sqlite_url(path_or_url: str | None) -> str:
 
 # Use constants for the PRAGMA executions to avoid raw string injection risks.
 SQLITE_FOREIGN_KEYS_ON = "PRAGMA foreign_keys=ON"
-SQLITE_WAL_MODE = "PRAGMA journal_mode=WAL"
+
+# Filesystem types (as reported by /proc/mounts) known to be network-backed.
+# SQLite's WAL mode relies on shared-memory locking between all writers, which
+# does not work once those writers are on different hosts (see
+# https://www.sqlite.org/wal.html: "All processes using a database must be on
+# the same host computer; WAL does not work over a network filesystem.").
+_NETWORK_FS_TYPES = frozenset(
+    {
+        "nfs", "nfs4", "nfsd", "cifs", "smb", "smb2", "smb3", "smbfs",
+        "afs", "afpfs", "ceph", "cephfs", "glusterfs", "9p", "lustre",
+        "gpfs", "panfs",
+    }
+)
 
 
-def _configure_sqlite_pragmas(engine) -> None:
+def _is_network_filesystem(path: Path) -> bool:
+    """Best-effort check whether ``path`` lives on a network filesystem.
+
+    Linux-only (parses ``/proc/mounts``); any failure to determine the type
+    (non-Linux platform, missing ``/proc/mounts``, permissions, an odd mount
+    line) is treated as "not a network filesystem" so a failed check never
+    blocks database creation -- it just falls back to WAL's default-on
+    behaviour.
+    """
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        resolved = str(path.resolve())
+        best_match = ""
+        fstype = None
+        with open("/proc/mounts") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                mount_point, fs_type = parts[1], parts[2]
+                if (
+                    (resolved == mount_point or resolved.startswith(mount_point.rstrip("/") + "/"))
+                    and len(mount_point) > len(best_match)
+                ):
+                    best_match, fstype = mount_point, fs_type
+        return fstype is not None and fstype.lower() in _NETWORK_FS_TYPES
+    except OSError:
+        logger.debug("Could not determine filesystem type for %s", path, exc_info=True)
+        return False
+
+
+def _configure_sqlite_pragmas(engine, db_path: Path | None) -> None:
     # PRAGMA is sqlite-only; running it on Postgres/MySQL connections would
     # raise at connect time, so gate the listener on the dialect.
     if engine.dialect.name != "sqlite":
@@ -153,15 +198,32 @@ def _configure_sqlite_pragmas(engine) -> None:
 
     @event.listens_for(engine, "connect")
     def _set_sqlite_pragma(dbapi_connection, connection_record):
+        # foreign_keys is a per-connection setting in SQLite (it does not
+        # persist in the db file), so it must be re-applied on every connect.
         cursor = dbapi_connection.cursor()
         try:
-            # We use static constant strings here. We cannot use sqlalchemy.text()
+            # We use a static constant string here. We cannot use sqlalchemy.text()
             # because we are operating on a raw DBAPI cursor at the 'connect' event.
             cursor.execute(SQLITE_FOREIGN_KEYS_ON)
-            if not is_memory:
-                cursor.execute(SQLITE_WAL_MODE)
         finally:
             cursor.close()
+
+    if is_memory:
+        return
+
+    # journal_mode, unlike foreign_keys, is persisted in the database file
+    # itself, so it only needs to be set once at engine creation rather than
+    # on every connection.
+    use_wal = db_path is None or not _is_network_filesystem(db_path)
+    if not use_wal:
+        logger.warning(
+            "Cache database %s appears to be on a network filesystem; "
+            "SQLite's WAL journal mode does not work across hosts, so it "
+            "has been disabled in favor of the default rollback journal.",
+            db_path,
+        )
+    with engine.connect() as conn:
+        conn.exec_driver_sql(f"PRAGMA journal_mode={'WAL' if use_wal else 'DELETE'}")
 
 
 @dataclass(frozen=True)
@@ -185,7 +247,12 @@ class Sql(PerKeyLockMixin, CallStorage):
         is_sqlite = coerced_url.startswith("sqlite:")
         connect_args = {"check_same_thread": False} if is_sqlite else {}
         engine = create_engine(coerced_url, echo=self.echo, future=True, connect_args=connect_args)
-        _configure_sqlite_pragmas(engine)
+        db_path = None
+        if is_sqlite and coerced_url.startswith("sqlite:///"):
+            raw_path = coerced_url[len("sqlite:///"):]
+            if raw_path and raw_path != ":memory:":
+                db_path = Path(raw_path)
+        _configure_sqlite_pragmas(engine, db_path)
         Base.metadata.create_all(engine)
         object.__setattr__(self, "engine", engine)
         object.__setattr__(self, "session", sessionmaker(

--- a/tests/unit/storage/test_sql_pragmas.py
+++ b/tests/unit/storage/test_sql_pragmas.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from fleche.storage import sql as sql_module
 from fleche.storage.sql import Sql
 
 
@@ -24,3 +25,64 @@ def test_no_wal_mode_on_memory_sqlite():
     """In-memory SQLite must remain in the default memory journal mode."""
     sql = Sql(url=None)
     assert _journal_mode(sql) == "memory"
+
+
+def test_wal_disabled_on_network_filesystem(tmp_path, monkeypatch):
+    """A cache detected as living on a network filesystem must fall back to
+    the rollback journal instead of WAL, since WAL does not work once
+    writers are on different hosts (https://www.sqlite.org/wal.html).
+    """
+    monkeypatch.setattr(sql_module, "_is_network_filesystem", lambda path: True)
+    db_path = tmp_path / "calls.db"
+    sql = Sql(url=str(db_path))
+    assert _journal_mode(sql) == "delete"
+
+
+def test_wal_kept_when_not_network_filesystem(tmp_path, monkeypatch):
+    """Sanity check that the detection hook is actually consulted and, when
+    it says "local", WAL stays on.
+    """
+    monkeypatch.setattr(sql_module, "_is_network_filesystem", lambda path: False)
+    db_path = tmp_path / "calls.db"
+    sql = Sql(url=str(db_path))
+    assert _journal_mode(sql) == "wal"
+
+
+def test_is_network_filesystem_non_linux(monkeypatch):
+    """The detector is Linux-only; other platforms conservatively report
+    "not a network filesystem" rather than guessing.
+    """
+    monkeypatch.setattr(sql_module.sys, "platform", "darwin")
+    assert sql_module._is_network_filesystem(sql_module.Path("/tmp")) is False
+
+
+def test_is_network_filesystem_reads_proc_mounts(tmp_path, monkeypatch):
+    """The detector matches the longest mount-point prefix against a table of
+    known network filesystem types parsed from ``/proc/mounts``.
+    """
+    fake_mounts = tmp_path / "mounts"
+    nested = tmp_path / "mnt" / "nfsshare"
+    nested.mkdir(parents=True)
+    fake_mounts.write_text(
+        "\n".join(
+            [
+                "sysfs /sys sysfs rw 0 0",
+                f"server:/export {tmp_path / 'mnt' / 'nfsshare'} nfs4 rw 0 0",
+                "/dev/sda1 / ext4 rw 0 0",
+            ]
+        )
+        + "\n"
+    )
+
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/mounts":
+            return real_open(fake_mounts, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(sql_module, "open", fake_open, raising=False)
+    monkeypatch.setattr(sql_module.sys, "platform", "linux")
+
+    assert sql_module._is_network_filesystem(nested / "calls.db") is True
+    assert sql_module._is_network_filesystem(tmp_path / "calls.db") is False


### PR DESCRIPTION
## Summary
- Sniff the filesystem type of the sqlite cache db at `Sql` init time (via `/proc/mounts` on Linux; conservatively "not network" everywhere else / on any lookup failure) and fall back to `journal_mode=DELETE` when it's on a known network filesystem (nfs, cifs, ceph, glusterfs, ...), since SQLite's WAL mode does not work across hosts.
- Set `journal_mode` once at engine creation instead of on every `connect` event, since (unlike `foreign_keys`) it's persisted in the db file itself.

Fixes #815

Generated with [Claude Code](https://claude.ai/code)
