### PR TITLE
fix(sql): use last-wins tie-break for duplicate /proc/mounts entries

### DIFF
--- a/src/fleche/storage/sql.py
+++ b/src/fleche/storage/sql.py
@@ -177,9 +177,10 @@ def _is_network_filesystem(path: Path) -> bool:
                 mount_point, fs_type = parts[1], parts[2]
                 if (
                     (resolved == mount_point or resolved.startswith(mount_point.rstrip("/") + "/"))
-                    and len(mount_point) > len(best_match)
+                    and len(mount_point) >= len(best_match)
                 ):
                     best_match, fstype = mount_point, fs_type
+        logger.debug("Detected filesystem type %r for %s (mount point %r)", fstype, path, best_match)
         return fstype is not None and fstype.lower() in _NETWORK_FS_TYPES
     except OSError:
         logger.debug("Could not determine filesystem type for %s", path, exc_info=True)

--- a/tests/unit/storage/test_sql_pragmas.py
+++ b/tests/unit/storage/test_sql_pragmas.py
@@ -86,3 +86,36 @@ def test_is_network_filesystem_reads_proc_mounts(tmp_path, monkeypatch):
 
     assert sql_module._is_network_filesystem(nested / "calls.db") is True
     assert sql_module._is_network_filesystem(tmp_path / "calls.db") is False
+
+
+def test_is_network_filesystem_duplicate_mount_point_last_wins(tmp_path, monkeypatch):
+    """``/proc/mounts`` can list the same mount point twice, e.g. an autofs
+    trigger followed by the real NFS mount it resolves to. The later entry
+    must win the tie so the detector reports the actual (network) fstype
+    instead of the autofs placeholder (see #821).
+    """
+    fake_mounts = tmp_path / "mounts"
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_mounts.write_text(
+        "\n".join(
+            [
+                "/dev/sda1 / ext4 rw 0 0",
+                f"/etc/auto.home {home} autofs rw,fd=57 0 0",
+                f"server:/export {home} nfs rw,vers=3 0 0",
+            ]
+        )
+        + "\n"
+    )
+
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/mounts":
+            return real_open(fake_mounts, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(sql_module, "open", fake_open, raising=False)
+    monkeypatch.setattr(sql_module.sys, "platform", "linux")
+
+    assert sql_module._is_network_filesystem(home / "calls.db") is True


### PR DESCRIPTION
## Summary

Fixes a follow-up bug to #815: `_is_network_filesystem` used a strict `>` when comparing mount-point prefix lengths, so when /proc/mounts lists the same mount point twice at equal length (e.g. an autofs trigger followed by the real NFS mount it resolves to — the standard arrangement for automounted HPC home directories), the first (autofs) entry won the tie and the later `nfs` entry was never considered. This left WAL journal mode enabled on a network filesystem, silently reproducing the corruption risk from #815.

**Changes:**
- Changed the tie-break comparison from `>` to `>=` so later /proc/mounts entries win ties, matching "last mount shadows earlier one" semantics.
- Added a debug-level log of the detected fstype and matched mount point, so this is diagnosable without instrumenting the function.
- Added a regression test reproducing the autofs+nfs-at-same-mount-point scenario from the issue.

Closes #821.

🤖 Generated with [Claude Code](https://claude.ai/code)