### PR TITLE
fix(call): review follow-ups for the two-phase save protocol

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -13,7 +13,7 @@ from . import storage
 from .storage.base import _apply_shrink, _resolve_prefix, Intent, OperationContext
 from .storage.destructuring import HasChildDigests
 from .storage.thread_safe import PerKeyLockMixin, _PicklableRLock
-from .call import Call, DigestedCall, LazyCall, PreparedCall, QueryCall
+from .call import Call, LazyCall, PreparedCall, QueryCall
 from . import call
 from . import query
 
@@ -71,14 +71,13 @@ class BaseCache(OperationContext):
         return PreparedCall(digested=call.digest(), cache=self)
 
     @abstractmethod
-    def save(self, call: DigestedCall | Call) -> str:
+    def save(self, call: PreparedCall | Call) -> str:
         """File a call record.
 
         Takes either a live :class:`Call` — values are stored on the spot, the
-        one-shot form — or a :class:`DigestedCall` whose argument values were
-        already stored by :meth:`prepare`, in which case only its result (if
-        any) still needs storing.  See :meth:`prepare` for the two-phase
-        protocol that does both in the right order."""
+        one-shot form — or a :class:`~fleche.call.PreparedCall` whose argument
+        values were already stored by :meth:`prepare` and whose pending result
+        is stored now, as returned."""
         ...
 
     @abstractmethod
@@ -332,27 +331,33 @@ class Cache(PerKeyLockMixin, BaseCache):
         # storages carry their own per-key locking where they need it.
         return PreparedCall(digested=call.stash(self.values), cache=self)
 
-    def save(self, call: DigestedCall | Call) -> str:
+    def save(self, call: PreparedCall | Call) -> str:
         key = call.to_lookup_key()
         with self._operation_context(key):
             try:
                 if isinstance(call, Call):
-                    # One-shot form: nothing was stored ahead of time.  With no
-                    # function body between digesting and filing there is
-                    # nothing to drift, so stash-then-file is equivalent to
-                    # prepare/commit here.
-                    call = call.stash(self.values)
-                elif call.result is not None and not isinstance(call.result, Digest):
-                    # Second half of the two-phase protocol: the arguments are
-                    # already digests (stored by ``prepare``), only the result
-                    # arrives live from ``PreparedCall.commit``.  Not re-saving
-                    # the arguments here is the point — reading them again
-                    # *after* the body ran would file the record under
-                    # post-mutation content.
-                    call = replace(call, result=self.values.save(call.result))
+                    # One-shot form: nothing was stored ahead of time, and with
+                    # no function body between digesting and filing there is
+                    # nothing to drift.
+                    digested = call.stash(self.values)
+                elif isinstance(call, PreparedCall):
+                    # Committed result, stored as returned; the arguments must
+                    # NOT be re-saved here — reading them after the body ran is
+                    # exactly the post-mutation keying prepare exists to
+                    # prevent.
+                    digested = replace(
+                        call.digested,
+                        result=self.values.save(call._result),
+                        metadata=call.digested.metadata
+                        if call._metadata is None
+                        else call._metadata,
+                    )
+                else:
+                    # Already fully digested: file as-is.
+                    digested = call
             except storage.SaveError as e:
                 raise Rejected(e)
-            return self.calls.save(call)
+            return self.calls.save(digested)
 
     def load(self, key: str) -> LazyCall:
         with self._operation_context(key):
@@ -525,7 +530,7 @@ class CacheWrapper(BaseCache):
         # so wrapper policy (read-only, filtering, size limits) still applies.
         return replace(self.cache.prepare(call), cache=self)
 
-    def save(self, call: DigestedCall | Call) -> str:
+    def save(self, call: PreparedCall | Call) -> str:
         return self.cache.save(call)
 
     def load(self, key: str) -> LazyCall:
@@ -575,7 +580,7 @@ class ReadOnlyMixin:
     short-circuits ``save``/``evict`` without a round-trip).
     """
 
-    def save(self, call: DigestedCall | Call):
+    def save(self, call: PreparedCall | Call):
         raise Rejected(self, call)
 
     def evict(self, key: str | Digest) -> None:
@@ -834,9 +839,7 @@ class CacheStack(PerKeyLockMixin, _MultiCache):
             if isinstance(c, CacheStack):
                 raise ValueError("CacheStack cannot be nested inside another CacheStack")
 
-    def save(self, call: DigestedCall | Call) -> str:
-        # Returning the key (rather than dropping it, as this used to) keeps
-        # the BaseCache contract that PreparedCall.commit hands back to callers.
+    def save(self, call: PreparedCall | Call) -> str:
         return self.stack[0].save(call)
 
     def prepare(self, call: Call) -> PreparedCall:
@@ -997,7 +1000,7 @@ class SizeLimitedMixin(BaseCache):
                 target = self._pick_eviction_target(list(self._keys))
                 self.evict(target)
 
-    def save(self, call: call.DigestedCall | call.Call) -> str:
+    def save(self, call: call.PreparedCall | call.Call) -> str:
         with self._lock:
             key = super().save(call)
             self._keys.add(key)

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -345,13 +345,7 @@ class Cache(PerKeyLockMixin, BaseCache):
                     # NOT be re-saved here — reading them after the body ran is
                     # exactly the post-mutation keying prepare exists to
                     # prevent.
-                    digested = replace(
-                        call.digested,
-                        result=self.values.save(call._result),
-                        metadata=call.digested.metadata
-                        if call._metadata is None
-                        else call._metadata,
-                    )
+                    digested = call.resolve(self.values.save(call._result))
                 else:
                     # Already fully digested: file as-is.
                     digested = call

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -389,13 +389,18 @@ class PreparedCall:
     def to_lookup_key(self) -> Digest:
         return self.digested.to_lookup_key()
 
-    def __getstate__(self) -> dict:
-        # The cache binding is process-local (it may hold live locks or an SSH
-        # connection); a PreparedCall on the wire carries only the record and
-        # the pending result.
-        state = self.__dict__.copy()
-        state["cache"] = None
-        return state
+    def resolve(self, result: Digest) -> DigestedCall:
+        """Return the final record with the pending result resolved to *result*.
+
+        The shared ending of the two-phase save: the cache stores
+        :attr:`_result` wherever its values live and hands the digest back
+        here; pending metadata is applied at the same time.
+        """
+        return replace(
+            self.digested,
+            result=result,
+            metadata=self.digested.metadata if self._metadata is None else self._metadata,
+        )
 
     def abandon(self) -> None:
         """Release the call without recording it.

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -266,11 +266,9 @@ class DigestedCall:
 
     name: str
     arguments: dict[str, "digest.Digest"]
-    # Normally a Digest pointer, or None while the result is still unknown
-    # (a record prepared before its function body ran).  Between
-    # :meth:`PreparedCall.commit` and the cache's ``save`` it briefly holds the
-    # live return value, which ``save`` stores and replaces with its Digest.
-    result: "digest.Digest | Any" = None
+    # None while the result is still unknown (a record prepared before its
+    # function body ran).
+    result: "digest.Digest | None" = None
     metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
     module: str | None = None
     version: str | int | None = None
@@ -355,6 +353,10 @@ class PreparedCall:
     digested: DigestedCall
     cache: Any
     _finished: bool = field(default=False, init=False, repr=False)
+    # The live result and metadata between commit and the cache's save;
+    # DigestedCall itself only ever holds digests.
+    _result: Any = field(default=None, init=False, repr=False)
+    _metadata: "dict | None" = field(default=None, init=False, repr=False)
 
     def commit(self, result: Any, metadata: dict | None = None) -> Digest:
         """Attach *result* and *metadata* to the record and file it.
@@ -379,12 +381,21 @@ class PreparedCall:
         if self._finished:
             raise RuntimeError("PreparedCall already committed or abandoned")
         self._finished = True
-        digested = replace(
-            self.digested,
-            result=result,
-            metadata=self.digested.metadata if metadata is None else metadata,
-        )
-        return self.cache.save(digested)
+        self._result = result
+        if metadata is not None:
+            self._metadata = metadata
+        return self.cache.save(self)
+
+    def to_lookup_key(self) -> Digest:
+        return self.digested.to_lookup_key()
+
+    def __getstate__(self) -> dict:
+        # The cache binding is process-local (it may hold live locks or an SSH
+        # connection); a PreparedCall on the wire carries only the record and
+        # the pending result.
+        state = self.__dict__.copy()
+        state["cache"] = None
+        return state
 
     def abandon(self) -> None:
         """Release the call without recording it.

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -374,12 +374,17 @@ class PreparedCall:
         Raises:
             fleche.caches.Rejected: if the result cannot be stored or the cache
                 refuses the record.
+            RuntimeError: if this call was already committed or abandoned.
         """
-        self.digested.result = result
-        if metadata is not None:
-            self.digested.metadata = metadata
+        if self._finished:
+            raise RuntimeError("PreparedCall already committed or abandoned")
         self._finished = True
-        return self.cache.save(self.digested)
+        digested = replace(
+            self.digested,
+            result=result,
+            metadata=self.digested.metadata if metadata is None else metadata,
+        )
+        return self.cache.save(digested)
 
     def abandon(self) -> None:
         """Release the call without recording it.
@@ -388,7 +393,7 @@ class PreparedCall:
         The default is a no-op: argument values stored by
         :meth:`~fleche.caches.BaseCache.prepare` are content-addressed orphans
         that a later garbage collection sweep reclaims.  Subclasses may hook
-        cleanup here.
+        cleanup here.  Idempotent; only :meth:`commit` is barred afterwards.
         """
         self._finished = True
 

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -141,6 +141,22 @@ def _query_result(cache: BaseCache, args: tuple) -> tuple[DigestedCall, ...]:
     return tuple(_strip_cache(lc) for lc in cache.query(template))
 
 
+def _save_value(cache: BaseCache, value: Any) -> Digest:
+    """Store a bare *value* in the served cache and return its digest.
+
+    The write-side counterpart of ``load_value``, existing only in the wire
+    protocol.  Routed through :meth:`~fleche.caches.BaseCache.prepare` with a
+    synthetic, never-committed call, so wrappers and stacks direct the value
+    to the same storage their saves use; the value is kept (content-addressed)
+    while no call record is ever filed.
+    """
+    prepared = cache.prepare(
+        _call.Call(name="fleche.remote:save_value", arguments={"value": value})
+    )
+    prepared.abandon()
+    return prepared.digested.arguments["value"]
+
+
 # Single inventory of every method `SshCache` forwards across the wire; the
 # client-side stubs near `SshCache` call these names via `self._conn.call(...)`.
 # Adding a new RPC-exposed cache method only requires one entry here.
@@ -148,9 +164,10 @@ _REMOTE_METHODS: dict[str, _RemoteMethod] = {
     "save": _RemoteMethod(lambda cache, args: cache.save(*args)),
     "load": _RemoteMethod(lambda cache, args: _strip_cache(cache.load(*args))),
     "load_value": _RemoteMethod(lambda cache, args: cache.load_value(*args)),
+    "save_value": _RemoteMethod(lambda cache, args: _save_value(cache, *args)),
     # Only the sealed record travels back; the server-side PreparedCall is
-    # dropped (abandon is a no-op) and the client finishes the protocol with a
-    # plain ``save`` once the body has run.
+    # dropped (abandon is a no-op) and the client finishes the protocol with
+    # ``save_value`` + ``save`` once the body has run.
     "prepare": _RemoteMethod(lambda cache, args: cache.prepare(*args).digested),
     "evict": _RemoteMethod(lambda cache, args: cache.evict(*args), void=True),
     "contains": _RemoteMethod(lambda cache, args: cache.contains(*args)),
@@ -684,6 +701,9 @@ _CLIENT_METHODS: dict[str, _ClientMethod] = {
     "save": _ClientMethod(write=True),
     "load": _ClientMethod(unwrap=_fetch_lazy_call),
     "load_value": _ClientMethod(),
+    # Write-gated so a commit against a read-only remote is rejected locally
+    # before the first trip.
+    "save_value": _ClientMethod(write=True),
     # Read-only remotes never reach this entry: `SshCache.prepare` short-circuits
     # to the local digest-only admission before dispatching.
     "prepare": _ClientMethod(),
@@ -791,10 +811,13 @@ class SshCache(BaseCache):
         return spec.unwrap(self, self._conn.call(name, *args))
 
     def save(self, call: PreparedCall | _call.Call) -> str:
-        # A PreparedCall pickles without its cache binding (see
-        # ``PreparedCall.__getstate__``), so only the sealed record and the
-        # pending result travel; the server's cache stores the result and files
-        # the record.
+        if isinstance(call, PreparedCall):
+            # Recreate Cache.save's ending in two trips: ship the result value,
+            # then file the plain digested record — a PreparedCall itself never
+            # goes over the wire.  A failure between the trips leaves the value
+            # as a content-addressed orphan for gc, like any abandoned call.
+            digested = call.resolve(self._rpc("save_value", call._result))
+            return self._rpc("save", digested)
         return self._rpc("save", call)
 
     def load(self, key: str) -> LazyCall:

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -790,7 +790,11 @@ class SshCache(BaseCache):
             raise Rejected(self, *args)
         return spec.unwrap(self, self._conn.call(name, *args))
 
-    def save(self, call: DigestedCall | _call.Call) -> str:
+    def save(self, call: PreparedCall | _call.Call) -> str:
+        # A PreparedCall pickles without its cache binding (see
+        # ``PreparedCall.__getstate__``), so only the sealed record and the
+        # pending result travel; the server's cache stores the result and files
+        # the record.
         return self._rpc("save", call)
 
     def load(self, key: str) -> LazyCall:

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -235,14 +235,16 @@ def make_wrapper(func, policy, meta, isolate, get_call):
             for m in active_meta:
                 metadata[m.name] |= m.pre(replace(call, metadata={}))
 
-            # Two-phase save: argument values are stored and the record's key
-            # sealed *before* the body runs, so the recorded identity is the
-            # arguments as passed — even if the body mutates them (e.g. writes
-            # into a directory it received).  A read-only cache stashes
-            # nothing here (digest-only prepare) and rejects at commit time,
-            # so the call still runs and returns uncached, as it previously
-            # did when the post-body save was rejected.
-            prepared = cache.prepare(call)
+            # Seal the call's identity (and stash its argument values) before
+            # the body runs, so mutations the body makes to its arguments
+            # cannot leak into the recorded key.  A read-only cache seals
+            # without writing and rejects at commit; the call still runs and
+            # returns uncached.
+            try:
+                prepared = cache.prepare(call)
+            except Rejected as e:
+                logger.warning("Cache rejected prepare: %s", e.args)
+                return func(*args, **kwargs)
 
             try:
                 result: _T = func(*args, **kwargs)

--- a/src/fleche/wrapper.py
+++ b/src/fleche/wrapper.py
@@ -245,6 +245,12 @@ def make_wrapper(func, policy, meta, isolate, get_call):
             except Rejected as e:
                 logger.warning("Cache rejected prepare: %s", e.args)
                 return func(*args, **kwargs)
+            except Exception:
+                # Not a policy rejection but an actual error (storage fault,
+                # lost connection, ...): still prefer running the call uncached
+                # over failing before the body ever ran.
+                logger.warning("Cache failed to prepare call", exc_info=True)
+                return func(*args, **kwargs)
 
             try:
                 result: _T = func(*args, **kwargs)
@@ -283,7 +289,6 @@ def make_wrapper(func, policy, meta, isolate, get_call):
                             metadata[m.name], replace(call, metadata={})
                         )
                     try:
-                        call.metadata = metadata
                         logger.debug("Saving result for %s with key %s", call.name, key)
                         prepared.commit(call.result, metadata)
                     except Rejected as e:

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -201,6 +201,30 @@ def test_no_mislabeled_entry_for_mutated_state(cache):
     assert len(runs) == 2
 
 
+@pytest.mark.parametrize("exc", [Rejected("no admission"), OSError("storage down")])
+def test_prepare_failure_degrades_to_uncached(exc):
+    """A prepare that fails — policy rejection or actual error — must not stop
+    the call: the body runs and the result comes back uncached."""
+
+    class Broken(Cache):
+        def prepare(self, call):
+            raise exc
+
+    broken = Broken(ValueMemory({}), CallMemory({}))
+    runs = []
+
+    @fleche
+    def f(x):
+        runs.append(1)
+        return x + 1
+
+    with fl.cache(broken):
+        assert f(1) == 2
+        assert f(1) == 2
+    assert len(runs) == 2  # never cached: prepare fails on every call
+    assert list(broken.calls.list()) == []
+
+
 def test_body_exception_leaves_no_record(cache):
     runs = []
 

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -92,6 +92,27 @@ def test_context_manager_does_not_swallow_exceptions(cache):
     assert not cache.contains(call.to_lookup_key())
 
 
+def test_commit_is_exactly_once(cache):
+    prepared = cache.prepare(make_call(x=1))
+    prepared.commit(1)
+    with pytest.raises(RuntimeError):
+        prepared.commit(2)
+
+
+def test_abandon_is_idempotent_but_bars_commit(cache):
+    prepared = cache.prepare(make_call(x=1))
+    prepared.abandon()
+    prepared.abandon()
+    with pytest.raises(RuntimeError):
+        prepared.commit(1)
+
+
+def test_commit_does_not_mutate_the_prepared_record(cache):
+    prepared = cache.prepare(make_call(x=1))
+    prepared.commit("r")
+    assert prepared.digested.result is None
+
+
 def test_readonly_prepare_is_digest_only_and_commit_rejects(cache):
     """A read-only cache admits the call without writing anything; the
     rejection lands at commit time, after the body would have run."""
@@ -145,10 +166,9 @@ def test_wrapper_prepare_commits_through_the_wrapper(cache):
 # ---- end-to-end: argument mutation no longer corrupts identity ----
 
 
-def test_mutating_consumer_hits_on_honest_repeat():
+def test_mutating_consumer_hits_on_honest_repeat(cache):
     """A function that mutates its argument is keyed on the *pre-call* state:
     a repeat call with the same initial state is a hit."""
-    fl.cache("memory")
     runs = []
 
     @fleche
@@ -157,16 +177,16 @@ def test_mutating_consumer_hits_on_honest_repeat():
         xs.append(99)
         return sum(xs)
 
-    assert consume([1, 2]) == 102
-    assert consume([1, 2]) == 102
+    with fl.cache(cache):
+        assert consume([1, 2]) == 102
+        assert consume([1, 2]) == 102
     assert len(runs) == 1
 
 
-def test_no_mislabeled_entry_for_mutated_state():
+def test_no_mislabeled_entry_for_mutated_state(cache):
     """The post-mutation argument state is a *different* call and recomputes —
     the old behavior filed the first call under this state (a false hit that
     returned a result computed from different input)."""
-    fl.cache("memory")
     runs = []
 
     @fleche
@@ -175,13 +195,13 @@ def test_no_mislabeled_entry_for_mutated_state():
         xs.append(99)
         return len(xs)
 
-    assert consume([1, 2]) == 3
-    assert consume([1, 2, 99]) == 4      # miss: its own honest computation
+    with fl.cache(cache):
+        assert consume([1, 2]) == 3
+        assert consume([1, 2, 99]) == 4  # miss: its own honest computation
     assert len(runs) == 2
 
 
-def test_body_exception_leaves_no_record():
-    fl.cache("memory")
+def test_body_exception_leaves_no_record(cache):
     runs = []
 
     @fleche
@@ -189,8 +209,9 @@ def test_body_exception_leaves_no_record():
         runs.append(1)
         raise ValueError("no")
 
-    for _ in range(2):
-        with pytest.raises(ValueError):
-            boom(1)
-    assert len(runs) == 2                # nothing cached, body ran twice
-    assert not boom.contains(1)
+    with fl.cache(cache):
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                boom(1)
+        assert len(runs) == 2            # nothing cached, body ran twice
+        assert not boom.contains(1)

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -229,6 +229,7 @@ def test_dispatch_covers_every_registered_method():
         "save",
         "load",
         "load_value",
+        "save_value",
         "prepare",
         "evict",
         "contains",
@@ -310,7 +311,19 @@ def test_read_only_false_for_writable_remote(remote):
 
 def test_prepare_commit_round_trip(remote, server_cache):
     """`prepare` stashes the arguments server-side before the body runs;
-    `commit` ships the live result and files the record under the sealed key."""
+    `commit` ships the result value and then the plain digested record —
+    a PreparedCall itself never goes over the wire."""
+    from fleche.call import PreparedCall
+
+    shipped = []
+    original_call = remote._conn.call
+
+    def spy(method, *args, **kwargs):
+        shipped.append((method, args))
+        return original_call(method, *args, **kwargs)
+
+    remote._conn.call = spy  # type: ignore[method-assign]
+
     xs = [1, 2]
     c = Call(name="f", arguments={"xs": xs}, module="m", version="1")
     sealed = c.to_lookup_key()
@@ -322,6 +335,12 @@ def test_prepare_commit_round_trip(remote, server_cache):
     xs.append(3)  # the "function body" mutates the argument
     key = prepared.commit(xs)
     assert key == sealed  # NOT c.to_lookup_key(): that drifted with the mutation
+    # The commit took two trips (result value, then the record), and nothing
+    # PreparedCall-shaped ever crossed the wire.
+    assert [m for m, _ in shipped if m in ("save_value", "save")] == ["save_value", "save"]
+    assert not any(
+        isinstance(a, PreparedCall) for _, args in shipped for a in args
+    )
     lc = remote.load(key)
     assert lc.result == [1, 2, 3]  # result: as returned
     assert lc.arguments["xs"] == [1, 2]  # argument: as passed

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -17,7 +17,7 @@ import fleche.state as _state
 from fleche.call import Call, QueryCall
 from fleche.caches import Cache, Rejected
 from fleche.config import cache_to_config, load_cache_config
-from fleche.digest import Digest
+from fleche.digest import Digest, digest
 from fleche.remote import (
     RemoteConnectionError,
     SshCache,
@@ -301,6 +301,59 @@ def test_read_only_short_circuits_save_and_evict():
 def test_read_only_false_for_writable_remote(remote):
     """A normal remote cache reports `read_only == False`."""
     assert remote.read_only is False
+
+
+# ---------------------------------------------------------------------------
+# Two-phase save protocol over the wire
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_commit_round_trip(remote, server_cache):
+    """`prepare` stashes the arguments server-side before the body runs;
+    `commit` ships the live result and files the record under the sealed key."""
+    xs = [1, 2]
+    c = Call(name="f", arguments={"xs": xs}, module="m", version="1")
+    sealed = c.to_lookup_key()
+    prepared = remote.prepare(c)
+    assert prepared.cache is remote
+    assert prepared.digested.to_lookup_key() == sealed
+    # The argument value is already on the server before any commit.
+    assert server_cache.values.load(digest([1, 2])) == [1, 2]
+    xs.append(3)  # the "function body" mutates the argument
+    key = prepared.commit(xs)
+    assert key == sealed  # NOT c.to_lookup_key(): that drifted with the mutation
+    lc = remote.load(key)
+    assert lc.result == [1, 2, 3]  # result: as returned
+    assert lc.arguments["xs"] == [1, 2]  # argument: as passed
+
+
+def test_read_only_prepare_is_local_and_commit_rejects():
+    """`prepare` against a read-only remote seals the key locally — no RPC,
+    nothing stashed — and the commit's `save` is rejected without a round trip."""
+    server = Cache(ValueMemory({}), CallMemory({})).readonly()
+    sc = _make_remote(server)
+    try:
+        # Trigger the info fetch once so the read_only flag is cached.
+        assert sc.read_only is True
+
+        rpc_calls = []
+        original_call = sc._conn.call
+
+        def spy(method, *args, **kwargs):
+            rpc_calls.append(method)
+            return original_call(method, *args, **kwargs)
+
+        sc._conn.call = spy  # type: ignore[method-assign]
+
+        c = Call(name="f", arguments={"xs": [1, 2]}, module="m", version="1")
+        prepared = sc.prepare(c)
+        assert prepared.digested.to_lookup_key() == c.to_lookup_key()
+        assert list(server.cache.values.list()) == []  # nothing stashed
+        with pytest.raises(Rejected):
+            prepared.commit(42)
+        assert rpc_calls == [], f"unexpected RPCs: {rpc_calls}"
+    finally:
+        sc.close()
 
 
 def test_reconnect_invalidates_info_cache(remote, server_cache):


### PR DESCRIPTION
Implements the changes approved in the #793 review threads, revised per the #825 review ("combine" with the #827 sketch; broadened prepare guard; two-trip remote commit). Stacked onto `prepared-call` for merging into that branch.

## Changes

- **Pending result lives on `PreparedCall`, never on `DigestedCall`** (combining #827 with the replace-based commit): `PreparedCall` carries `_result`/`_metadata` as private fields, `commit` hands the whole `PreparedCall` to `cache.save`, and the cache stores the result and files a record built via `PreparedCall.resolve` — `DigestedCall.result` is back to a checkable `Digest | None`, and `commit` never mutates `digested`. A bare `DigestedCall` still files as-is.
- **`PreparedCall` never goes over the wire**: `SshCache.save` recreates `Cache.save`'s ending in two trips — a write-gated `save_value` RPC stores the result value remotely, then the plain `DigestedCall` is filed. Only `Call` and `DigestedCall` cross the wire (asserted by a spy in the round-trip test). Server-side, `save_value` routes through `prepare` with a synthetic never-committed call, so wrappers and stacks direct the value to the same storage their saves use without adding a public cache method; a failure between the trips leaves a content-addressed orphan for gc, like any abandoned call.
- **`commit` is single-shot**: a second `commit` or a `commit` after `abandon` raises `RuntimeError`; `abandon` stays idempotent so cleanup paths can't trip it.
- **Wrapper degrades gracefully on any `prepare` failure**: `Rejected` logs a policy warning; any other `Exception` (storage fault, lost connection) logs with traceback — in both cases the body runs and returns uncached instead of failing before it ever ran. Also drops the dead `call.metadata` assignment.
- **Remote `prepare` tests**: live wire round trip (arguments stashed server-side before the body runs, sealed key survives argument mutation, two-trip commit) and the read-only branch (local digest-only admission, zero RPCs, commit rejected locally before the first trip).
- **Test hygiene fix (drive-by)**: the e2e tests in `test_prepared_call.py` activated the shared named-`"memory"` cache stickily; that singleton lives in `config._live_caches`, so populating it leaked into any later test that round-trips the named cache's config (`test_run_server_serves_active_cache_over_stdio_until_eof[memory]` crashes in `dataclasses.asdict` when the files run back to back — masked in the full suite by `tests/unit/config`'s `_live_caches.clear()` fixture). The tests now scope a private `Cache` instance.

Parked separately: the gc/in-flight race is #826.

## Testing

Full suite: 1659 passed, 11 skipped. `ty check src/` clean. The affected file pair also passes in the previously-failing collection order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QT4DxU9dVALrMvff7setnk