### PR TITLE
docs(caches): trim protocol comments to their invariants

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -53,20 +53,16 @@ class BaseCache(OperationContext):
 
         The first half of the two-phase save protocol.  Caches that own a
         value storage (:class:`Cache`) override this to stash the argument
-        values *now* — before the function body runs — so the recorded
-        identity describes the arguments as they were at call time, even if
-        the body later mutates them.
-
-        This base implementation is the digest-only admission used by caches
-        that cannot (or must not) write ahead of the body — read-only views,
-        aggregates without their own value storage: the key is sealed, but
-        nothing is written and whether a record survives is decided by
-        :meth:`save` at commit time.  Because ``digest(x) == values.save(x)``
-        for every storable value, both forms seal the same key.
+        values now, so the recorded identity describes the arguments as they
+        were at call time, even if the body later mutates them.  This base
+        implementation is the digest-only admission for caches that cannot
+        (or must not) write ahead of the body — read-only views, aggregates
+        without their own storage; ``digest(x) == values.save(x)``, so both
+        forms seal the same key.
 
         Finish the returned :class:`~fleche.call.PreparedCall` with exactly
-        one of :meth:`~fleche.call.PreparedCall.commit` (store the result,
-        file the record) or :meth:`~fleche.call.PreparedCall.abandon`.
+        one of :meth:`~fleche.call.PreparedCall.commit` or
+        :meth:`~fleche.call.PreparedCall.abandon`.
         """
         return PreparedCall(digested=call.digest(), cache=self)
 
@@ -324,11 +320,9 @@ class Cache(PerKeyLockMixin, BaseCache):
 
     def prepare(self, call: Call) -> PreparedCall:
         # Stash the arguments *now*, before the function body runs, so the
-        # record cannot end up keyed on post-mutation content.  ``stash``
-        # leaves the still-unknown result as ``None``; ``save`` below stores
-        # it once ``commit`` fills it in.  No cache-level lock: the keys are
-        # only known once the value storage has digested each value, and value
-        # storages carry their own per-key locking where they need it.
+        # record cannot end up keyed on post-mutation content.  No cache-level
+        # lock: the keys are only known once the value storage has digested
+        # each value, and value storages carry their own per-key locking.
         return PreparedCall(digested=call.stash(self.values), cache=self)
 
     def save(self, call: PreparedCall | Call) -> str:
@@ -581,12 +575,10 @@ class ReadOnlyMixin:
         raise Rejected("Cannot evict from a read-only cache", self, key)
 
     def prepare(self, call: Call) -> "PreparedCall":
-        # Digest-only admission (the BaseCache default, restated because this
-        # mixin is base-free and must beat CacheWrapper.prepare in the MRO): a
-        # read-only cache stashes nothing, so the function body still runs with
-        # a correctly sealed key and the eventual commit is rejected by
-        # ``save`` above — the behavior save() rejection produced before the
-        # two-phase protocol, minus the wasted writes.
+        # Digest-only admission, restated from BaseCache because this mixin is
+        # base-free and must beat CacheWrapper.prepare in the MRO: nothing is
+        # stashed, the key is still sealed, and the commit is rejected by
+        # ``save`` above — the body runs and returns uncached.
         return PreparedCall(digested=call.digest(), cache=self)
 
 

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -831,7 +831,7 @@ class SshCache(BaseCache):
         # argument values before the body runs and seals the record, which
         # comes back for the client to complete with ``save``.  Values travel
         # by cloudpickle, so a Path argument ships its path *string*, not its
-        # content — paths over SSH remain unsupported, as before.
+        # content — paths over SSH are unsupported.
         self._ensure_handshake()
         if self._info_cache and self._info_cache.get("read_only", False):
             # Digest-only admission, as BaseCache: the body still runs, and the


### PR DESCRIPTION
Applies the remaining comment trims flagged in the #793 review (the rest already landed with #825). Narration and before/after history go; invariants stay:

- `BaseCache.prepare` docstring: 20 → 15 lines; keeps the override contract, the digest-only base semantics, and the `digest(x) == values.save(x)` key-equality invariant.
- `Cache.prepare`: drops the result-lifecycle narration (documented on `PreparedCall`/`save`); keeps the pre-body stash rationale and the no-cache-level-lock explanation.
- `ReadOnlyMixin.prepare`: drops "the behavior save() rejection produced before the two-phase protocol, minus the wasted writes"; keeps the MRO reason and the seal-without-writing behavior.
- `SshCache.prepare`: drops the ", as before" tail; keeps the Path-over-SSH caveat.

Comment-only diff. Affected test dirs pass (191 tests), `ty check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QT4DxU9dVALrMvff7setnk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QT4DxU9dVALrMvff7setnk)_