### PR TITLE
fix(remote): reject unstorable results; resolve() takes the value storage

### DIFF
--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -830,9 +830,9 @@ class CacheStack(PerKeyLockMixin, _MultiCache):
 
     def prepare(self, call: Call) -> PreparedCall:
         # Writes always land on stack[0] (matching save), so that is where the
-        # arguments are stashed; rebinding the cache routes the commit back
-        # through this stack's ``save``.
-        return replace(self.stack[0].prepare(call), cache=self)
+        # arguments are stashed and where the commit files directly — this
+        # stack's own ``save`` is a pure forward to the same place.
+        return self.stack[0].prepare(call)
 
     @contextlib.contextmanager
     def _operation_context(self, key, *, intent: Intent = Intent.WRITE):

--- a/src/fleche/caches.py
+++ b/src/fleche/caches.py
@@ -339,7 +339,7 @@ class Cache(PerKeyLockMixin, BaseCache):
                     # NOT be re-saved here — reading them after the body ran is
                     # exactly the post-mutation keying prepare exists to
                     # prevent.
-                    digested = call.resolve(self.values.save(call._result))
+                    digested = call.resolve(self.values)
                 else:
                     # Already fully digested: file as-is.
                     digested = call

--- a/src/fleche/call.py
+++ b/src/fleche/call.py
@@ -389,16 +389,16 @@ class PreparedCall:
     def to_lookup_key(self) -> Digest:
         return self.digested.to_lookup_key()
 
-    def resolve(self, result: Digest) -> DigestedCall:
-        """Return the final record with the pending result resolved to *result*.
+    def resolve(self, values) -> DigestedCall:
+        """Save the pending result into *values*, returning the final record.
 
-        The shared ending of the two-phase save: the cache stores
-        :attr:`_result` wherever its values live and hands the digest back
-        here; pending metadata is applied at the same time.
+        The shared ending of the two-phase save, mirroring :meth:`Call.stash`:
+        the cache hands in the value storage where its saves land; pending
+        metadata is applied at the same time.
         """
         return replace(
             self.digested,
-            result=result,
+            result=values.save(self._result),
             metadata=self.digested.metadata if self._metadata is None else self._metadata,
         )
 

--- a/src/fleche/remote.py
+++ b/src/fleche/remote.py
@@ -59,6 +59,7 @@ from . import call as _call
 from .caches import BaseCache, Rejected
 from .call import DigestedCall, LazyCall, PreparedCall, QueryCall
 from .digest import Digest
+from .storage.base import SaveError
 
 logger = logging.getLogger("fleche.remote")
 
@@ -147,14 +148,28 @@ def _save_value(cache: BaseCache, value: Any) -> Digest:
     The write-side counterpart of ``load_value``, existing only in the wire
     protocol.  Routed through :meth:`~fleche.caches.BaseCache.prepare` with a
     synthetic, never-committed call, so wrappers and stacks direct the value
-    to the same storage their saves use; the value is kept (content-addressed)
-    while no call record is ever filed.
+    to the same storage their saves use.  The value rides in the *result*
+    position for its strict save semantics: a refused value must reject the
+    commit (as in ``Cache.save``), where the argument position would fall
+    back to a digest-only reference and file a record with a dangling
+    result.  ``None`` — the one result the stash skips — rides as an
+    argument instead; storing ``None`` cannot fail.
     """
-    prepared = cache.prepare(
-        _call.Call(name="fleche.remote:save_value", arguments={"value": value})
-    )
+    if value is None:
+        prepared = cache.prepare(
+            _call.Call(name="fleche.remote:save_value", arguments={"value": None})
+        )
+        prepared.abandon()
+        return prepared.digested.arguments["value"]
+    try:
+        prepared = cache.prepare(
+            _call.Call(name="fleche.remote:save_value", arguments={}, result=value)
+        )
+    except SaveError as e:
+        raise Rejected(e)
     prepared.abandon()
-    return prepared.digested.arguments["value"]
+    assert prepared.digested.result is not None  # value is not None here
+    return prepared.digested.result
 
 
 # Single inventory of every method `SshCache` forwards across the wire; the
@@ -685,6 +700,21 @@ class _ClientMethod:
     reject_message: str | None = None
 
 
+@dataclass(frozen=True)
+class _RemoteValues:
+    """The slice of the value-storage write surface a remote commit needs.
+
+    Lets :meth:`SshCache.save` hand :meth:`~fleche.call.PreparedCall.resolve`
+    a values object, in parity with the local ``Cache.save``; ``save`` is one
+    ``save_value`` round trip.
+    """
+
+    _cache: "SshCache"
+
+    def save(self, value: Any) -> Digest:
+        return self._cache._rpc("save_value", value)
+
+
 def _fetch_lazy_call(sc: "SshCache", dc: DigestedCall) -> LazyCall:
     return dc.fetch(sc)
 
@@ -816,7 +846,7 @@ class SshCache(BaseCache):
             # then file the plain digested record — a PreparedCall itself never
             # goes over the wire.  A failure between the trips leaves the value
             # as a content-addressed orphan for gc, like any abandoned call.
-            digested = call.resolve(self._rpc("save_value", call._result))
+            digested = call.resolve(_RemoteValues(self))
             return self._rpc("save", digested)
         return self._rpc("save", call)
 

--- a/tests/unit/call/test_prepared_call.py
+++ b/tests/unit/call/test_prepared_call.py
@@ -136,14 +136,15 @@ def test_key_matches_one_shot_save(cache):
 # ---- wrappers and stacks: storage from the inner cache, policy from the outer ----
 
 
-def test_stack_prepares_on_stack0_and_commits_through_the_stack(cache):
-    """Arguments are stashed where the stack's saves land; the commit still
-    goes through the stack itself (its ``save`` policy, not stack[0]'s)."""
+def test_stack_prepares_and_commits_on_stack0(cache):
+    """Arguments and commit both land on stack[0], where the stack's saves go;
+    the stack's own ``save`` is a pure forward, so prepare binds stack[0]
+    directly."""
     second = Cache(ValueMemory({}), CallMemory({}))
     stack = CacheStack([cache, second])
     call = make_call(x=[1, 2])
     prepared = stack.prepare(call)
-    assert prepared.cache is stack
+    assert prepared.cache is cache
     key = prepared.commit([1, 2, 3])
     assert key == call.to_lookup_key()
     assert cache.load(key).result == [1, 2, 3]

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -30,6 +30,7 @@ from fleche.remote import (
     serve,
 )
 from fleche.storage import CallMemory, ValueMemory
+from fleche.storage.base import SaveError
 
 
 class _PipeConnection(_Connection):
@@ -344,6 +345,36 @@ def test_prepare_commit_round_trip(remote, server_cache):
     lc = remote.load(key)
     assert lc.result == [1, 2, 3]  # result: as returned
     assert lc.arguments["xs"] == [1, 2]  # argument: as passed
+
+
+def test_unstorable_result_rejects_like_local_save():
+    """A result the server's value storage refuses must reject the commit —
+    not degrade to a digest-only reference that files a dangling record."""
+
+    class PickyValues(ValueMemory):
+        __hash__ = object.__hash__
+
+        def save(self, value, key=None):
+            if value == "REFUSE_ME":
+                raise SaveError("refused")
+            return super().save(value, key)
+
+    server = Cache(PickyValues({}), CallMemory({}))
+    sc = _make_remote(server)
+    try:
+        c = Call(name="f", arguments={"x": 1}, module="m", version="1")
+        prepared = sc.prepare(c)
+        with pytest.raises(Rejected):
+            prepared.commit("REFUSE_ME")
+        assert not server.contains(c.to_lookup_key())
+    finally:
+        sc.close()
+
+
+def test_commit_none_result_round_trips(remote, server_cache):
+    c = Call(name="f", arguments={"x": 1}, module="m", version="1")
+    key = remote.prepare(c).commit(None)
+    assert remote.load(key).result is None
 
 
 def test_read_only_prepare_is_local_and_commit_rejects():


### PR DESCRIPTION
Three items from the final read-through of #793 and its review threads, stacked onto `prepared-call`:

## Bug fix: unstorable results over SSH filed dangling records

`_save_value` routed the value through the synthetic call's *argument* position, and `stash` treats argument `SaveError`s leniently (digest-only fallback). Verified divergence: locally a commit of a storage-refused result raises `Rejected` and files nothing; over the wire the client got back a digest for a value that was **never stored** and filed a record whose result dangles — which then loads as a `KeyError`, i.e. a permanent phantom miss that re-executes forever.

Fix: the value now rides in the *result* position, whose save semantics are strict, with `SaveError` wrapped in `Rejected` to match `Cache.save`. `None` — the one result the stash skips — rides as an argument, where storing cannot fail. Regression tests cover both: refused result → `Rejected` at the client, no record; `commit(None)` round-trips.

## Review suggestion: `resolve(values)` in parity with `stash(values)`

Per the [suggestion](https://github.com/pmrv/fleche/pull/793#discussion_r3737082003) threads on #793: `PreparedCall.resolve` now takes the value storage and saves the pending result itself, mirroring `Call.stash`. `Cache.save` passes `self.values`; `SshCache.save` passes a minimal `_RemoteValues` shim whose `save` is one `save_value` round trip (also a natural seed for the deferred remote values facade).

## Review decision: drop the `CacheStack.prepare` rebind

Per the [thread](https://github.com/pmrv/fleche/pull/793#discussion_r3737110020): `CacheStack.save` is a pure forward to `stack[0]`, so rebinding the `PreparedCall` to the stack bought nothing — `prepare` now hands back `stack[0]`'s own admission and the commit files there directly.

## Testing

Full suite: 1661 passed, 11 skipped. `ty check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QT4DxU9dVALrMvff7setnk