### PR TITLE
docs(notebooks): add FiveMinuteTour intro notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+tags
+build/
 .claude/worktrees
 *.egg-info/
 .ipynb_checkpoints/*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Welcome to the **Fleche** library documentation.
    :maxdepth: 1
    :caption: Notebooks
 
+   notebooks/FiveMinuteTour
    notebooks/GettingStarted
    notebooks/ExtraMethods
    notebooks/StorageBackends

--- a/docs/notebooks/FiveMinuteTour.ipynb
+++ b/docs/notebooks/FiveMinuteTour.ipynb
@@ -1,0 +1,1 @@
+../../notebooks/FiveMinuteTour.ipynb

--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -1,0 +1,522 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ac3ee647",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:53.036853Z",
+     "iopub.status.busy": "2026-08-07T17:20:53.036683Z",
+     "iopub.status.idle": "2026-08-07T17:20:53.185560Z",
+     "shell.execute_reply": "2026-08-07T17:20:53.184356Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!rm -rf .five_minute_cache"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "787d5ce6",
+   "metadata": {},
+   "source": [
+    "# Fleche in Five Minutes\n",
+    "\n",
+    "*A persistent cache for expensive Python functions — `lru_cache` on steroids.*\n",
+    "\n",
+    "Decorate a function and `fleche` stores every result under a SHA256 key built from the\n",
+    "function's identity and the **content** of its arguments. Results survive restarts, can\n",
+    "live in files, HDF5, SQL, or on another machine — and everything you ever computed stays\n",
+    "queryable like a small database.\n",
+    "\n",
+    "If your day involves functions that take minutes to days — structure relaxations,\n",
+    "phonons, MD, training runs — and you re-run them more often than you'd like, this is\n",
+    "for you.\n",
+    "\n",
+    "```\n",
+    "pip install fleche          # or: conda install -c conda-forge fleche\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3096adaf",
+   "metadata": {},
+   "source": [
+    "## 1. Decorate and forget\n",
+    "\n",
+    "Point the active cache at a directory (in real projects you'd do this once in a\n",
+    "`fleche.toml` next to your code — see the end of this notebook), then just decorate:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d0dfa14b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:53.188382Z",
+     "iopub.status.busy": "2026-08-07T17:20:53.188160Z",
+     "iopub.status.idle": "2026-08-07T17:20:53.728584Z",
+     "shell.execute_reply": "2026-08-07T17:20:53.727432Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from fleche import fleche, cache, tags, wrap_executor\n",
+    "from fleche.caches import Cache\n",
+    "\n",
+    "cache(Cache.from_config({\"template\": \"cloudpickle\", \"root\": \"./.five_minute_cache\"}));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7c518acf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:53.731531Z",
+     "iopub.status.busy": "2026-08-07T17:20:53.731225Z",
+     "iopub.status.idle": "2026-08-07T17:20:55.741402Z",
+     "shell.execute_reply": "2026-08-07T17:20:55.740259Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "crunching 4 ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16   <- first call: 2.00 s\n",
+      "16   <- second call: 0.0015 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "@fleche\n",
+    "def expensive(x):\n",
+    "    print(f\"crunching {x} ...\")\n",
+    "    time.sleep(2)                     # pretend this is a real calculation\n",
+    "    return x ** 2\n",
+    "\n",
+    "\n",
+    "start = time.time()\n",
+    "print(expensive(4), f\"  <- first call: {time.time() - start:.2f} s\")\n",
+    "\n",
+    "start = time.time()\n",
+    "print(expensive(4), f\"  <- second call: {time.time() - start:.4f} s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c1932ef",
+   "metadata": {},
+   "source": [
+    "The second call never enters the function body. Unlike `lru_cache`, the result is on\n",
+    "disk, not in process memory — restart the kernel (skip the cleanup cell at the top) and\n",
+    "it is still instant. A brand-new cache object pointed at the same directory already\n",
+    "knows the answer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9f4c538d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:55.743616Z",
+     "iopub.status.busy": "2026-08-07T17:20:55.743406Z",
+     "iopub.status.idle": "2026-08-07T17:20:55.748564Z",
+     "shell.execute_reply": "2026-08-07T17:20:55.747301Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cached? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "fresh = Cache.from_config({\"template\": \"cloudpickle\", \"root\": \"./.five_minute_cache\"})\n",
+    "with cache(fresh):\n",
+    "    print(\"cached?\", expensive.fleche.contains(4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c72c4055",
+   "metadata": {},
+   "source": [
+    "The cache is just a directory — `rsync` it, back it up, share it with your group.\n",
+    "\n",
+    "## 2. Keys are content, not object identity\n",
+    "\n",
+    "Arguments are digested by **value** — not `id()`, not pickle bytes. NumPy arrays,\n",
+    "pandas frames, dataclasses, and nested containers work out of the box; equal content\n",
+    "means equal key, no matter who constructed the object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "41dd9bef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:55.750625Z",
+     "iopub.status.busy": "2026-08-07T17:20:55.750407Z",
+     "iopub.status.idle": "2026-08-07T17:20:55.843935Z",
+     "shell.execute_reply": "2026-08-07T17:20:55.843251Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "computing ...\n",
+      "577.3504135273193\n",
+      "577.3504135273193\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "@fleche\n",
+    "def norm(arr):\n",
+    "    print(\"computing ...\")\n",
+    "    return float(np.linalg.norm(arr))\n",
+    "\n",
+    "\n",
+    "a = np.linspace(0, 1, 1_000_000)\n",
+    "print(norm(a))\n",
+    "print(norm(a.copy()))                 # different object, same content -> cache hit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaa8041b",
+   "metadata": {},
+   "source": [
+    "The digest machinery is pluggable for third-party types. If you use ASE:\n",
+    "`pip install fleche-ase` and `Atoms`, `Calculator`, and `VibrationsData` objects digest\n",
+    "correctly with **zero further setup** (registered via entry points):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dfba66c2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:55.854407Z",
+     "iopub.status.busy": "2026-08-07T17:20:55.854178Z",
+     "iopub.status.idle": "2026-08-07T17:20:56.637324Z",
+     "shell.execute_reply": "2026-08-07T17:20:56.636088Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "running EMT ...\n",
+      "-0.022726045434316333\n",
+      "-0.022726045434316333\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from ase.build import bulk\n",
+    "    from ase.calculators.emt import EMT\n",
+    "\n",
+    "    @fleche\n",
+    "    def energy(atoms):\n",
+    "        print(\"running EMT ...\")\n",
+    "        atoms = atoms.copy()\n",
+    "        atoms.calc = EMT()\n",
+    "        return atoms.get_potential_energy()\n",
+    "\n",
+    "    print(energy(bulk(\"Cu\", cubic=True)))\n",
+    "    print(energy(bulk(\"Cu\", cubic=True)))   # freshly built Atoms -> cache hit\n",
+    "except ImportError:\n",
+    "    print(\"pip install ase fleche-ase to run this cell\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03f8d80d",
+   "metadata": {},
+   "source": [
+    "## 3. Your cache is a database\n",
+    "\n",
+    "Every call is recorded — arguments, runtime, metadata — *separately* from the (possibly\n",
+    "heavy) result values, so you can browse what you computed without deserializing any of\n",
+    "it. Tag calls, then query into a pandas DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7900dba9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:56.640049Z",
+     "iopub.status.busy": "2026-08-07T17:20:56.639694Z",
+     "iopub.status.idle": "2026-08-07T17:20:56.972089Z",
+     "shell.execute_reply": "2026-08-07T17:20:56.971069Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>module</th>\n",
+       "      <th>result</th>\n",
+       "      <th>timestart</th>\n",
+       "      <th>timestop</th>\n",
+       "      <th>walltime</th>\n",
+       "      <th>project</th>\n",
+       "      <th>a</th>\n",
+       "      <th>k</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ad2b</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>{'energy': -14.0, 'volume': 42.875}</td>\n",
+       "      <td>2026-08-07 17:20:56.643192053+00:00</td>\n",
+       "      <td>2026-08-07 17:20:56.744186878+00:00</td>\n",
+       "      <td>0.100995</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0275</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
+       "      <td>2026-08-07 17:20:56.746165514+00:00</td>\n",
+       "      <td>2026-08-07 17:20:56.846971989+00:00</td>\n",
+       "      <td>0.100806</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "      <td>3.6</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ba58</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
+       "      <td>2026-08-07 17:20:56.848810196+00:00</td>\n",
+       "      <td>2026-08-07 17:20:56.949890375+00:00</td>\n",
+       "      <td>0.101080</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "      <td>3.7</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       name    module                                           result  \\\n",
+       "ad2b  relax  __main__              {'energy': -14.0, 'volume': 42.875}   \n",
+       "0275  relax  __main__  {'energy': -14.4, 'volume': 46.656000000000006}   \n",
+       "ba58  relax  __main__  {'energy': -14.8, 'volume': 50.653000000000006}   \n",
+       "\n",
+       "                               timestart                            timestop  \\\n",
+       "ad2b 2026-08-07 17:20:56.643192053+00:00 2026-08-07 17:20:56.744186878+00:00   \n",
+       "0275 2026-08-07 17:20:56.746165514+00:00 2026-08-07 17:20:56.846971989+00:00   \n",
+       "ba58 2026-08-07 17:20:56.848810196+00:00 2026-08-07 17:20:56.949890375+00:00   \n",
+       "\n",
+       "      walltime           project    a  k  \n",
+       "ad2b  0.100995  five-minute-demo  3.5  4  \n",
+       "0275  0.100806  five-minute-demo  3.6  4  \n",
+       "ba58  0.101080  five-minute-demo  3.7  4  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@fleche\n",
+    "def relax(a, k):\n",
+    "    time.sleep(0.1)                   # pretend\n",
+    "    return {\"energy\": -a * k, \"volume\": a ** 3}\n",
+    "\n",
+    "\n",
+    "with tags(project=\"five-minute-demo\"):\n",
+    "    for a_lat in (3.5, 3.6, 3.7):\n",
+    "        relax(a_lat, k=4)\n",
+    "\n",
+    "relax.fleche.query().table(arguments=[\"a\", \"k\"], results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35c50cd6",
+   "metadata": {},
+   "source": [
+    "Queries chain (`filter`, `unique`, `sorted`, ...) and terminal methods can `transfer()`\n",
+    "matching entries to another cache or `evict()` them; `cache().table()` shows everything\n",
+    "across all functions.\n",
+    "\n",
+    "## 4. Plays well with executors — including executorlib\n",
+    "\n",
+    "`wrap_executor` patches any `concurrent.futures`-style executor. Fleche-decorated\n",
+    "functions carry the active cache into worker processes automatically, and cache hits\n",
+    "come back as already-completed futures **without ever being submitted**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bc4603e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:20:56.974575Z",
+     "iopub.status.busy": "2026-08-07T17:20:56.974338Z",
+     "iopub.status.idle": "2026-08-07T17:20:59.421714Z",
+     "shell.execute_reply": "2026-08-07T17:20:59.420438Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cold: [0, 1, 8, 27] in 2.40 s\n",
+      "warm: [0, 1, 8, 27] in 0.04 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from executorlib import SingleNodeExecutor as Executor\n",
+    "except ImportError:\n",
+    "    from concurrent.futures import ProcessPoolExecutor as Executor\n",
+    "\n",
+    "\n",
+    "@fleche\n",
+    "def md_step(x):\n",
+    "    time.sleep(1)                     # pretend\n",
+    "    return x ** 3\n",
+    "\n",
+    "\n",
+    "for attempt in (\"cold\", \"warm\"):\n",
+    "    start = time.time()\n",
+    "    with Executor(max_workers=4) as ex:\n",
+    "        wrap_executor(ex)\n",
+    "        results = [f.result() for f in [ex.submit(md_step, x) for x in range(4)]]\n",
+    "    print(f\"{attempt}: {results} in {time.time() - start:.2f} s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08ec26f9",
+   "metadata": {},
+   "source": [
+    "On the warm pass every future is done before `submit` returns — the executor never sees\n",
+    "the work. Executor-specific kwargs like executorlib's `resource_dict` are forwarded\n",
+    "transparently.\n",
+    "\n",
+    "## 5. Things worth a second look\n",
+    "\n",
+    "- **Configuration by file** — drop a `fleche.toml` next to your project (or in `$HOME`);\n",
+    "  decorated code never changes:\n",
+    "\n",
+    "  ```toml\n",
+    "  [default]\n",
+    "  cache = \"persistent\"\n",
+    "\n",
+    "  [persistent]\n",
+    "  template = \"cloudpickle\"\n",
+    "  root = \"~/.cache/fleche\"\n",
+    "  ```\n",
+    "\n",
+    "- **HDF5 storage** — `template = \"bagofholding_hdf\"` stores values via pyiron's\n",
+    "  [bagofholding](https://github.com/pyiron/bagofholding).\n",
+    "- **SQL call index** — keep call records in SQLite/Postgres for server-side filtering\n",
+    "  over large caches, while values stay in files or HDF5.\n",
+    "- **Caches on other machines** — `SshCache` forwards a whole cache over SSH to a\n",
+    "  `python -m fleche remote --serve` process on, say, your cluster's login node. Stack a\n",
+    "  local cache in front (`CacheStack`) for read-through with back-fill, or fan reads over\n",
+    "  teammates' caches with a read-only `CachePool`.\n",
+    "- **Take results home** — `query().transfer(other_cache)` moves selected results\n",
+    "  between caches (cluster → laptop); see `TransferWorkflow.ipynb`.\n",
+    "- **Invalidation you control** — bump `@fleche(version=2)` to retire old entries, or\n",
+    "  `hash_code=True` to invalidate on any code edit; `ignore=`/`require=` shape the key.\n",
+    "- **Signed storage** — HMAC-sign pickle-family entries with a `secret_key`; tampered or\n",
+    "  wrong-key entries surface as plain cache misses, never as executed code.\n",
+    "\n",
+    "## Where to go next\n",
+    "\n",
+    "- Docs: <https://fleche.readthedocs.io>\n",
+    "- Source: <https://github.com/pmrv/fleche>\n",
+    "- Deeper notebooks in this directory: `GettingStarted`, `ExtraMethods`,\n",
+    "  `StorageBackends`, `ConcurrentExecution`, `CacheStack`, `SecureStorage`,\n",
+    "  `TransferWorkflow`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -3,13 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ac3ee647",
+   "id": "1cd89779",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:53.036853Z",
-     "iopub.status.busy": "2026-08-07T17:20:53.036683Z",
-     "iopub.status.idle": "2026-08-07T17:20:53.185560Z",
-     "shell.execute_reply": "2026-08-07T17:20:53.184356Z"
+     "iopub.execute_input": "2026-08-07T17:27:07.700030Z",
+     "iopub.status.busy": "2026-08-07T17:27:07.699833Z",
+     "iopub.status.idle": "2026-08-07T17:27:07.848925Z",
+     "shell.execute_reply": "2026-08-07T17:27:07.847603Z"
     }
    },
    "outputs": [],
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "787d5ce6",
+   "id": "2b4f22e7",
    "metadata": {},
    "source": [
     "# Fleche in Five Minutes\n",
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3096adaf",
+   "id": "fa0bcebb",
    "metadata": {},
    "source": [
     "## 1. Decorate and forget\n",
@@ -54,13 +54,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "d0dfa14b",
+   "id": "a966def8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:53.188382Z",
-     "iopub.status.busy": "2026-08-07T17:20:53.188160Z",
-     "iopub.status.idle": "2026-08-07T17:20:53.728584Z",
-     "shell.execute_reply": "2026-08-07T17:20:53.727432Z"
+     "iopub.execute_input": "2026-08-07T17:27:07.852541Z",
+     "iopub.status.busy": "2026-08-07T17:27:07.852297Z",
+     "iopub.status.idle": "2026-08-07T17:27:08.360707Z",
+     "shell.execute_reply": "2026-08-07T17:27:08.359671Z"
     }
    },
    "outputs": [],
@@ -75,13 +75,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "7c518acf",
+   "id": "79ac0557",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:53.731531Z",
-     "iopub.status.busy": "2026-08-07T17:20:53.731225Z",
-     "iopub.status.idle": "2026-08-07T17:20:55.741402Z",
-     "shell.execute_reply": "2026-08-07T17:20:55.740259Z"
+     "iopub.execute_input": "2026-08-07T17:27:08.363371Z",
+     "iopub.status.busy": "2026-08-07T17:27:08.363075Z",
+     "iopub.status.idle": "2026-08-07T17:27:10.374197Z",
+     "shell.execute_reply": "2026-08-07T17:27:10.373018Z"
     }
    },
    "outputs": [
@@ -97,7 +97,7 @@
      "output_type": "stream",
      "text": [
       "16   <- first call: 2.00 s\n",
-      "16   <- second call: 0.0015 s\n"
+      "16   <- second call: 0.0016 s\n"
      ]
     }
    ],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c1932ef",
+   "id": "db5e4f85",
    "metadata": {},
    "source": [
     "The second call never enters the function body. Unlike `lru_cache`, the result is on\n",
@@ -130,13 +130,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9f4c538d",
+   "id": "d5ec553c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:55.743616Z",
-     "iopub.status.busy": "2026-08-07T17:20:55.743406Z",
-     "iopub.status.idle": "2026-08-07T17:20:55.748564Z",
-     "shell.execute_reply": "2026-08-07T17:20:55.747301Z"
+     "iopub.execute_input": "2026-08-07T17:27:10.376337Z",
+     "iopub.status.busy": "2026-08-07T17:27:10.376125Z",
+     "iopub.status.idle": "2026-08-07T17:27:10.380841Z",
+     "shell.execute_reply": "2026-08-07T17:27:10.379751Z"
     }
    },
    "outputs": [
@@ -156,7 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c72c4055",
+   "id": "205d004a",
    "metadata": {},
    "source": [
     "The cache is just a directory — `rsync` it, back it up, share it with your group.\n",
@@ -171,13 +171,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "41dd9bef",
+   "id": "f16b7988",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:55.750625Z",
-     "iopub.status.busy": "2026-08-07T17:20:55.750407Z",
-     "iopub.status.idle": "2026-08-07T17:20:55.843935Z",
-     "shell.execute_reply": "2026-08-07T17:20:55.843251Z"
+     "iopub.execute_input": "2026-08-07T17:27:10.382964Z",
+     "iopub.status.busy": "2026-08-07T17:27:10.382769Z",
+     "iopub.status.idle": "2026-08-07T17:27:10.472007Z",
+     "shell.execute_reply": "2026-08-07T17:27:10.471286Z"
     }
    },
    "outputs": [
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaa8041b",
+   "id": "17374400",
    "metadata": {},
    "source": [
     "The digest machinery is pluggable for third-party types. If you use ASE:\n",
@@ -219,13 +219,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "dfba66c2",
+   "id": "6130812e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:55.854407Z",
-     "iopub.status.busy": "2026-08-07T17:20:55.854178Z",
-     "iopub.status.idle": "2026-08-07T17:20:56.637324Z",
-     "shell.execute_reply": "2026-08-07T17:20:56.636088Z"
+     "iopub.execute_input": "2026-08-07T17:27:10.479790Z",
+     "iopub.status.busy": "2026-08-07T17:27:10.479514Z",
+     "iopub.status.idle": "2026-08-07T17:27:11.232626Z",
+     "shell.execute_reply": "2026-08-07T17:27:11.231596Z"
     }
    },
    "outputs": [
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03f8d80d",
+   "id": "955c4472",
    "metadata": {},
    "source": [
     "## 3. Your cache is a database\n",
@@ -272,13 +272,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "7900dba9",
+   "id": "5a736640",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:56.640049Z",
-     "iopub.status.busy": "2026-08-07T17:20:56.639694Z",
-     "iopub.status.idle": "2026-08-07T17:20:56.972089Z",
-     "shell.execute_reply": "2026-08-07T17:20:56.971069Z"
+     "iopub.execute_input": "2026-08-07T17:27:11.235182Z",
+     "iopub.status.busy": "2026-08-07T17:27:11.234848Z",
+     "iopub.status.idle": "2026-08-07T17:27:11.567679Z",
+     "shell.execute_reply": "2026-08-07T17:27:11.566251Z"
     }
    },
    "outputs": [
@@ -320,9 +320,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.0, 'volume': 42.875}</td>\n",
-       "      <td>2026-08-07 17:20:56.643192053+00:00</td>\n",
-       "      <td>2026-08-07 17:20:56.744186878+00:00</td>\n",
-       "      <td>0.100995</td>\n",
+       "      <td>2026-08-07 17:27:11.237918139+00:00</td>\n",
+       "      <td>2026-08-07 17:27:11.339107752+00:00</td>\n",
+       "      <td>0.101190</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.5</td>\n",
        "      <td>4</td>\n",
@@ -332,9 +332,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
-       "      <td>2026-08-07 17:20:56.746165514+00:00</td>\n",
-       "      <td>2026-08-07 17:20:56.846971989+00:00</td>\n",
-       "      <td>0.100806</td>\n",
+       "      <td>2026-08-07 17:27:11.340700626+00:00</td>\n",
+       "      <td>2026-08-07 17:27:11.441451073+00:00</td>\n",
+       "      <td>0.100750</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.6</td>\n",
        "      <td>4</td>\n",
@@ -344,9 +344,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
-       "      <td>2026-08-07 17:20:56.848810196+00:00</td>\n",
-       "      <td>2026-08-07 17:20:56.949890375+00:00</td>\n",
-       "      <td>0.101080</td>\n",
+       "      <td>2026-08-07 17:27:11.443126440+00:00</td>\n",
+       "      <td>2026-08-07 17:27:11.543898106+00:00</td>\n",
+       "      <td>0.100772</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.7</td>\n",
        "      <td>4</td>\n",
@@ -362,14 +362,14 @@
        "ba58  relax  __main__  {'energy': -14.8, 'volume': 50.653000000000006}   \n",
        "\n",
        "                               timestart                            timestop  \\\n",
-       "ad2b 2026-08-07 17:20:56.643192053+00:00 2026-08-07 17:20:56.744186878+00:00   \n",
-       "0275 2026-08-07 17:20:56.746165514+00:00 2026-08-07 17:20:56.846971989+00:00   \n",
-       "ba58 2026-08-07 17:20:56.848810196+00:00 2026-08-07 17:20:56.949890375+00:00   \n",
+       "ad2b 2026-08-07 17:27:11.237918139+00:00 2026-08-07 17:27:11.339107752+00:00   \n",
+       "0275 2026-08-07 17:27:11.340700626+00:00 2026-08-07 17:27:11.441451073+00:00   \n",
+       "ba58 2026-08-07 17:27:11.443126440+00:00 2026-08-07 17:27:11.543898106+00:00   \n",
        "\n",
        "      walltime           project    a  k  \n",
-       "ad2b  0.100995  five-minute-demo  3.5  4  \n",
-       "0275  0.100806  five-minute-demo  3.6  4  \n",
-       "ba58  0.101080  five-minute-demo  3.7  4  "
+       "ad2b  0.101190  five-minute-demo  3.5  4  \n",
+       "0275  0.100750  five-minute-demo  3.6  4  \n",
+       "ba58  0.100772  five-minute-demo  3.7  4  "
       ]
      },
      "execution_count": 7,
@@ -393,7 +393,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35c50cd6",
+   "id": "dc5900ab",
    "metadata": {},
    "source": [
     "Queries chain (`filter`, `unique`, `sorted`, ...) and terminal methods can `transfer()`\n",
@@ -410,13 +410,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "bc4603e2",
+   "id": "f22c425f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:56.974575Z",
-     "iopub.status.busy": "2026-08-07T17:20:56.974338Z",
-     "iopub.status.idle": "2026-08-07T17:20:59.421714Z",
-     "shell.execute_reply": "2026-08-07T17:20:59.420438Z"
+     "iopub.execute_input": "2026-08-07T17:27:11.570012Z",
+     "iopub.status.busy": "2026-08-07T17:27:11.569733Z",
+     "iopub.status.idle": "2026-08-07T17:27:13.955590Z",
+     "shell.execute_reply": "2026-08-07T17:27:13.954629Z"
     }
    },
    "outputs": [
@@ -424,8 +424,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cold: [0, 1, 8, 27] in 2.40 s\n",
-      "warm: [0, 1, 8, 27] in 0.04 s\n"
+      "cold: [0, 1, 8, 27] in 2.34 s\n",
+      "warm: [0, 1, 8, 27] in 0.03 s\n"
      ]
     }
    ],
@@ -452,14 +452,134 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08ec26f9",
+   "id": "f8360425",
    "metadata": {},
    "source": [
     "On the warm pass every future is done before `submit` returns — the executor never sees\n",
     "the work. Executor-specific kwargs like executorlib's `resource_dict` are forwarded\n",
     "transparently.\n",
     "\n",
-    "## 5. Things worth a second look\n",
+    "## 5. Stack caches — a read-only, prepopulated base\n",
+    "\n",
+    "Say your group already has a cache full of results — on a shared filesystem, or a\n",
+    "teammate's directory. `CacheStack` puts your own writable cache *in front* of it: loads\n",
+    "fall through to the base and hits are back-filled into the front, while saves only ever\n",
+    "touch the front. Wrap the base in `ReadOnlyCache` and nothing you do can modify it —\n",
+    "writes and evictions raise `Rejected`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8ebfccac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:27:13.958333Z",
+     "iopub.status.busy": "2026-08-07T17:27:13.958130Z",
+     "iopub.status.idle": "2026-08-07T17:27:15.967726Z",
+     "shell.execute_reply": "2026-08-07T17:27:15.966172Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "computing DOS for fcc-Al ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dos(fcc-Al)   <- from the shared base: 0.001 s\n",
+      "computing DOS for bcc-Fe ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dos(bcc-Fe)   <- not in the base: computed here\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fleche.caches import CacheStack, ReadOnlyCache\n",
+    "from fleche.storage.memory import ValueMemory, CallMemory\n",
+    "\n",
+    "\n",
+    "@fleche\n",
+    "def phonon_dos(structure):\n",
+    "    print(f\"computing DOS for {structure} ...\")\n",
+    "    time.sleep(1)                     # pretend\n",
+    "    return f\"dos({structure})\"\n",
+    "\n",
+    "\n",
+    "# the group's prepopulated cache (in memory here; files or SSH in real life)\n",
+    "shared = Cache(ValueMemory({}), CallMemory({}))\n",
+    "with cache(shared):\n",
+    "    phonon_dos(\"fcc-Al\")\n",
+    "\n",
+    "mine = Cache(ValueMemory({}), CallMemory({}))\n",
+    "stack = CacheStack((mine, ReadOnlyCache(shared)))\n",
+    "\n",
+    "with cache(stack):\n",
+    "    start = time.time()\n",
+    "    print(phonon_dos(\"fcc-Al\"), f\"  <- from the shared base: {time.time() - start:.3f} s\")\n",
+    "    print(phonon_dos(\"bcc-Fe\"), \"  <- not in the base: computed here\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7eebee17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:27:15.970099Z",
+     "iopub.status.busy": "2026-08-07T17:27:15.969904Z",
+     "iopub.status.idle": "2026-08-07T17:27:15.975062Z",
+     "shell.execute_reply": "2026-08-07T17:27:15.973714Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "back-filled into my cache: True\n",
+      "new result in my cache:    True\n",
+      "shared base untouched:     True\n"
+     ]
+    }
+   ],
+   "source": [
+    "with cache(mine):\n",
+    "    print(\"back-filled into my cache:\", phonon_dos.fleche.contains(\"fcc-Al\"))\n",
+    "    print(\"new result in my cache:   \", phonon_dos.fleche.contains(\"bcc-Fe\"))\n",
+    "with cache(shared):\n",
+    "    print(\"shared base untouched:    \", not phonon_dos.fleche.contains(\"bcc-Fe\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f73d9e00",
+   "metadata": {},
+   "source": [
+    "The same stack straight from `fleche.toml` — an array of tables, first entry is the\n",
+    "front where saves land:\n",
+    "\n",
+    "```toml\n",
+    "[[stacked]]\n",
+    "template = \"memory\"\n",
+    "\n",
+    "[[stacked]]\n",
+    "template = \"cloudpickle\"\n",
+    "root = \"/groupshare/fleche-cache\"\n",
+    "read_only = true\n",
+    "```\n",
+    "\n",
+    "## 6. Things worth a second look\n",
     "\n",
     "- **Configuration by file** — drop a `fleche.toml` next to your project (or in `$HOME`);\n",
     "  decorated code never changes:\n",
@@ -478,9 +598,9 @@
     "- **SQL call index** — keep call records in SQLite/Postgres for server-side filtering\n",
     "  over large caches, while values stay in files or HDF5.\n",
     "- **Caches on other machines** — `SshCache` forwards a whole cache over SSH to a\n",
-    "  `python -m fleche remote --serve` process on, say, your cluster's login node. Stack a\n",
-    "  local cache in front (`CacheStack`) for read-through with back-fill, or fan reads over\n",
-    "  teammates' caches with a read-only `CachePool`.\n",
+    "  `python -m fleche remote --serve` process on, say, your cluster's login node. Stack it\n",
+    "  behind a local cache exactly as above, or fan reads over several teammates' caches at\n",
+    "  once with a read-only `CachePool`.\n",
     "- **Take results home** — `query().transfer(other_cache)` moves selected results\n",
     "  between caches (cluster → laptop); see `TransferWorkflow.ipynb`.\n",
     "- **Invalidation you control** — bump `@fleche(version=2)` to retire old entries, or\n",

--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -6,10 +6,10 @@
    "id": "ac3ee647",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:13.378150Z",
-     "iopub.status.busy": "2026-08-07T18:33:13.377976Z",
-     "iopub.status.idle": "2026-08-07T18:33:13.503182Z",
-     "shell.execute_reply": "2026-08-07T18:33:13.502389Z"
+     "iopub.execute_input": "2026-08-07T18:36:49.188995Z",
+     "iopub.status.busy": "2026-08-07T18:36:49.188899Z",
+     "iopub.status.idle": "2026-08-07T18:36:49.308514Z",
+     "shell.execute_reply": "2026-08-07T18:36:49.308153Z"
     }
    },
    "outputs": [],
@@ -37,6 +37,7 @@
     "\n",
     "```\n",
     "pip install fleche          # or: conda install -c conda-forge fleche\n",
+    "pip install ase fleche-ase executorlib      # for the ASE and executor sections\n",
     "```"
    ]
   },
@@ -57,10 +58,10 @@
    "id": "d0dfa14b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:13.505236Z",
-     "iopub.status.busy": "2026-08-07T18:33:13.504955Z",
-     "iopub.status.idle": "2026-08-07T18:33:13.737077Z",
-     "shell.execute_reply": "2026-08-07T18:33:13.736328Z"
+     "iopub.execute_input": "2026-08-07T18:36:49.310486Z",
+     "iopub.status.busy": "2026-08-07T18:36:49.310380Z",
+     "iopub.status.idle": "2026-08-07T18:36:49.525265Z",
+     "shell.execute_reply": "2026-08-07T18:36:49.524644Z"
     }
    },
    "outputs": [],
@@ -78,10 +79,10 @@
    "id": "7c518acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:13.738754Z",
-     "iopub.status.busy": "2026-08-07T18:33:13.738402Z",
-     "iopub.status.idle": "2026-08-07T18:33:15.747684Z",
-     "shell.execute_reply": "2026-08-07T18:33:15.746901Z"
+     "iopub.execute_input": "2026-08-07T18:36:49.527026Z",
+     "iopub.status.busy": "2026-08-07T18:36:49.526802Z",
+     "iopub.status.idle": "2026-08-07T18:36:51.532652Z",
+     "shell.execute_reply": "2026-08-07T18:36:51.532370Z"
     }
    },
    "outputs": [
@@ -97,7 +98,7 @@
      "output_type": "stream",
      "text": [
       "16   <- first call: 2.00 s\n",
-      "16   <- second call: 0.0011 s\n"
+      "16   <- second call: 0.0006 s\n"
      ]
     }
    ],
@@ -133,10 +134,10 @@
    "id": "9f4c538d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:15.749293Z",
-     "iopub.status.busy": "2026-08-07T18:33:15.749059Z",
-     "iopub.status.idle": "2026-08-07T18:33:15.752826Z",
-     "shell.execute_reply": "2026-08-07T18:33:15.752119Z"
+     "iopub.execute_input": "2026-08-07T18:36:51.534212Z",
+     "iopub.status.busy": "2026-08-07T18:36:51.534101Z",
+     "iopub.status.idle": "2026-08-07T18:36:51.536483Z",
+     "shell.execute_reply": "2026-08-07T18:36:51.536203Z"
     }
    },
    "outputs": [
@@ -174,10 +175,10 @@
    "id": "41dd9bef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:15.754203Z",
-     "iopub.status.busy": "2026-08-07T18:33:15.754089Z",
-     "iopub.status.idle": "2026-08-07T18:33:15.801263Z",
-     "shell.execute_reply": "2026-08-07T18:33:15.800813Z"
+     "iopub.execute_input": "2026-08-07T18:36:51.538436Z",
+     "iopub.status.busy": "2026-08-07T18:36:51.538340Z",
+     "iopub.status.idle": "2026-08-07T18:36:51.578590Z",
+     "shell.execute_reply": "2026-08-07T18:36:51.578147Z"
     }
    },
    "outputs": [
@@ -222,10 +223,10 @@
    "id": "dfba66c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:15.805807Z",
-     "iopub.status.busy": "2026-08-07T18:33:15.805551Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.282810Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.282096Z"
+     "iopub.execute_input": "2026-08-07T18:36:51.580264Z",
+     "iopub.status.busy": "2026-08-07T18:36:51.580126Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.028764Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.027952Z"
     }
    },
    "outputs": [
@@ -240,21 +241,20 @@
     }
    ],
    "source": [
-    "try:\n",
-    "    from ase.build import bulk\n",
-    "    from ase.calculators.emt import EMT\n",
+    "from ase.build import bulk\n",
+    "from ase.calculators.emt import EMT\n",
     "\n",
-    "    @fleche\n",
-    "    def energy(atoms):\n",
-    "        print(\"running EMT ...\")\n",
-    "        atoms = atoms.copy()\n",
-    "        atoms.calc = EMT()\n",
-    "        return atoms.get_potential_energy()\n",
     "\n",
-    "    print(energy(bulk(\"Cu\", cubic=True)))\n",
-    "    print(energy(bulk(\"Cu\", cubic=True)))   # freshly built Atoms -> cache hit\n",
-    "except ImportError:\n",
-    "    print(\"pip install ase fleche-ase to run this cell\")"
+    "@fleche\n",
+    "def energy(atoms):\n",
+    "    print(\"running EMT ...\")\n",
+    "    atoms = atoms.copy()\n",
+    "    atoms.calc = EMT()\n",
+    "    return atoms.get_potential_energy()\n",
+    "\n",
+    "\n",
+    "print(energy(bulk(\"Cu\", cubic=True)))\n",
+    "print(energy(bulk(\"Cu\", cubic=True)))   # freshly built Atoms -> cache hit"
    ]
   },
   {
@@ -273,10 +273,10 @@
    "id": "16a7b1a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.284910Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.284449Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.301745Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.301004Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.030539Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.030123Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.043252Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.042472Z"
     }
    },
    "outputs": [
@@ -330,10 +330,10 @@
    "id": "38815c03",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.303852Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.303599Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.314498Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.313833Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.044706Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.044603Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.050412Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.049897Z"
     }
    },
    "outputs": [
@@ -394,10 +394,10 @@
    "id": "7900dba9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.315945Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.315733Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.644312Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.643806Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.052376Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.052273Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.371664Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.371127Z"
     }
    },
    "outputs": [
@@ -439,9 +439,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.0, 'volume': 42.875}</td>\n",
-       "      <td>2026-08-07 14:33:16.318236589-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.418902874-04:00</td>\n",
-       "      <td>0.100666</td>\n",
+       "      <td>2026-08-07 14:36:52.053804398-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.154572487-04:00</td>\n",
+       "      <td>0.100768</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.5</td>\n",
        "      <td>4</td>\n",
@@ -451,9 +451,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
-       "      <td>2026-08-07 14:33:16.420043945-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.520668507-04:00</td>\n",
-       "      <td>0.100625</td>\n",
+       "      <td>2026-08-07 14:36:52.155696630-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.256235838-04:00</td>\n",
+       "      <td>0.100539</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.6</td>\n",
        "      <td>4</td>\n",
@@ -463,9 +463,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
-       "      <td>2026-08-07 14:33:16.522812843-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.623849154-04:00</td>\n",
-       "      <td>0.101036</td>\n",
+       "      <td>2026-08-07 14:36:52.257377625-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.357872009-04:00</td>\n",
+       "      <td>0.100494</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.7</td>\n",
        "      <td>4</td>\n",
@@ -481,14 +481,14 @@
        "ba58  relax  __main__  {'energy': -14.8, 'volume': 50.653000000000006}   \n",
        "\n",
        "                               timestart                            timestop  \\\n",
-       "ad2b 2026-08-07 14:33:16.318236589-04:00 2026-08-07 14:33:16.418902874-04:00   \n",
-       "0275 2026-08-07 14:33:16.420043945-04:00 2026-08-07 14:33:16.520668507-04:00   \n",
-       "ba58 2026-08-07 14:33:16.522812843-04:00 2026-08-07 14:33:16.623849154-04:00   \n",
+       "ad2b 2026-08-07 14:36:52.053804398-04:00 2026-08-07 14:36:52.154572487-04:00   \n",
+       "0275 2026-08-07 14:36:52.155696630-04:00 2026-08-07 14:36:52.256235838-04:00   \n",
+       "ba58 2026-08-07 14:36:52.257377625-04:00 2026-08-07 14:36:52.357872009-04:00   \n",
        "\n",
        "      walltime           project    a  k  \n",
-       "ad2b  0.100666  five-minute-demo  3.5  4  \n",
-       "0275  0.100625  five-minute-demo  3.6  4  \n",
-       "ba58  0.101036  five-minute-demo  3.7  4  "
+       "ad2b  0.100768  five-minute-demo  3.5  4  \n",
+       "0275  0.100539  five-minute-demo  3.6  4  \n",
+       "ba58  0.100494  five-minute-demo  3.7  4  "
       ]
      },
      "execution_count": 9,
@@ -525,10 +525,10 @@
    "id": "aa558a10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.645859Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.645675Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.661729Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.661268Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.373477Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.373360Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.386859Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.386153Z"
     }
    },
    "outputs": [
@@ -577,9 +577,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
-       "      <td>2026-08-07 14:33:16.522812843-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.623849154-04:00</td>\n",
-       "      <td>0.101036</td>\n",
+       "      <td>2026-08-07 14:36:52.257377625-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.357872009-04:00</td>\n",
+       "      <td>0.100494</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.7</td>\n",
        "      <td>4</td>\n",
@@ -589,9 +589,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
-       "      <td>2026-08-07 14:33:16.420043945-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.520668507-04:00</td>\n",
-       "      <td>0.100625</td>\n",
+       "      <td>2026-08-07 14:36:52.155696630-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.256235838-04:00</td>\n",
+       "      <td>0.100539</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.6</td>\n",
        "      <td>4</td>\n",
@@ -606,12 +606,12 @@
        "0275  relax  __main__  {'energy': -14.4, 'volume': 46.656000000000006}   \n",
        "\n",
        "                               timestart                            timestop  \\\n",
-       "ba58 2026-08-07 14:33:16.522812843-04:00 2026-08-07 14:33:16.623849154-04:00   \n",
-       "0275 2026-08-07 14:33:16.420043945-04:00 2026-08-07 14:33:16.520668507-04:00   \n",
+       "ba58 2026-08-07 14:36:52.257377625-04:00 2026-08-07 14:36:52.357872009-04:00   \n",
+       "0275 2026-08-07 14:36:52.155696630-04:00 2026-08-07 14:36:52.256235838-04:00   \n",
        "\n",
        "      walltime           project    a  k  \n",
-       "ba58  0.101036  five-minute-demo  3.7  4  \n",
-       "0275  0.100625  five-minute-demo  3.6  4  "
+       "ba58  0.100494  five-minute-demo  3.7  4  \n",
+       "0275  0.100539  five-minute-demo  3.6  4  "
       ]
      },
      "execution_count": 10,
@@ -647,10 +647,10 @@
    "id": "8ad1922d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.663672Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.663536Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.672706Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.672233Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.388406Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.388176Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.400420Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.399910Z"
     }
    },
    "outputs": [
@@ -688,90 +688,90 @@
        "      <th>6bd4</th>\n",
        "      <td>expensive</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:13.742344618-04:00</td>\n",
-       "      <td>2026-08-07 14:33:15.743030071-04:00</td>\n",
-       "      <td>2.000685</td>\n",
+       "      <td>2026-08-07 14:36:49.529283046-04:00</td>\n",
+       "      <td>2026-08-07 14:36:51.529879808-04:00</td>\n",
+       "      <td>2.000597</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>fcbd</th>\n",
        "      <td>norm</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:15.765870333-04:00</td>\n",
-       "      <td>2026-08-07 14:33:15.782294989-04:00</td>\n",
-       "      <td>0.016425</td>\n",
+       "      <td>2026-08-07 14:36:51.549785614-04:00</td>\n",
+       "      <td>2026-08-07 14:36:51.566371441-04:00</td>\n",
+       "      <td>0.016586</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>31e0</th>\n",
        "      <td>energy</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.275425196-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.279080153-04:00</td>\n",
-       "      <td>0.003655</td>\n",
+       "      <td>2026-08-07 14:36:52.022333145-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.025355101-04:00</td>\n",
+       "      <td>0.003022</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7104</th>\n",
        "      <td>Simulation.run</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.289031744-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.295549631-04:00</td>\n",
-       "      <td>0.006518</td>\n",
+       "      <td>2026-08-07 14:36:52.032764196-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.037906885-04:00</td>\n",
+       "      <td>0.005143</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>b439</th>\n",
        "      <td>Simulation.run</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.297431231-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.298872471-04:00</td>\n",
-       "      <td>0.001441</td>\n",
+       "      <td>2026-08-07 14:36:52.039353132-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.040598631-04:00</td>\n",
+       "      <td>0.001245</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>cb7a</th>\n",
        "      <td>free_energy</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.306963444-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.307482958-04:00</td>\n",
-       "      <td>0.000520</td>\n",
+       "      <td>2026-08-07 14:36:52.046242237-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.046474218-04:00</td>\n",
+       "      <td>0.000232</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>b823</th>\n",
        "      <td>free_energy</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.310760021-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.311264992-04:00</td>\n",
-       "      <td>0.000505</td>\n",
+       "      <td>2026-08-07 14:36:52.047894001-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.048075914-04:00</td>\n",
+       "      <td>0.000182</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ad2b</th>\n",
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.318236589-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.418902874-04:00</td>\n",
-       "      <td>0.100666</td>\n",
+       "      <td>2026-08-07 14:36:52.053804398-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.154572487-04:00</td>\n",
+       "      <td>0.100768</td>\n",
        "      <td>five-minute-demo</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0275</th>\n",
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.420043945-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.520668507-04:00</td>\n",
-       "      <td>0.100625</td>\n",
+       "      <td>2026-08-07 14:36:52.155696630-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.256235838-04:00</td>\n",
+       "      <td>0.100539</td>\n",
        "      <td>five-minute-demo</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ba58</th>\n",
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:33:16.522812843-04:00</td>\n",
-       "      <td>2026-08-07 14:33:16.623849154-04:00</td>\n",
-       "      <td>0.101036</td>\n",
+       "      <td>2026-08-07 14:36:52.257377625-04:00</td>\n",
+       "      <td>2026-08-07 14:36:52.357872009-04:00</td>\n",
+       "      <td>0.100494</td>\n",
        "      <td>five-minute-demo</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -780,28 +780,28 @@
       ],
       "text/plain": [
        "                name    module                           timestart  \\\n",
-       "6bd4       expensive  __main__ 2026-08-07 14:33:13.742344618-04:00   \n",
-       "fcbd            norm  __main__ 2026-08-07 14:33:15.765870333-04:00   \n",
-       "31e0          energy  __main__ 2026-08-07 14:33:16.275425196-04:00   \n",
-       "7104  Simulation.run  __main__ 2026-08-07 14:33:16.289031744-04:00   \n",
-       "b439  Simulation.run  __main__ 2026-08-07 14:33:16.297431231-04:00   \n",
-       "cb7a     free_energy  __main__ 2026-08-07 14:33:16.306963444-04:00   \n",
-       "b823     free_energy  __main__ 2026-08-07 14:33:16.310760021-04:00   \n",
-       "ad2b           relax  __main__ 2026-08-07 14:33:16.318236589-04:00   \n",
-       "0275           relax  __main__ 2026-08-07 14:33:16.420043945-04:00   \n",
-       "ba58           relax  __main__ 2026-08-07 14:33:16.522812843-04:00   \n",
+       "6bd4       expensive  __main__ 2026-08-07 14:36:49.529283046-04:00   \n",
+       "fcbd            norm  __main__ 2026-08-07 14:36:51.549785614-04:00   \n",
+       "31e0          energy  __main__ 2026-08-07 14:36:52.022333145-04:00   \n",
+       "7104  Simulation.run  __main__ 2026-08-07 14:36:52.032764196-04:00   \n",
+       "b439  Simulation.run  __main__ 2026-08-07 14:36:52.039353132-04:00   \n",
+       "cb7a     free_energy  __main__ 2026-08-07 14:36:52.046242237-04:00   \n",
+       "b823     free_energy  __main__ 2026-08-07 14:36:52.047894001-04:00   \n",
+       "ad2b           relax  __main__ 2026-08-07 14:36:52.053804398-04:00   \n",
+       "0275           relax  __main__ 2026-08-07 14:36:52.155696630-04:00   \n",
+       "ba58           relax  __main__ 2026-08-07 14:36:52.257377625-04:00   \n",
        "\n",
        "                                timestop  walltime           project  \n",
-       "6bd4 2026-08-07 14:33:15.743030071-04:00  2.000685               NaN  \n",
-       "fcbd 2026-08-07 14:33:15.782294989-04:00  0.016425               NaN  \n",
-       "31e0 2026-08-07 14:33:16.279080153-04:00  0.003655               NaN  \n",
-       "7104 2026-08-07 14:33:16.295549631-04:00  0.006518               NaN  \n",
-       "b439 2026-08-07 14:33:16.298872471-04:00  0.001441               NaN  \n",
-       "cb7a 2026-08-07 14:33:16.307482958-04:00  0.000520               NaN  \n",
-       "b823 2026-08-07 14:33:16.311264992-04:00  0.000505               NaN  \n",
-       "ad2b 2026-08-07 14:33:16.418902874-04:00  0.100666  five-minute-demo  \n",
-       "0275 2026-08-07 14:33:16.520668507-04:00  0.100625  five-minute-demo  \n",
-       "ba58 2026-08-07 14:33:16.623849154-04:00  0.101036  five-minute-demo  "
+       "6bd4 2026-08-07 14:36:51.529879808-04:00  2.000597               NaN  \n",
+       "fcbd 2026-08-07 14:36:51.566371441-04:00  0.016586               NaN  \n",
+       "31e0 2026-08-07 14:36:52.025355101-04:00  0.003022               NaN  \n",
+       "7104 2026-08-07 14:36:52.037906885-04:00  0.005143               NaN  \n",
+       "b439 2026-08-07 14:36:52.040598631-04:00  0.001245               NaN  \n",
+       "cb7a 2026-08-07 14:36:52.046474218-04:00  0.000232               NaN  \n",
+       "b823 2026-08-07 14:36:52.048075914-04:00  0.000182               NaN  \n",
+       "ad2b 2026-08-07 14:36:52.154572487-04:00  0.100768  five-minute-demo  \n",
+       "0275 2026-08-07 14:36:52.256235838-04:00  0.100539  five-minute-demo  \n",
+       "ba58 2026-08-07 14:36:52.357872009-04:00  0.100494  five-minute-demo  "
       ]
      },
      "execution_count": 11,
@@ -831,10 +831,10 @@
    "id": "bf324a0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.674584Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.674477Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.692703Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.692200Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.402270Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.402160Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.415507Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.414770Z"
     }
    },
    "outputs": [
@@ -883,10 +883,10 @@
    "id": "3b79d4b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.694033Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.693812Z",
-     "iopub.status.idle": "2026-08-07T18:33:16.714522Z",
-     "shell.execute_reply": "2026-08-07T18:33:16.713969Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.416886Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.416793Z",
+     "iopub.status.idle": "2026-08-07T18:36:52.434335Z",
+     "shell.execute_reply": "2026-08-07T18:36:52.433566Z"
     }
    },
    "outputs": [
@@ -923,10 +923,10 @@
    "id": "bc4603e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:16.716054Z",
-     "iopub.status.busy": "2026-08-07T18:33:16.715944Z",
-     "iopub.status.idle": "2026-08-07T18:33:18.513329Z",
-     "shell.execute_reply": "2026-08-07T18:33:18.512428Z"
+     "iopub.execute_input": "2026-08-07T18:36:52.435636Z",
+     "iopub.status.busy": "2026-08-07T18:36:52.435537Z",
+     "iopub.status.idle": "2026-08-07T18:36:54.107065Z",
+     "shell.execute_reply": "2026-08-07T18:36:54.106427Z"
     }
    },
    "outputs": [
@@ -934,16 +934,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cold: [0, 1, 8, 27] in 1.77 s\n",
+      "cold: [0, 1, 8, 27] in 1.64 s\n",
       "warm: [0, 1, 8, 27] in 0.02 s\n"
      ]
     }
    ],
    "source": [
-    "try:\n",
-    "    from executorlib import SingleNodeExecutor as Executor\n",
-    "except ImportError:\n",
-    "    from concurrent.futures import ProcessPoolExecutor as Executor\n",
+    "from executorlib import SingleNodeExecutor as Executor\n",
     "\n",
     "\n",
     "@fleche\n",
@@ -984,10 +981,10 @@
    "id": "54bbd748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:18.515244Z",
-     "iopub.status.busy": "2026-08-07T18:33:18.515095Z",
-     "iopub.status.idle": "2026-08-07T18:33:20.521313Z",
-     "shell.execute_reply": "2026-08-07T18:33:20.520630Z"
+     "iopub.execute_input": "2026-08-07T18:36:54.108665Z",
+     "iopub.status.busy": "2026-08-07T18:36:54.108560Z",
+     "iopub.status.idle": "2026-08-07T18:36:56.114075Z",
+     "shell.execute_reply": "2026-08-07T18:36:56.113349Z"
     }
    },
    "outputs": [
@@ -1046,10 +1043,10 @@
    "id": "5e636dc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T18:33:20.522498Z",
-     "iopub.status.busy": "2026-08-07T18:33:20.522384Z",
-     "iopub.status.idle": "2026-08-07T18:33:20.526106Z",
-     "shell.execute_reply": "2026-08-07T18:33:20.525359Z"
+     "iopub.execute_input": "2026-08-07T18:36:56.115941Z",
+     "iopub.status.busy": "2026-08-07T18:36:56.115834Z",
+     "iopub.status.idle": "2026-08-07T18:36:56.118770Z",
+     "shell.execute_reply": "2026-08-07T18:36:56.118067Z"
     }
    },
    "outputs": [

--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -4,14 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "ac3ee647",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:49.188995Z",
-     "iopub.status.busy": "2026-08-07T18:36:49.188899Z",
-     "iopub.status.idle": "2026-08-07T18:36:49.308514Z",
-     "shell.execute_reply": "2026-08-07T18:36:49.308153Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!rm -rf .five_minute_cache"
@@ -24,7 +17,7 @@
    "source": [
     "# Fleche in Five Minutes\n",
     "\n",
-    "*A persistent cache for expensive Python functions, like `lru_cache` on steroids.*\n",
+    "*A persistent cache for expensive Python functions.*\n",
     "\n",
     "Decorate a function and `fleche` stores every result under a SHA256 key built from the\n",
     "function's identity and the **content** of its arguments. Results survive restarts, can\n",
@@ -56,14 +49,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "d0dfa14b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:49.310486Z",
-     "iopub.status.busy": "2026-08-07T18:36:49.310380Z",
-     "iopub.status.idle": "2026-08-07T18:36:49.525265Z",
-     "shell.execute_reply": "2026-08-07T18:36:49.524644Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
@@ -77,28 +63,15 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "7c518acf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:49.527026Z",
-     "iopub.status.busy": "2026-08-07T18:36:49.526802Z",
-     "iopub.status.idle": "2026-08-07T18:36:51.532652Z",
-     "shell.execute_reply": "2026-08-07T18:36:51.532370Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "crunching 4 ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "crunching 4 ...\n",
       "16   <- first call: 2.00 s\n",
-      "16   <- second call: 0.0006 s\n"
+      "16   <- second call: 0.0009 s\n"
      ]
     }
    ],
@@ -118,6 +91,43 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4abce81a-23f6-432f-b7ae-0b7d13dc0984",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".five_minute_cache/calls/6bd4a06377ba5fe070ae8efc9f652637332ad07fa9db0ab9b88eb441ee301670\n"
+     ]
+    }
+   ],
+   "source": [
+    "ls .five_minute_cache/calls/*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "146b8aee-f607-4948-99e9-a051806c8b4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".five_minute_cache/values/83ada2198553b88cb3d0882f7fca8c4e9531049b978df3e9e3b5d6301c6c0bfa\n",
+      ".five_minute_cache/values/ab7147c672380ae7a61133670895102a6a22971e1aaaefa270a166334d06a49a\n"
+     ]
+    }
+   ],
+   "source": [
+    "ls .five_minute_cache/values/*"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9c1932ef",
    "metadata": {},
@@ -130,16 +140,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "9f4c538d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:51.534212Z",
-     "iopub.status.busy": "2026-08-07T18:36:51.534101Z",
-     "iopub.status.idle": "2026-08-07T18:36:51.536483Z",
-     "shell.execute_reply": "2026-08-07T18:36:51.536203Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -160,7 +163,7 @@
    "id": "c72c4055",
    "metadata": {},
    "source": [
-    "The cache is just a directory: `rsync` it, back it up, share it with your group.\n",
+    "The cache is just a directory: relocatable or sharable.\n",
     "\n",
     "## 2. Keys are content, not object identity\n",
     "\n",
@@ -171,16 +174,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "41dd9bef",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:51.538436Z",
-     "iopub.status.busy": "2026-08-07T18:36:51.538340Z",
-     "iopub.status.idle": "2026-08-07T18:36:51.578590Z",
-     "shell.execute_reply": "2026-08-07T18:36:51.578147Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -212,23 +208,16 @@
    "id": "aaa8041b",
    "metadata": {},
    "source": [
-    "The digest machinery is pluggable for third-party types. If you use ASE:\n",
-    "`pip install fleche-ase` and `Atoms`, `Calculator`, and `VibrationsData` objects digest\n",
-    "correctly with **zero further setup** (registered via entry points):"
+    "\n",
+    "The digest machinery is pluggable for third-party types. \n",
+    "For ASE, there is `fleche-ase`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "dfba66c2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:51.580264Z",
-     "iopub.status.busy": "2026-08-07T18:36:51.580126Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.028764Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.027952Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -269,16 +258,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "16a7b1a2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.030539Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.030123Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.043252Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.042472Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -314,6 +296,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6f0fee83-a760-4d02-ad3a-bf6a75bea864",
+   "metadata": {},
+   "source": [
+    "Like every function, this requires 'pure' functions, ie. no side-effects. If the method changes instance attributes, fleche **won't** replay those."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84c82541",
    "metadata": {},
    "source": [
@@ -326,16 +316,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "38815c03",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.044706Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.044603Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.050412Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.049897Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -370,10 +353,10 @@
    "id": "ceaf73f2",
    "metadata": {},
    "source": [
-    "This hashes *this* function's source, not the code it calls; a change in a helper or in\n",
-    "a dependency invalidates nothing. Where that matters, say so explicitly with\n",
-    "`@fleche(version=...)` and bump it. `ignore=` and `require=` control which arguments take\n",
-    "part in the key at all."
+    "This hashes *this* function's source, you can explicitly invalidate entries or force to keep the cache key equal by setting \n",
+    "`@fleche(version=...)`.\n",
+    "`ignore=` and `require=` control which arguments take part in the key at all.\n",
+    "Results for multiple different versions and code hashes can be part of the the same cache."
    ]
   },
   {
@@ -390,16 +373,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "7900dba9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.052376Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.052273Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.371664Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.371127Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -439,23 +415,11 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.0, 'volume': 42.875}</td>\n",
-       "      <td>2026-08-07 14:36:52.053804398-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.154572487-04:00</td>\n",
-       "      <td>0.100768</td>\n",
+       "      <td>2026-08-10 08:49:05.949266672-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.049993515-04:00</td>\n",
+       "      <td>0.100727</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.5</td>\n",
-       "      <td>4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0275</th>\n",
-       "      <td>relax</td>\n",
-       "      <td>__main__</td>\n",
-       "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
-       "      <td>2026-08-07 14:36:52.155696630-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.256235838-04:00</td>\n",
-       "      <td>0.100539</td>\n",
-       "      <td>five-minute-demo</td>\n",
-       "      <td>3.6</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -463,11 +427,23 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
-       "      <td>2026-08-07 14:36:52.257377625-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.357872009-04:00</td>\n",
-       "      <td>0.100494</td>\n",
+       "      <td>2026-08-10 08:49:06.152344465-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.252923727-04:00</td>\n",
+       "      <td>0.100579</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.7</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0275</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
+       "      <td>2026-08-10 08:49:06.050945997-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.151510239-04:00</td>\n",
+       "      <td>0.100564</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "      <td>3.6</td>\n",
        "      <td>4</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -477,21 +453,21 @@
       "text/plain": [
        "       name    module                                           result  \\\n",
        "ad2b  relax  __main__              {'energy': -14.0, 'volume': 42.875}   \n",
-       "0275  relax  __main__  {'energy': -14.4, 'volume': 46.656000000000006}   \n",
        "ba58  relax  __main__  {'energy': -14.8, 'volume': 50.653000000000006}   \n",
+       "0275  relax  __main__  {'energy': -14.4, 'volume': 46.656000000000006}   \n",
        "\n",
        "                               timestart                            timestop  \\\n",
-       "ad2b 2026-08-07 14:36:52.053804398-04:00 2026-08-07 14:36:52.154572487-04:00   \n",
-       "0275 2026-08-07 14:36:52.155696630-04:00 2026-08-07 14:36:52.256235838-04:00   \n",
-       "ba58 2026-08-07 14:36:52.257377625-04:00 2026-08-07 14:36:52.357872009-04:00   \n",
+       "ad2b 2026-08-10 08:49:05.949266672-04:00 2026-08-10 08:49:06.049993515-04:00   \n",
+       "ba58 2026-08-10 08:49:06.152344465-04:00 2026-08-10 08:49:06.252923727-04:00   \n",
+       "0275 2026-08-10 08:49:06.050945997-04:00 2026-08-10 08:49:06.151510239-04:00   \n",
        "\n",
        "      walltime           project    a  k  \n",
-       "ad2b  0.100768  five-minute-demo  3.5  4  \n",
-       "0275  0.100539  five-minute-demo  3.6  4  \n",
-       "ba58  0.100494  five-minute-demo  3.7  4  "
+       "ad2b  0.100727  five-minute-demo  3.5  4  \n",
+       "ba58  0.100579  five-minute-demo  3.7  4  \n",
+       "0275  0.100564  five-minute-demo  3.6  4  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -515,23 +491,14 @@
    "id": "74212951",
    "metadata": {},
    "source": [
-    "Because that record is a real index, you can also ask what you *nearly* have, which is\n",
-    "worth a look before queueing a run someone already did at a slightly different\n",
-    "parameter:"
+    "Cache is queryable, to filter and sort results or to check what's already been computed."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "aa558a10",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.373477Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.373360Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.386859Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.386153Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -578,9 +545,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
-       "      <td>2026-08-07 14:36:52.257377625-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.357872009-04:00</td>\n",
-       "      <td>0.100494</td>\n",
+       "      <td>2026-08-10 08:49:06.152344465-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.252923727-04:00</td>\n",
+       "      <td>0.100579</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.7</td>\n",
        "      <td>4</td>\n",
@@ -590,9 +557,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
-       "      <td>2026-08-07 14:36:52.155696630-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.256235838-04:00</td>\n",
-       "      <td>0.100539</td>\n",
+       "      <td>2026-08-10 08:49:06.050945997-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.151510239-04:00</td>\n",
+       "      <td>0.100564</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.6</td>\n",
        "      <td>4</td>\n",
@@ -607,15 +574,15 @@
        "0275  relax  __main__  {'energy': -14.4, 'volume': 46.656000000000006}   \n",
        "\n",
        "                               timestart                            timestop  \\\n",
-       "ba58 2026-08-07 14:36:52.257377625-04:00 2026-08-07 14:36:52.357872009-04:00   \n",
-       "0275 2026-08-07 14:36:52.155696630-04:00 2026-08-07 14:36:52.256235838-04:00   \n",
+       "ba58 2026-08-10 08:49:06.152344465-04:00 2026-08-10 08:49:06.252923727-04:00   \n",
+       "0275 2026-08-10 08:49:06.050945997-04:00 2026-08-10 08:49:06.151510239-04:00   \n",
        "\n",
        "      walltime           project    a  k  \n",
-       "ba58  0.100494  five-minute-demo  3.7  4  \n",
-       "0275  0.100539  five-minute-demo  3.6  4  "
+       "ba58  0.100579  five-minute-demo  3.7  4  \n",
+       "0275  0.100564  five-minute-demo  3.6  4  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -644,16 +611,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "8ad1922d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.388406Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.388176Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.400420Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.399910Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -686,94 +646,94 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>6bd4</th>\n",
-       "      <td>expensive</td>\n",
+       "      <th>31e0</th>\n",
+       "      <td>energy</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:49.529283046-04:00</td>\n",
-       "      <td>2026-08-07 14:36:51.529879808-04:00</td>\n",
-       "      <td>2.000597</td>\n",
+       "      <td>2026-08-10 08:49:05.911141634-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.913827658-04:00</td>\n",
+       "      <td>0.002686</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>fcbd</th>\n",
        "      <td>norm</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:51.549785614-04:00</td>\n",
-       "      <td>2026-08-07 14:36:51.566371441-04:00</td>\n",
-       "      <td>0.016586</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31e0</th>\n",
-       "      <td>energy</td>\n",
-       "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.022333145-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.025355101-04:00</td>\n",
-       "      <td>0.003022</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7104</th>\n",
-       "      <td>Simulation.run</td>\n",
-       "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.032764196-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.037906885-04:00</td>\n",
-       "      <td>0.005143</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>b439</th>\n",
-       "      <td>Simulation.run</td>\n",
-       "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.039353132-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.040598631-04:00</td>\n",
-       "      <td>0.001245</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>cb7a</th>\n",
-       "      <td>free_energy</td>\n",
-       "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.046242237-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.046474218-04:00</td>\n",
-       "      <td>0.000232</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>b823</th>\n",
-       "      <td>free_energy</td>\n",
-       "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.047894001-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.048075914-04:00</td>\n",
-       "      <td>0.000182</td>\n",
+       "      <td>2026-08-10 08:49:05.463237286-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.472317219-04:00</td>\n",
+       "      <td>0.009080</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ad2b</th>\n",
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.053804398-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.154572487-04:00</td>\n",
-       "      <td>0.100768</td>\n",
+       "      <td>2026-08-10 08:49:05.949266672-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.049993515-04:00</td>\n",
+       "      <td>0.100727</td>\n",
        "      <td>five-minute-demo</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0275</th>\n",
-       "      <td>relax</td>\n",
+       "      <th>8e7d</th>\n",
+       "      <td>free_energy</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.155696630-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.256235838-04:00</td>\n",
-       "      <td>0.100539</td>\n",
-       "      <td>five-minute-demo</td>\n",
+       "      <td>2026-08-10 08:49:05.936557293-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.936736107-04:00</td>\n",
+       "      <td>0.000179</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>ba58</th>\n",
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
-       "      <td>2026-08-07 14:36:52.257377625-04:00</td>\n",
-       "      <td>2026-08-07 14:36:52.357872009-04:00</td>\n",
-       "      <td>0.100494</td>\n",
+       "      <td>2026-08-10 08:49:06.152344465-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.252923727-04:00</td>\n",
+       "      <td>0.100579</td>\n",
        "      <td>five-minute-demo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b439</th>\n",
+       "      <td>Simulation.run</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-10 08:49:05.928089380-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.930385351-04:00</td>\n",
+       "      <td>0.002296</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0275</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-10 08:49:06.050945997-04:00</td>\n",
+       "      <td>2026-08-10 08:49:06.151510239-04:00</td>\n",
+       "      <td>0.100564</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6bd4</th>\n",
+       "      <td>expensive</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-10 08:49:03.205544472-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.206341982-04:00</td>\n",
+       "      <td>2.000798</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23f1</th>\n",
+       "      <td>free_energy</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-10 08:49:05.935136557-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.935358524-04:00</td>\n",
+       "      <td>0.000222</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7104</th>\n",
+       "      <td>Simulation.run</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-10 08:49:05.918736458-04:00</td>\n",
+       "      <td>2026-08-10 08:49:05.925585270-04:00</td>\n",
+       "      <td>0.006849</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -781,31 +741,31 @@
       ],
       "text/plain": [
        "                name    module                           timestart  \\\n",
-       "6bd4       expensive  __main__ 2026-08-07 14:36:49.529283046-04:00   \n",
-       "fcbd            norm  __main__ 2026-08-07 14:36:51.549785614-04:00   \n",
-       "31e0          energy  __main__ 2026-08-07 14:36:52.022333145-04:00   \n",
-       "7104  Simulation.run  __main__ 2026-08-07 14:36:52.032764196-04:00   \n",
-       "b439  Simulation.run  __main__ 2026-08-07 14:36:52.039353132-04:00   \n",
-       "cb7a     free_energy  __main__ 2026-08-07 14:36:52.046242237-04:00   \n",
-       "b823     free_energy  __main__ 2026-08-07 14:36:52.047894001-04:00   \n",
-       "ad2b           relax  __main__ 2026-08-07 14:36:52.053804398-04:00   \n",
-       "0275           relax  __main__ 2026-08-07 14:36:52.155696630-04:00   \n",
-       "ba58           relax  __main__ 2026-08-07 14:36:52.257377625-04:00   \n",
+       "31e0          energy  __main__ 2026-08-10 08:49:05.911141634-04:00   \n",
+       "fcbd            norm  __main__ 2026-08-10 08:49:05.463237286-04:00   \n",
+       "ad2b           relax  __main__ 2026-08-10 08:49:05.949266672-04:00   \n",
+       "8e7d     free_energy  __main__ 2026-08-10 08:49:05.936557293-04:00   \n",
+       "ba58           relax  __main__ 2026-08-10 08:49:06.152344465-04:00   \n",
+       "b439  Simulation.run  __main__ 2026-08-10 08:49:05.928089380-04:00   \n",
+       "0275           relax  __main__ 2026-08-10 08:49:06.050945997-04:00   \n",
+       "6bd4       expensive  __main__ 2026-08-10 08:49:03.205544472-04:00   \n",
+       "23f1     free_energy  __main__ 2026-08-10 08:49:05.935136557-04:00   \n",
+       "7104  Simulation.run  __main__ 2026-08-10 08:49:05.918736458-04:00   \n",
        "\n",
        "                                timestop  walltime           project  \n",
-       "6bd4 2026-08-07 14:36:51.529879808-04:00  2.000597               NaN  \n",
-       "fcbd 2026-08-07 14:36:51.566371441-04:00  0.016586               NaN  \n",
-       "31e0 2026-08-07 14:36:52.025355101-04:00  0.003022               NaN  \n",
-       "7104 2026-08-07 14:36:52.037906885-04:00  0.005143               NaN  \n",
-       "b439 2026-08-07 14:36:52.040598631-04:00  0.001245               NaN  \n",
-       "cb7a 2026-08-07 14:36:52.046474218-04:00  0.000232               NaN  \n",
-       "b823 2026-08-07 14:36:52.048075914-04:00  0.000182               NaN  \n",
-       "ad2b 2026-08-07 14:36:52.154572487-04:00  0.100768  five-minute-demo  \n",
-       "0275 2026-08-07 14:36:52.256235838-04:00  0.100539  five-minute-demo  \n",
-       "ba58 2026-08-07 14:36:52.357872009-04:00  0.100494  five-minute-demo  "
+       "31e0 2026-08-10 08:49:05.913827658-04:00  0.002686               NaN  \n",
+       "fcbd 2026-08-10 08:49:05.472317219-04:00  0.009080               NaN  \n",
+       "ad2b 2026-08-10 08:49:06.049993515-04:00  0.100727  five-minute-demo  \n",
+       "8e7d 2026-08-10 08:49:05.936736107-04:00  0.000179               NaN  \n",
+       "ba58 2026-08-10 08:49:06.252923727-04:00  0.100579  five-minute-demo  \n",
+       "b439 2026-08-10 08:49:05.930385351-04:00  0.002296               NaN  \n",
+       "0275 2026-08-10 08:49:06.151510239-04:00  0.100564  five-minute-demo  \n",
+       "6bd4 2026-08-10 08:49:05.206341982-04:00  2.000798               NaN  \n",
+       "23f1 2026-08-10 08:49:05.935358524-04:00  0.000222               NaN  \n",
+       "7104 2026-08-10 08:49:05.925585270-04:00  0.006849               NaN  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -828,22 +788,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "bf324a0f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.402270Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.402160Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.415507Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.414770Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6 results, 281 KiB of arrays  ->  cache grew by 97 KiB\n"
+      "5 results, 234 KiB of arrays  ->  cache grew by 49 KiB\n"
      ]
     }
    ],
@@ -857,12 +810,13 @@
     "\n",
     "@fleche\n",
     "def relax_structure(scale):\n",
-    "    basin = round(scale)              # different starting points, same minimum\n",
-    "    return np.random.default_rng(basin).normal(size=(2000, 3))\n",
+    "    # a real relaxation would iterate here; all these starting points fall into\n",
+    "    # the same minimum, so every call returns the same positions\n",
+    "    return np.full((2000, 3), 3.61)\n",
     "\n",
     "\n",
     "before = cache_size()\n",
-    "scales = (0.9, 0.95, 1.0, 1.05, 1.1, 2.0)\n",
+    "scales = (0.9, 0.95, 1.0, 1.05, 1.1)\n",
     "raw = sum(relax_structure(s).nbytes for s in scales)\n",
     "print(f\"{len(scales)} results, {raw / 1024:.0f} KiB of arrays\"\n",
     "      f\"  ->  cache grew by {(cache_size() - before) / 1024:.0f} KiB\")"
@@ -873,29 +827,21 @@
    "id": "623535f2",
    "metadata": {},
    "source": [
-    "A cache that only ever grows is a liability, so throwing things away is explicit and in\n",
-    "two steps: evicting call records leaves the values behind, and `gc()` then sweeps\n",
-    "whatever no remaining call points at. Values shared with calls you kept survive."
+    "To clear values from a cache, evicting call records leaves the values behind, and `gc()` then sweeps\n",
+    "anything without a reference.  Needs to be done *manually*!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "3b79d4b5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.416886Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.416793Z",
-     "iopub.status.idle": "2026-08-07T18:36:52.434335Z",
-     "shell.execute_reply": "2026-08-07T18:36:52.433566Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "value entries reclaimed by gc(): 8\n",
+      "value entries reclaimed by gc(): 6\n",
       "earlier results untouched: True\n"
      ]
     }
@@ -920,22 +866,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "bc4603e2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:52.435636Z",
-     "iopub.status.busy": "2026-08-07T18:36:52.435537Z",
-     "iopub.status.idle": "2026-08-07T18:36:54.107065Z",
-     "shell.execute_reply": "2026-08-07T18:36:54.106427Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cold: [0, 1, 8, 27] in 1.64 s\n",
+      "cold: [0, 1, 8, 27] in 1.79 s\n",
       "warm: [0, 1, 8, 27] in 0.02 s\n"
      ]
     }
@@ -969,8 +908,8 @@
     "\n",
     "## 6. Stack caches: a read-only, prepopulated base\n",
     "\n",
-    "Say your group already has a cache full of results, on a shared filesystem or in a\n",
-    "teammate's directory. `CacheStack` puts your own writable cache *in front* of it: loads\n",
+    "Say you already have a cache full of results, on a shared filesystem. \n",
+    "`CacheStack`/`Cache.push`. puts your own writable cache *in front* of it: loads\n",
     "fall through to the base and hits are back-filled into the front, while saves only ever\n",
     "touch the front. Wrap the base in `ReadOnlyCache` and nothing you do can modify it,\n",
     "since writes and evictions raise `Rejected`:"
@@ -978,44 +917,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "54bbd748",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:54.108665Z",
-     "iopub.status.busy": "2026-08-07T18:36:54.108560Z",
-     "iopub.status.idle": "2026-08-07T18:36:56.114075Z",
-     "shell.execute_reply": "2026-08-07T18:36:56.113349Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "computing DOS for fcc-Al ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "computing DOS for fcc-Al ...\n",
       "dos(fcc-Al)   <- from the shared base: 0.000 s\n",
-      "computing DOS for bcc-Fe ...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "computing DOS for bcc-Fe ...\n",
       "dos(bcc-Fe)   <- not in the base: computed here\n"
      ]
     }
    ],
    "source": [
-    "from fleche.caches import CacheStack, ReadOnlyCache\n",
-    "from fleche.storage.memory import ValueMemory, CallMemory\n",
-    "\n",
+    "from fleche.caches import BaseCache\n",
     "\n",
     "@fleche\n",
     "def phonon_dos(structure):\n",
@@ -1024,13 +942,13 @@
     "    return f\"dos({structure})\"\n",
     "\n",
     "\n",
-    "# the group's prepopulated cache (in memory here; files or SSH in real life)\n",
-    "shared = Cache(ValueMemory({}), CallMemory({}))\n",
+    "# an external prepopulated cache (in memory here; files or SSH in real life)\n",
+    "shared = BaseCache.from_config({\"template\": \"memory\"})\n",
     "with cache(shared):\n",
     "    phonon_dos(\"fcc-Al\")\n",
     "\n",
-    "mine = Cache(ValueMemory({}), CallMemory({}))\n",
-    "stack = CacheStack((mine, ReadOnlyCache(shared)))\n",
+    "mine = BaseCache.from_config({\"template\": \"memory\"})\n",
+    "stack = shared.readonly().push(mine)\n",
     "\n",
     "with cache(stack):\n",
     "    start = time.time()\n",
@@ -1040,16 +958,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "5e636dc7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-08-07T18:36:56.115941Z",
-     "iopub.status.busy": "2026-08-07T18:36:56.115834Z",
-     "iopub.status.idle": "2026-08-07T18:36:56.118770Z",
-     "shell.execute_reply": "2026-08-07T18:36:56.118067Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1067,6 +978,14 @@
     "    print(\"new result in my cache:   \", phonon_dos.fleche.contains(\"bcc-Fe\"))\n",
     "with cache(shared):\n",
     "    print(\"shared base untouched:    \", not phonon_dos.fleche.contains(\"bcc-Fe\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d890fac1-cb84-4c63-9db9-27981453192e",
+   "metadata": {},
+   "source": [
+    "Cache configuration can get cumbersome, so there's a config file for permanent setups."
    ]
   },
   {
@@ -1108,17 +1027,20 @@
     "  over large caches, while values stay in files or HDF5.\n",
     "- **Caches on other machines**: `SshCache` forwards a whole cache over SSH to a\n",
     "  `python -m fleche remote --serve` process on, say, your cluster's login node. Stack it\n",
-    "  behind a local cache exactly as above, or fan reads over several teammates' caches at\n",
+    "  behind a local cache exactly as above, or fan reads over several caches at\n",
     "  once with a read-only `CachePool`.\n",
-    "- **Take results home**: `query().transfer(other_cache)` moves selected results\n",
+    "- **Take results elsewhere**: `query().transfer(other_cache)` moves selected results\n",
     "  between caches (cluster to laptop); see `TransferWorkflow.ipynb`.\n",
     "- **Ship a warm cache**: because a cache is just a directory, you can hand one to CI or\n",
-    "  to students so notebooks that would otherwise need a supercomputer replay instantly.\n",
+    "  anyone running a notebooks that would otherwise need a supercomputer replay instantly.\n",
     "- **Inside pyiron_workflow**: `@fleche` and `@pyiron_workflow.atomic` do not interfere,\n",
     "  and passing a fleche `Cache` to a `RunConfig` lets decorated nodes hit the same cache\n",
     "  during a workflow run.\n",
     "- **Signed storage**: HMAC-sign pickle-family entries with a `secret_key`; tampered or\n",
     "  wrong-key entries surface as plain cache misses, never as executed code.\n",
+    "\n",
+    "\n",
+    "- Caching input and output files or directories does not work yet, but is actively developed.\n",
     "\n",
     "## Where to go next\n",
     "\n",
@@ -1146,7 +1068,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.6"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -6,10 +6,10 @@
    "id": "ac3ee647",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:53.036853Z",
-     "iopub.status.busy": "2026-08-07T17:20:53.036683Z",
-     "iopub.status.idle": "2026-08-07T17:20:53.185560Z",
-     "shell.execute_reply": "2026-08-07T17:20:53.184356Z"
+     "iopub.execute_input": "2026-08-07T17:43:39.999378Z",
+     "iopub.status.busy": "2026-08-07T17:43:39.999255Z",
+     "iopub.status.idle": "2026-08-07T17:43:40.119566Z",
+     "shell.execute_reply": "2026-08-07T17:43:40.118719Z"
     }
    },
    "outputs": [],
@@ -57,10 +57,10 @@
    "id": "d0dfa14b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:53.188382Z",
-     "iopub.status.busy": "2026-08-07T17:20:53.188160Z",
-     "iopub.status.idle": "2026-08-07T17:20:53.728584Z",
-     "shell.execute_reply": "2026-08-07T17:20:53.727432Z"
+     "iopub.execute_input": "2026-08-07T17:43:40.122069Z",
+     "iopub.status.busy": "2026-08-07T17:43:40.121832Z",
+     "iopub.status.idle": "2026-08-07T17:43:40.341322Z",
+     "shell.execute_reply": "2026-08-07T17:43:40.340647Z"
     }
    },
    "outputs": [],
@@ -78,10 +78,10 @@
    "id": "7c518acf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:53.731531Z",
-     "iopub.status.busy": "2026-08-07T17:20:53.731225Z",
-     "iopub.status.idle": "2026-08-07T17:20:55.741402Z",
-     "shell.execute_reply": "2026-08-07T17:20:55.740259Z"
+     "iopub.execute_input": "2026-08-07T17:43:40.343137Z",
+     "iopub.status.busy": "2026-08-07T17:43:40.342930Z",
+     "iopub.status.idle": "2026-08-07T17:43:42.349789Z",
+     "shell.execute_reply": "2026-08-07T17:43:42.349128Z"
     }
    },
    "outputs": [
@@ -97,7 +97,7 @@
      "output_type": "stream",
      "text": [
       "16   <- first call: 2.00 s\n",
-      "16   <- second call: 0.0015 s\n"
+      "16   <- second call: 0.0009 s\n"
      ]
     }
    ],
@@ -133,10 +133,10 @@
    "id": "9f4c538d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:55.743616Z",
-     "iopub.status.busy": "2026-08-07T17:20:55.743406Z",
-     "iopub.status.idle": "2026-08-07T17:20:55.748564Z",
-     "shell.execute_reply": "2026-08-07T17:20:55.747301Z"
+     "iopub.execute_input": "2026-08-07T17:43:42.351689Z",
+     "iopub.status.busy": "2026-08-07T17:43:42.351580Z",
+     "iopub.status.idle": "2026-08-07T17:43:42.354362Z",
+     "shell.execute_reply": "2026-08-07T17:43:42.353829Z"
     }
    },
    "outputs": [
@@ -174,10 +174,10 @@
    "id": "41dd9bef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:55.750625Z",
-     "iopub.status.busy": "2026-08-07T17:20:55.750407Z",
-     "iopub.status.idle": "2026-08-07T17:20:55.843935Z",
-     "shell.execute_reply": "2026-08-07T17:20:55.843251Z"
+     "iopub.execute_input": "2026-08-07T17:43:42.355995Z",
+     "iopub.status.busy": "2026-08-07T17:43:42.355894Z",
+     "iopub.status.idle": "2026-08-07T17:43:42.398521Z",
+     "shell.execute_reply": "2026-08-07T17:43:42.395474Z"
     }
    },
    "outputs": [
@@ -222,10 +222,10 @@
    "id": "dfba66c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:55.854407Z",
-     "iopub.status.busy": "2026-08-07T17:20:55.854178Z",
-     "iopub.status.idle": "2026-08-07T17:20:56.637324Z",
-     "shell.execute_reply": "2026-08-07T17:20:56.636088Z"
+     "iopub.execute_input": "2026-08-07T17:43:42.402630Z",
+     "iopub.status.busy": "2026-08-07T17:43:42.402435Z",
+     "iopub.status.idle": "2026-08-07T17:43:42.887824Z",
+     "shell.execute_reply": "2026-08-07T17:43:42.887091Z"
     }
    },
    "outputs": [
@@ -259,6 +259,125 @@
   },
   {
    "cell_type": "markdown",
+   "id": "60256615",
+   "metadata": {},
+   "source": [
+    "Methods work too, without special handling: `self` is just another argument, digested by\n",
+    "content like any other. Two instances carrying the same state share cache entries, and\n",
+    "mutating the state you care about invalidates them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "16a7b1a2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:43:42.889639Z",
+     "iopub.status.busy": "2026-08-07T17:43:42.889427Z",
+     "iopub.status.idle": "2026-08-07T17:43:42.903138Z",
+     "shell.execute_reply": "2026-08-07T17:43:42.902354Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  ...actually running heat at 300.0 K\n",
+      "3000.0\n",
+      "3000.0\n",
+      "  ...actually running heat at 400.0 K\n",
+      "4000.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class Simulation:\n",
+    "    temperature: float\n",
+    "    steps: int = 10\n",
+    "\n",
+    "    @fleche\n",
+    "    def run(self, label):\n",
+    "        print(f\"  ...actually running {label} at {self.temperature} K\")\n",
+    "        return self.temperature * self.steps\n",
+    "\n",
+    "\n",
+    "print(Simulation(300.0).run(\"heat\"))\n",
+    "print(Simulation(300.0).run(\"heat\"))    # a different object, same state -> hit\n",
+    "print(Simulation(400.0).run(\"heat\"))    # different state -> miss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84c82541",
+   "metadata": {},
+   "source": [
+    "### What goes into the key\n",
+    "\n",
+    "Name, module, and arguments — but *not* the function body, so editing a function keeps\n",
+    "serving the old results. Opt in with `hash_code=True` and every source edit invalidates\n",
+    "its entries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "38815c03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:43:42.904791Z",
+     "iopub.status.busy": "2026-08-07T17:43:42.904608Z",
+     "iopub.status.idle": "2026-08-07T17:43:42.912639Z",
+     "shell.execute_reply": "2026-08-07T17:43:42.912187Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-450.0   cached? True\n",
+      "after editing the body, cached? False\n",
+      "-630.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "@fleche(hash_code=True)\n",
+    "def free_energy(T):\n",
+    "    return -1.5 * T                       # first version of the model\n",
+    "\n",
+    "\n",
+    "print(free_energy(300), \"  cached?\", free_energy.fleche.contains(300))\n",
+    "\n",
+    "\n",
+    "@fleche(hash_code=True)\n",
+    "def free_energy(T):                       # same name, corrected model\n",
+    "    return -1.5 * T - 0.002 * T ** 2\n",
+    "\n",
+    "\n",
+    "print(\"after editing the body, cached?\", free_energy.fleche.contains(300))\n",
+    "print(free_energy(300))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceaf73f2",
+   "metadata": {},
+   "source": [
+    "This hashes *this* function's source, not the code it calls — a change in a helper or in a\n",
+    "dependency invalidates nothing. Where that matters, say so explicitly with\n",
+    "`@fleche(version=...)` and bump it; `ignore=` and `require=` control which arguments take\n",
+    "part in the key at all."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "03f8d80d",
    "metadata": {},
    "source": [
@@ -271,14 +390,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "7900dba9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:56.640049Z",
-     "iopub.status.busy": "2026-08-07T17:20:56.639694Z",
-     "iopub.status.idle": "2026-08-07T17:20:56.972089Z",
-     "shell.execute_reply": "2026-08-07T17:20:56.971069Z"
+     "iopub.execute_input": "2026-08-07T17:43:42.914149Z",
+     "iopub.status.busy": "2026-08-07T17:43:42.914055Z",
+     "iopub.status.idle": "2026-08-07T17:43:43.232936Z",
+     "shell.execute_reply": "2026-08-07T17:43:43.232333Z"
     }
    },
    "outputs": [
@@ -320,9 +439,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.0, 'volume': 42.875}</td>\n",
-       "      <td>2026-08-07 17:20:56.643192053+00:00</td>\n",
-       "      <td>2026-08-07 17:20:56.744186878+00:00</td>\n",
-       "      <td>0.100995</td>\n",
+       "      <td>2026-08-07 13:43:42.915848732-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.016426086-04:00</td>\n",
+       "      <td>0.100577</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.5</td>\n",
        "      <td>4</td>\n",
@@ -332,9 +451,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
-       "      <td>2026-08-07 17:20:56.746165514+00:00</td>\n",
-       "      <td>2026-08-07 17:20:56.846971989+00:00</td>\n",
-       "      <td>0.100806</td>\n",
+       "      <td>2026-08-07 13:43:43.017625809-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.118124723-04:00</td>\n",
+       "      <td>0.100499</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.6</td>\n",
        "      <td>4</td>\n",
@@ -344,9 +463,9 @@
        "      <td>relax</td>\n",
        "      <td>__main__</td>\n",
        "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
-       "      <td>2026-08-07 17:20:56.848810196+00:00</td>\n",
-       "      <td>2026-08-07 17:20:56.949890375+00:00</td>\n",
-       "      <td>0.101080</td>\n",
+       "      <td>2026-08-07 13:43:43.119174004-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.219753265-04:00</td>\n",
+       "      <td>0.100579</td>\n",
        "      <td>five-minute-demo</td>\n",
        "      <td>3.7</td>\n",
        "      <td>4</td>\n",
@@ -362,17 +481,17 @@
        "ba58  relax  __main__  {'energy': -14.8, 'volume': 50.653000000000006}   \n",
        "\n",
        "                               timestart                            timestop  \\\n",
-       "ad2b 2026-08-07 17:20:56.643192053+00:00 2026-08-07 17:20:56.744186878+00:00   \n",
-       "0275 2026-08-07 17:20:56.746165514+00:00 2026-08-07 17:20:56.846971989+00:00   \n",
-       "ba58 2026-08-07 17:20:56.848810196+00:00 2026-08-07 17:20:56.949890375+00:00   \n",
+       "ad2b 2026-08-07 13:43:42.915848732-04:00 2026-08-07 13:43:43.016426086-04:00   \n",
+       "0275 2026-08-07 13:43:43.017625809-04:00 2026-08-07 13:43:43.118124723-04:00   \n",
+       "ba58 2026-08-07 13:43:43.119174004-04:00 2026-08-07 13:43:43.219753265-04:00   \n",
        "\n",
        "      walltime           project    a  k  \n",
-       "ad2b  0.100995  five-minute-demo  3.5  4  \n",
-       "0275  0.100806  five-minute-demo  3.6  4  \n",
-       "ba58  0.101080  five-minute-demo  3.7  4  "
+       "ad2b  0.100577  five-minute-demo  3.5  4  \n",
+       "0275  0.100499  five-minute-demo  3.6  4  \n",
+       "ba58  0.100579  five-minute-demo  3.7  4  "
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -393,14 +512,405 @@
   },
   {
    "cell_type": "markdown",
+   "id": "74212951",
+   "metadata": {},
+   "source": [
+    "Because that record is a real index, you can also ask what you *nearly* have — worth a\n",
+    "look before queueing a run someone already did at a slightly different parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "aa558a10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:43:43.234431Z",
+     "iopub.status.busy": "2026-08-07T17:43:43.234308Z",
+     "iopub.status.idle": "2026-08-07T17:43:43.247573Z",
+     "shell.execute_reply": "2026-08-07T17:43:43.246816Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nothing cached for a=3.68, but 2 nearby run(s):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>module</th>\n",
+       "      <th>result</th>\n",
+       "      <th>timestart</th>\n",
+       "      <th>timestop</th>\n",
+       "      <th>walltime</th>\n",
+       "      <th>project</th>\n",
+       "      <th>a</th>\n",
+       "      <th>k</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ba58</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>{'energy': -14.8, 'volume': 50.653000000000006}</td>\n",
+       "      <td>2026-08-07 13:43:43.119174004-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.219753265-04:00</td>\n",
+       "      <td>0.100579</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "      <td>3.7</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0275</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>{'energy': -14.4, 'volume': 46.656000000000006}</td>\n",
+       "      <td>2026-08-07 13:43:43.017625809-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.118124723-04:00</td>\n",
+       "      <td>0.100499</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "      <td>3.6</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       name    module                                           result  \\\n",
+       "ba58  relax  __main__  {'energy': -14.8, 'volume': 50.653000000000006}   \n",
+       "0275  relax  __main__  {'energy': -14.4, 'volume': 46.656000000000006}   \n",
+       "\n",
+       "                               timestart                            timestop  \\\n",
+       "ba58 2026-08-07 13:43:43.119174004-04:00 2026-08-07 13:43:43.219753265-04:00   \n",
+       "0275 2026-08-07 13:43:43.017625809-04:00 2026-08-07 13:43:43.118124723-04:00   \n",
+       "\n",
+       "      walltime           project    a  k  \n",
+       "ba58  0.100579  five-minute-demo  3.7  4  \n",
+       "0275  0.100499  five-minute-demo  3.6  4  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "target = 3.68\n",
+    "close = (\n",
+    "    relax.fleche.query()\n",
+    "    .filter(lambda c: abs(c.arguments[\"a\"] - target) < 0.1)\n",
+    "    .sorted(key=lambda c: abs(c.arguments[\"a\"] - target))\n",
+    ")\n",
+    "print(f\"nothing cached for a={target}, but {close.count()} nearby run(s):\")\n",
+    "close.table(arguments=[\"a\", \"k\"], results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8539edb2",
+   "metadata": {},
+   "source": [
+    "Queries chain (`filter`, `sorted`, `unique`, `groupby`, ...) and terminal methods can\n",
+    "`transfer()` matching entries to another cache or `evict()` them. And the view is not\n",
+    "per-function or per-project — `cache().table()` spans everything that ever wrote to this\n",
+    "cache:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8ad1922d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:43:43.249170Z",
+     "iopub.status.busy": "2026-08-07T17:43:43.249066Z",
+     "iopub.status.idle": "2026-08-07T17:43:43.257516Z",
+     "shell.execute_reply": "2026-08-07T17:43:43.256919Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>module</th>\n",
+       "      <th>timestart</th>\n",
+       "      <th>timestop</th>\n",
+       "      <th>walltime</th>\n",
+       "      <th>project</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>6bd4</th>\n",
+       "      <td>expensive</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:40.345532656-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.345995426-04:00</td>\n",
+       "      <td>2.000463</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>fcbd</th>\n",
+       "      <td>norm</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.366988659-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.382326603-04:00</td>\n",
+       "      <td>0.015338</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31e0</th>\n",
+       "      <td>energy</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.879736662-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.884329796-04:00</td>\n",
+       "      <td>0.004593</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7104</th>\n",
+       "      <td>Simulation.run</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.891786814-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.897278547-04:00</td>\n",
+       "      <td>0.005492</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b439</th>\n",
+       "      <td>Simulation.run</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.898984671-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.900375366-04:00</td>\n",
+       "      <td>0.001391</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cb7a</th>\n",
+       "      <td>free_energy</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.907274008-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.907721281-04:00</td>\n",
+       "      <td>0.000447</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b823</th>\n",
+       "      <td>free_energy</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.910212040-04:00</td>\n",
+       "      <td>2026-08-07 13:43:42.910451412-04:00</td>\n",
+       "      <td>0.000239</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ad2b</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:42.915848732-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.016426086-04:00</td>\n",
+       "      <td>0.100577</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0275</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:43.017625809-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.118124723-04:00</td>\n",
+       "      <td>0.100499</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ba58</th>\n",
+       "      <td>relax</td>\n",
+       "      <td>__main__</td>\n",
+       "      <td>2026-08-07 13:43:43.119174004-04:00</td>\n",
+       "      <td>2026-08-07 13:43:43.219753265-04:00</td>\n",
+       "      <td>0.100579</td>\n",
+       "      <td>five-minute-demo</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                name    module                           timestart  \\\n",
+       "6bd4       expensive  __main__ 2026-08-07 13:43:40.345532656-04:00   \n",
+       "fcbd            norm  __main__ 2026-08-07 13:43:42.366988659-04:00   \n",
+       "31e0          energy  __main__ 2026-08-07 13:43:42.879736662-04:00   \n",
+       "7104  Simulation.run  __main__ 2026-08-07 13:43:42.891786814-04:00   \n",
+       "b439  Simulation.run  __main__ 2026-08-07 13:43:42.898984671-04:00   \n",
+       "cb7a     free_energy  __main__ 2026-08-07 13:43:42.907274008-04:00   \n",
+       "b823     free_energy  __main__ 2026-08-07 13:43:42.910212040-04:00   \n",
+       "ad2b           relax  __main__ 2026-08-07 13:43:42.915848732-04:00   \n",
+       "0275           relax  __main__ 2026-08-07 13:43:43.017625809-04:00   \n",
+       "ba58           relax  __main__ 2026-08-07 13:43:43.119174004-04:00   \n",
+       "\n",
+       "                                timestop  walltime           project  \n",
+       "6bd4 2026-08-07 13:43:42.345995426-04:00  2.000463               NaN  \n",
+       "fcbd 2026-08-07 13:43:42.382326603-04:00  0.015338               NaN  \n",
+       "31e0 2026-08-07 13:43:42.884329796-04:00  0.004593               NaN  \n",
+       "7104 2026-08-07 13:43:42.897278547-04:00  0.005492               NaN  \n",
+       "b439 2026-08-07 13:43:42.900375366-04:00  0.001391               NaN  \n",
+       "cb7a 2026-08-07 13:43:42.907721281-04:00  0.000447               NaN  \n",
+       "b823 2026-08-07 13:43:42.910451412-04:00  0.000239               NaN  \n",
+       "ad2b 2026-08-07 13:43:43.016426086-04:00  0.100577  five-minute-demo  \n",
+       "0275 2026-08-07 13:43:43.118124723-04:00  0.100499  five-minute-demo  \n",
+       "ba58 2026-08-07 13:43:43.219753265-04:00  0.100579  five-minute-demo  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cache().table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "35c50cd6",
    "metadata": {},
    "source": [
-    "Queries chain (`filter`, `unique`, `sorted`, ...) and terminal methods can `transfer()`\n",
-    "matching entries to another cache or `evict()` them; `cache().table()` shows everything\n",
-    "across all functions.\n",
+    "## 4. Storing everything without filling the disk\n",
     "\n",
-    "## 4. Plays well with executors — including executorlib\n",
+    "Values are content-addressed, so equal results are stored once no matter how many calls\n",
+    "produced them. That is not a corner case — think relaxations converging to the same\n",
+    "minimum from different starting points:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "bf324a0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:43:43.258908Z",
+     "iopub.status.busy": "2026-08-07T17:43:43.258807Z",
+     "iopub.status.idle": "2026-08-07T17:43:43.275542Z",
+     "shell.execute_reply": "2026-08-07T17:43:43.274866Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 results, 281 KiB of arrays  ->  cache grew by 97 KiB\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "def cache_size(root=\"./.five_minute_cache\"):\n",
+    "    return sum(f.stat().st_size for f in Path(root).rglob(\"*\") if f.is_file())\n",
+    "\n",
+    "\n",
+    "@fleche\n",
+    "def relax_structure(scale):\n",
+    "    basin = round(scale)              # different starting points, same minimum\n",
+    "    return np.random.default_rng(basin).normal(size=(2000, 3))\n",
+    "\n",
+    "\n",
+    "before = cache_size()\n",
+    "scales = (0.9, 0.95, 1.0, 1.05, 1.1, 2.0)\n",
+    "raw = sum(relax_structure(s).nbytes for s in scales)\n",
+    "print(f\"{len(scales)} results, {raw / 1024:.0f} KiB of arrays\"\n",
+    "      f\"  ->  cache grew by {(cache_size() - before) / 1024:.0f} KiB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "623535f2",
+   "metadata": {},
+   "source": [
+    "A cache that only ever grows is a liability, so throwing things away is explicit and in\n",
+    "two steps: evicting call records leaves the values behind, and `gc()` then sweeps\n",
+    "whatever no remaining call points at. Values shared with calls you kept survive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3b79d4b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-07T17:43:43.276989Z",
+     "iopub.status.busy": "2026-08-07T17:43:43.276899Z",
+     "iopub.status.idle": "2026-08-07T17:43:43.294415Z",
+     "shell.execute_reply": "2026-08-07T17:43:43.293938Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "value entries reclaimed by gc(): 8\n",
+      "earlier results untouched: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "relax_structure.fleche.query().evict()               # drop those call records\n",
+    "print(\"value entries reclaimed by gc():\", len(cache().gc()))\n",
+    "print(\"earlier results untouched:\", relax.fleche.contains(3.5, k=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e6b2c3",
+   "metadata": {},
+   "source": [
+    "## 5. Plays well with executors — including executorlib\n",
     "\n",
     "`wrap_executor` patches any `concurrent.futures`-style executor. Fleche-decorated\n",
     "functions carry the active cache into worker processes automatically, and cache hits\n",
@@ -409,14 +919,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "id": "bc4603e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-07T17:20:56.974575Z",
-     "iopub.status.busy": "2026-08-07T17:20:56.974338Z",
-     "iopub.status.idle": "2026-08-07T17:20:59.421714Z",
-     "shell.execute_reply": "2026-08-07T17:20:59.420438Z"
+     "iopub.execute_input": "2026-08-07T17:43:43.295968Z",
+     "iopub.status.busy": "2026-08-07T17:43:43.295874Z",
+     "iopub.status.idle": "2026-08-07T17:43:44.988960Z",
+     "shell.execute_reply": "2026-08-07T17:43:44.988298Z"
     }
    },
    "outputs": [
@@ -424,8 +934,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cold: [0, 1, 8, 27] in 2.40 s\n",
-      "warm: [0, 1, 8, 27] in 0.04 s\n"
+      "cold: [0, 1, 8, 27] in 1.66 s\n",
+      "warm: [0, 1, 8, 27] in 0.02 s\n"
      ]
     }
    ],
@@ -459,7 +969,7 @@
     "the work. Executor-specific kwargs like executorlib's `resource_dict` are forwarded\n",
     "transparently.\n",
     "\n",
-    "## 5. Things worth a second look\n",
+    "## 6. Things worth a second look\n",
     "\n",
     "- **Configuration by file** — drop a `fleche.toml` next to your project (or in `$HOME`);\n",
     "  decorated code never changes:\n",
@@ -474,7 +984,8 @@
     "  ```\n",
     "\n",
     "- **HDF5 storage** — `template = \"bagofholding_hdf\"` stores values via pyiron's\n",
-    "  [bagofholding](https://github.com/pyiron/bagofholding).\n",
+    "  [bagofholding](https://github.com/pyiron/bagofholding), for storage meant to outlive\n",
+    "  the environment that wrote it.\n",
     "- **SQL call index** — keep call records in SQLite/Postgres for server-side filtering\n",
     "  over large caches, while values stay in files or HDF5.\n",
     "- **Caches on other machines** — `SshCache` forwards a whole cache over SSH to a\n",
@@ -483,8 +994,11 @@
     "  teammates' caches with a read-only `CachePool`.\n",
     "- **Take results home** — `query().transfer(other_cache)` moves selected results\n",
     "  between caches (cluster → laptop); see `TransferWorkflow.ipynb`.\n",
-    "- **Invalidation you control** — bump `@fleche(version=2)` to retire old entries, or\n",
-    "  `hash_code=True` to invalidate on any code edit; `ignore=`/`require=` shape the key.\n",
+    "- **Ship a warm cache** — because a cache is just a directory, you can hand one to CI or\n",
+    "  to students so notebooks that would otherwise need a supercomputer replay instantly.\n",
+    "- **Inside pyiron_workflow** — `@fleche` and `@pyiron_workflow.atomic` do not interfere,\n",
+    "  and passing a fleche `Cache` to a `RunConfig` lets decorated nodes hit the same cache\n",
+    "  during a workflow run.\n",
     "- **Signed storage** — HMAC-sign pickle-family entries with a `secret_key`; tampered or\n",
     "  wrong-key entries surface as plain cache misses, never as executed code.\n",
     "\n",
@@ -514,7 +1028,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.15"
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -24,15 +24,15 @@
    "source": [
     "# Fleche in Five Minutes\n",
     "\n",
-    "*A persistent cache for expensive Python functions — `lru_cache` on steroids.*\n",
+    "*A persistent cache for expensive Python functions, like `lru_cache` on steroids.*\n",
     "\n",
     "Decorate a function and `fleche` stores every result under a SHA256 key built from the\n",
     "function's identity and the **content** of its arguments. Results survive restarts, can\n",
-    "live in files, HDF5, SQL, or on another machine — and everything you ever computed stays\n",
+    "live in files, HDF5, SQL, or on another machine, and everything you ever computed stays\n",
     "queryable like a small database.\n",
     "\n",
-    "If your day involves functions that take minutes to days — structure relaxations,\n",
-    "phonons, MD, training runs — and you re-run them more often than you'd like, this is\n",
+    "If your day involves functions that take minutes to days (structure relaxations,\n",
+    "phonons, MD, training runs) and you re-run them more often than you'd like, this is\n",
     "for you.\n",
     "\n",
     "```\n",
@@ -49,7 +49,7 @@
     "## 1. Decorate and forget\n",
     "\n",
     "Point the active cache at a directory (in real projects you'd do this once in a\n",
-    "`fleche.toml` next to your code — see the end of this notebook), then just decorate:"
+    "`fleche.toml` next to your code; see the end of this notebook), then just decorate:"
    ]
   },
   {
@@ -123,7 +123,7 @@
    "metadata": {},
    "source": [
     "The second call never enters the function body. Unlike `lru_cache`, the result is on\n",
-    "disk, not in process memory — restart the kernel (skip the cleanup cell at the top) and\n",
+    "disk, not in process memory. Restart the kernel (skip the cleanup cell at the top) and\n",
     "it is still instant. A brand-new cache object pointed at the same directory already\n",
     "knows the answer:"
    ]
@@ -160,11 +160,11 @@
    "id": "c72c4055",
    "metadata": {},
    "source": [
-    "The cache is just a directory — `rsync` it, back it up, share it with your group.\n",
+    "The cache is just a directory: `rsync` it, back it up, share it with your group.\n",
     "\n",
     "## 2. Keys are content, not object identity\n",
     "\n",
-    "Arguments are digested by **value** — not `id()`, not pickle bytes. NumPy arrays,\n",
+    "Arguments are digested by **value**, not `id()`, not pickle bytes. NumPy arrays,\n",
     "pandas frames, dataclasses, and nested containers work out of the box; equal content\n",
     "means equal key, no matter who constructed the object:"
    ]
@@ -319,7 +319,7 @@
    "source": [
     "### What goes into the key\n",
     "\n",
-    "Name, module, and arguments — but *not* the function body, so editing a function keeps\n",
+    "Name, module, and arguments, but *not* the function body, so editing a function keeps\n",
     "serving the old results. Opt in with `hash_code=True` and every source edit invalidates\n",
     "its entries:"
    ]
@@ -370,9 +370,9 @@
    "id": "ceaf73f2",
    "metadata": {},
    "source": [
-    "This hashes *this* function's source, not the code it calls — a change in a helper or in a\n",
-    "dependency invalidates nothing. Where that matters, say so explicitly with\n",
-    "`@fleche(version=...)` and bump it; `ignore=` and `require=` control which arguments take\n",
+    "This hashes *this* function's source, not the code it calls; a change in a helper or in\n",
+    "a dependency invalidates nothing. Where that matters, say so explicitly with\n",
+    "`@fleche(version=...)` and bump it. `ignore=` and `require=` control which arguments take\n",
     "part in the key at all."
    ]
   },
@@ -383,9 +383,9 @@
    "source": [
     "## 3. Your cache is a database\n",
     "\n",
-    "Every call is recorded — arguments, runtime, metadata — *separately* from the (possibly\n",
-    "heavy) result values, so you can browse what you computed without deserializing any of\n",
-    "it. Tag calls, then query into a pandas DataFrame:"
+    "Every call is recorded with its arguments, runtime, and metadata, kept *separately* from\n",
+    "the (possibly heavy) result values, so you can browse what you computed without\n",
+    "deserializing any of it. Tag calls, then query into a pandas DataFrame:"
    ]
   },
   {
@@ -515,8 +515,9 @@
    "id": "74212951",
    "metadata": {},
    "source": [
-    "Because that record is a real index, you can also ask what you *nearly* have — worth a\n",
-    "look before queueing a run someone already did at a slightly different parameter:"
+    "Because that record is a real index, you can also ask what you *nearly* have, which is\n",
+    "worth a look before queueing a run someone already did at a slightly different\n",
+    "parameter:"
    ]
   },
   {
@@ -637,7 +638,7 @@
    "source": [
     "Queries chain (`filter`, `sorted`, `unique`, `groupby`, ...) and terminal methods can\n",
     "`transfer()` matching entries to another cache or `evict()` them. And the view is not\n",
-    "per-function or per-project — `cache().table()` spans everything that ever wrote to this\n",
+    "per-function or per-project. `cache().table()` spans everything that ever wrote to this\n",
     "cache:"
    ]
   },
@@ -821,7 +822,7 @@
     "## 4. Storing everything without filling the disk\n",
     "\n",
     "Values are content-addressed, so equal results are stored once no matter how many calls\n",
-    "produced them. That is not a corner case — think relaxations converging to the same\n",
+    "produced them. That is not a corner case. Think of relaxations converging to the same\n",
     "minimum from different starting points:"
    ]
   },
@@ -910,7 +911,7 @@
    "id": "24e6b2c3",
    "metadata": {},
    "source": [
-    "## 5. Plays well with executors — including executorlib\n",
+    "## 5. Plays well with executors, including executorlib\n",
     "\n",
     "`wrap_executor` patches any `concurrent.futures`-style executor. Fleche-decorated\n",
     "functions carry the active cache into worker processes automatically, and cache hits\n",
@@ -962,17 +963,17 @@
    "id": "08ec26f9",
    "metadata": {},
    "source": [
-    "On the warm pass every future is done before `submit` returns — the executor never sees\n",
-    "the work. Executor-specific kwargs like executorlib's `resource_dict` are forwarded\n",
+    "On the warm pass every future is done before `submit` returns, so the executor never\n",
+    "sees the work. Executor-specific kwargs like executorlib's `resource_dict` are forwarded\n",
     "transparently.\n",
     "\n",
-    "## 6. Stack caches — a read-only, prepopulated base\n",
+    "## 6. Stack caches: a read-only, prepopulated base\n",
     "\n",
-    "Say your group already has a cache full of results — on a shared filesystem, or a\n",
+    "Say your group already has a cache full of results, on a shared filesystem or in a\n",
     "teammate's directory. `CacheStack` puts your own writable cache *in front* of it: loads\n",
     "fall through to the base and hits are back-filled into the front, while saves only ever\n",
-    "touch the front. Wrap the base in `ReadOnlyCache` and nothing you do can modify it —\n",
-    "writes and evictions raise `Rejected`:"
+    "touch the front. Wrap the base in `ReadOnlyCache` and nothing you do can modify it,\n",
+    "since writes and evictions raise `Rejected`:"
    ]
   },
   {
@@ -1073,7 +1074,7 @@
    "id": "96f9616b",
    "metadata": {},
    "source": [
-    "The same stack straight from `fleche.toml` — an array of tables, first entry is the\n",
+    "The same stack straight from `fleche.toml`, an array of tables whose first entry is the\n",
     "front where saves land:\n",
     "\n",
     "```toml\n",
@@ -1088,7 +1089,7 @@
     "\n",
     "## 7. Things worth a second look\n",
     "\n",
-    "- **Configuration by file** — drop a `fleche.toml` next to your project (or in `$HOME`);\n",
+    "- **Configuration by file**: drop a `fleche.toml` next to your project (or in `$HOME`);\n",
     "  decorated code never changes:\n",
     "\n",
     "  ```toml\n",
@@ -1100,23 +1101,23 @@
     "  root = \"~/.cache/fleche\"\n",
     "  ```\n",
     "\n",
-    "- **HDF5 storage** — `template = \"bagofholding_hdf\"` stores values via pyiron's\n",
+    "- **HDF5 storage**: `template = \"bagofholding_hdf\"` stores values via pyiron's\n",
     "  [bagofholding](https://github.com/pyiron/bagofholding), for storage meant to outlive\n",
     "  the environment that wrote it.\n",
-    "- **SQL call index** — keep call records in SQLite/Postgres for server-side filtering\n",
+    "- **SQL call index**: keep call records in SQLite/Postgres for server-side filtering\n",
     "  over large caches, while values stay in files or HDF5.\n",
-    "- **Caches on other machines** — `SshCache` forwards a whole cache over SSH to a\n",
+    "- **Caches on other machines**: `SshCache` forwards a whole cache over SSH to a\n",
     "  `python -m fleche remote --serve` process on, say, your cluster's login node. Stack it\n",
     "  behind a local cache exactly as above, or fan reads over several teammates' caches at\n",
     "  once with a read-only `CachePool`.\n",
-    "- **Take results home** — `query().transfer(other_cache)` moves selected results\n",
-    "  between caches (cluster → laptop); see `TransferWorkflow.ipynb`.\n",
-    "- **Ship a warm cache** — because a cache is just a directory, you can hand one to CI or\n",
+    "- **Take results home**: `query().transfer(other_cache)` moves selected results\n",
+    "  between caches (cluster to laptop); see `TransferWorkflow.ipynb`.\n",
+    "- **Ship a warm cache**: because a cache is just a directory, you can hand one to CI or\n",
     "  to students so notebooks that would otherwise need a supercomputer replay instantly.\n",
-    "- **Inside pyiron_workflow** — `@fleche` and `@pyiron_workflow.atomic` do not interfere,\n",
+    "- **Inside pyiron_workflow**: `@fleche` and `@pyiron_workflow.atomic` do not interfere,\n",
     "  and passing a fleche `Cache` to a `RunConfig` lets decorated nodes hit the same cache\n",
     "  during a workflow run.\n",
-    "- **Signed storage** — HMAC-sign pickle-family entries with a `secret_key`; tampered or\n",
+    "- **Signed storage**: HMAC-sign pickle-family entries with a `secret_key`; tampered or\n",
     "  wrong-key entries surface as plain cache misses, never as executed code.\n",
     "\n",
     "## Where to go next\n",


### PR DESCRIPTION
A compact notebook for giving a ~5-minute live introduction of fleche to a new audience, executed with real outputs committed so it also reads well statically on readthedocs.

## Structure

1. **Decorate and forget** — the slow-then-instant demo, a look at the `calls/` and `values/` directories, and proof of on-disk persistence (a fresh `Cache` over the same root already `contains` the result).
2. **Keys are content, not object identity** — `norm(a)` vs `norm(a.copy())` on a NumPy array; an ASE `Atoms`/EMT demo showing `fleche-ase` digesting freshly-built `bulk("Cu")` objects with zero setup; methods, where `self` is digested like any other argument so equal state shares entries and changed state invalidates them; and what actually enters the key, including `hash_code=True` (editing the body invalidates), `version=`, `ignore=`/`require=`.
3. **Your cache is a database** — a tagged parameter sweep queried into a pandas table via `query().table(arguments=..., results=True)`, a `filter`/`sorted` query for "nothing cached at this value, but here are nearby runs", and `cache().table()` spanning everything that ever wrote to the cache.
4. **Storing everything without filling the disk** — content-addressed values, so five relaxations converging to the same result cost one copy; then `query().evict()` plus a manual `cache().gc()` sweeping the now-unreferenced values while earlier results stay put.
5. **Executors** — `wrap_executor` with executorlib's `SingleNodeExecutor`, cold vs warm timing showing hits returned as already-completed futures that are never submitted.
6. **Stacking** — a writable cache stacked in front of a `readonly()` prepopulated base: hits from the base are back-filled into the front, new work lands only in the front, and the base is never modified; plus the equivalent `fleche.toml` array-of-tables config with `read_only = true`.
7. **Things worth a second look** — `fleche.toml` config, bagofholding HDF5 storage, SQL call index, `SshCache`/`CachePool`, `query().transfer()`, shipping a warm cache, pyiron_workflow interop, HMAC-signed storage, and the not-yet-supported file/directory caching — each one line, with pointers to the deeper notebooks and docs.

## Wiring

- `docs/notebooks/FiveMinuteTour.ipynb` symlink added, matching the existing per-notebook symlinks.
- Listed first in the Notebooks toctree in `docs/index.rst`, since it's the natural entry point.
- The demo cache directory is `notebooks/.five_minute_cache`, covered by the existing `notebooks/.*` gitignore rule; `.gitignore` also picks up `tags` and `build/`.

Imports are unguarded: the notebook states its extra dependencies up front (`pip install ase fleche-ase executorlib`) rather than hiding sections behind `try`/`except ImportError`, so a missing dependency fails loudly at execution time instead of silently dropping a section from the rendered docs.

The notebook was executed top-to-bottom with `jupyter nbconvert --execute` against this checkout (with `ase`, `fleche-ase`, and `executorlib` installed) so the committed outputs show real cache-hit timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158i1HsAzkkTB3C4JvpFLzC
