### PR TITLE
docs(query): document all QueryIterator methods

### DIFF
--- a/docs/usage/query.rst
+++ b/docs/usage/query.rst
@@ -75,3 +75,94 @@ Behavior details
 Performance
 -----------
 When using the SQL backend, most simple filters (name/module/version/result/arguments and simple metadata predicates) are executed in the database for efficiency. Final results are then loaded and any remaining checks are applied client-side as needed.
+
+
+QueryIterator API
+-----------------
+
+Both ``myfunc.query(...)`` and ``cache().query(...)`` return a
+:class:`~fleche.query.QueryIterator`.  Iterating it yields
+:class:`~fleche.call.LazyCall` objects; the iterator can be consumed
+multiple times (each pass re-runs the underlying query).
+
+Inspection
+~~~~~~~~~~
+
+``.count() -> int``
+    Total number of matching calls.
+
+``.empty() -> bool``
+    ``True`` if there are no matching calls (cheaper than ``count() == 0``
+    when the underlying query short-circuits).
+
+``.any() -> LazyCall | None``
+    First matching call, or ``None`` if empty.  Pair with ``.sorted()`` to
+    control which call is returned.
+
+``.only() -> LazyCall``
+    The single matching call.  Raises :exc:`IndexError` if empty,
+    :exc:`ValueError` if there is more than one match.
+
+Filtering and ordering
+~~~~~~~~~~~~~~~~~~~~~~
+
+``.filter(predicate) -> QueryIterator``
+    Keep only calls for which ``predicate(call)`` is truthy.  Lazy.
+
+``.sorted(key=None, reverse=False) -> QueryIterator``
+    Sort by *key*, where *key* is a callable ``(LazyCall) -> Any`` or
+    a string argument name.  Lazy.
+
+``.unique(key) -> QueryIterator``
+    Remove duplicates, keeping the first call per group.  *key* is a
+    callable or a string argument name.  Lazy.
+
+``.take(n) -> QueryIterator``
+    First *n* results.  Lazy.
+
+``.skip(n) -> QueryIterator``
+    Skip the first *n* results.  Lazy.
+
+Temporal helpers
+~~~~~~~~~~~~~~~~
+
+Both require :class:`~fleche.metadata.Runtime` metadata (the default).
+
+``.latest() -> LazyCall``
+    Call with the most recent ``timestop``.  Raises :exc:`IndexError` if
+    empty.
+
+``.oldest() -> LazyCall``
+    Call with the oldest ``timestop``.  Raises :exc:`IndexError` if empty.
+
+Grouping
+~~~~~~~~
+
+``.groupby(key) -> dict[Any, QueryIterator]``
+    Partition calls into a dict of ``QueryIterator`` objects.  *key* is a
+    callable or a string argument name.  Materialises the full result set
+    to build the groups.
+
+Results and side effects
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``.results() -> Iterator[Any]``
+    Iterate over the *result values* of matching calls (triggers a value
+    load per call).
+
+``.table(arguments=(), results=False, shrink_keys=True) -> DataFrame``
+    Return a :class:`~pandas.DataFrame` summarising the matched calls.
+    Pass argument names (or ``True`` for all) via *arguments* to include
+    them as columns; set ``results=True`` to add a ``result`` column.
+    Metadata fields are flattened into columns automatically.  Index
+    entries are shortened to their shortest unambiguous digest prefix
+    unless ``shrink_keys=False``.
+
+``.evict() -> None``
+    Remove all matching calls from the cache.
+
+``.transfer(target, pop=False, overwrite=False) -> None``
+    Replay matching calls into *target* (another
+    :class:`~fleche.caches.BaseCache`).  Skips entries already present
+    unless ``overwrite=True``.  Set ``pop=True`` to evict them from the
+    source after transfer.


### PR DESCRIPTION
## Summary

`query.rst` described only the two query entry points (`myfunc.query(...)` and `cache().query(QueryCall(...))`) but said nothing about what you can do with the `QueryIterator` they return. The class has 14 public methods that were completely absent from the documentation.

- Added a "QueryIterator API" section to `docs/usage/query.rst` documenting all public methods, grouped by purpose: inspection (`.count`, `.empty`, `.any`, `.only`), filtering/ordering (`.filter`, `.sorted`, `.unique`, `.take`, `.skip`), temporal helpers (`.latest`, `.oldest`), grouping (`.groupby`), and results/side-effects (`.results`, `.table`, `.evict`, `.transfer`).

## Test plan

- [ ] Verify `QueryIterator` method signatures in `src/fleche/query.py` match the documented signatures
- [ ] Build docs locally and confirm the new section renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXXyKvrULnWdo9iuSsRJa4)_