### PR TITLE
docs(ssh_cache): correct read_only cost claim in Read-only short-circuit

### DIFF
--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -355,12 +355,13 @@ flag from the server info dict before issuing the RPC.  If the flag is
 ``True`` they raise :class:`~fleche.caches.Rejected` locally with no
 round-trip.
 
-The flag is populated lazily — the first time ``read_only`` (or
-``info()``) is consulted, an ``info`` RPC fires and the result is
-cached on the :class:`~fleche.remote.SshCache` instance.  Subsequent
-saves consult the cache directly.  Cost is therefore at most one
-extra round-trip per session, and zero in the common case where the
-first cache op is itself a write.
+The flag is populated as a side effect of the version handshake.
+Every cache operation calls ``_ensure_handshake()`` first (see
+*Version handshake* above), which fires the ``info`` RPC on the very
+first call — whether that first call is a read or a write.  By the
+time any ``save`` or ``evict`` reaches the read_only check, the flag
+is therefore already cached.  Subsequent operations consult the cached
+value directly with no extra round-trip.
 
 :meth:`~fleche.remote.SshCache.reconnect` invalidates the cached info
 so the next read re-fetches against the new subprocess.


### PR DESCRIPTION
## Summary

The "Read-only short-circuit" subsection of `docs/dev/ssh_cache.rst` contained a misleading cost claim:

> "Cost is therefore at most one extra round-trip per session, and zero in the common case where the first cache op is itself a write."

This is wrong on two counts:

1. `_rpc()` calls `_ensure_handshake()` at the **top of every operation** — including writes — so the `info` RPC fires on the very first call regardless of whether it is a read or a write. The "zero in the common case where the first op is a write" exception does not exist.
2. The flag is **not** populated lazily when `read_only` is first consulted; it is populated as a side effect of the version handshake that fires on the first cache operation of any kind.

The "Version handshake" section already documented the correct behaviour ("The handshake fires on the first BaseCache method on the SshCache, even reads — every method calls `_ensure_handshake()` at its top"). The Read-only short-circuit section now references that section and correctly states there is no extra round-trip beyond the handshake.

## Test plan

- [ ] Read `src/fleche/remote.py` and confirm `_rpc()` always calls `_ensure_handshake()` before the `read_only` check

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXXyKvrULnWdo9iuSsRJa4)_