### PR TITLE
docs(FiveMinuteTour): skip ASE section gracefully when ase is not installed

### DIFF
--- a/notebooks/FiveMinuteTour.ipynb
+++ b/notebooks/FiveMinuteTour.ipynb
@@ -215,36 +215,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "dfba66c2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "running EMT ...\n",
-      "-0.022726045434316333\n",
-      "-0.022726045434316333\n"
-     ]
-    }
-   ],
-   "source": [
-    "from ase.build import bulk\n",
-    "from ase.calculators.emt import EMT\n",
-    "\n",
-    "\n",
-    "@fleche\n",
-    "def energy(atoms):\n",
-    "    print(\"running EMT ...\")\n",
-    "    atoms = atoms.copy()\n",
-    "    atoms.calc = EMT()\n",
-    "    return atoms.get_potential_energy()\n",
-    "\n",
-    "\n",
-    "print(energy(bulk(\"Cu\", cubic=True)))\n",
-    "print(energy(bulk(\"Cu\", cubic=True)))   # freshly built Atoms -> cache hit"
-   ]
+   "outputs": [],
+   "source": "try:\n    from ase.build import bulk\n    from ase.calculators.emt import EMT\nexcept ImportError:\n    print(\"ase (and fleche-ase) not installed, skipping this section\")\nelse:\n    @fleche\n    def energy(atoms):\n        print(\"running EMT ...\")\n        atoms = atoms.copy()\n        atoms.calc = EMT()\n        return atoms.get_potential_energy()\n\n\n    print(energy(bulk(\"Cu\", cubic=True)))\n    print(energy(bulk(\"Cu\", cubic=True)))   # freshly built Atoms -> cache hit"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- The ASE cell in `notebooks/FiveMinuteTour.ipynb` imported `ase`/`fleche-ase` unconditionally, so executing the notebook without those optional deps installed (e.g. `jupyter nbconvert --execute`, which `tests/integration/test_notebooks.py` and `.github/workflows/rendernb.yml` run without `ase`/`fleche-ase`) raised `ModuleNotFoundError` and aborted the whole notebook run.
- Wrapped the ASE import in `try/except ImportError`, printing a short "not installed, skipping this section" message instead of failing when `ase` is unavailable, while keeping identical behavior (imports, `@fleche`-decorated `energy` function, and output) when `ase`/`fleche-ase` are installed.

## Test plan
- [x] `jupyter nbconvert --to notebook --execute` on the notebook with `ase`/`fleche-ase` **not** installed → exits 0, ASE cell prints the skip message, no cell errors anywhere in the notebook.
- [x] Same, with `ase` and `fleche-ase` installed → exits 0, ASE cell output identical to before (`running EMT ...` / energy values).
- [x] `pytest tests/integration/test_notebooks.py -k FiveMinuteTour` passes in both cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kq6PpFvgok4NoFqU5rTUaf)_