### PR TITLE
refactor(state): extract _lazy_default helper shared by get_cache/get_metadata

### DIFF
--- a/src/fleche/state.py
+++ b/src/fleche/state.py
@@ -1,7 +1,7 @@
 from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from typing import overload, Any, Callable, Iterator
+from typing import overload, Any, Callable, Iterator, TypeVar
 
 from . import caches, config, metadata
 
@@ -13,6 +13,22 @@ _CACHE: ContextVar[caches.BaseCache] = ContextVar("fleche.CACHE")
 #: config by clearing this dict.
 _DEFAULTS: dict[str, Any] = {}
 
+_T = TypeVar("_T")
+
+
+def _lazy_default(var: ContextVar[_T], key: str, loader: Callable[[], _T]) -> _T:
+    """Return ``var``'s active value, falling back to a memoised ``loader()`` result.
+
+    The fallback is resolved on first use and cached in :data:`_DEFAULTS` under
+    ``key``; clearing that entry (or the whole dict) forces re-resolution.
+    """
+    try:
+        return var.get()
+    except LookupError:
+        if key not in _DEFAULTS:
+            _DEFAULTS[key] = loader()
+        return _DEFAULTS[key]
+
 
 def get_cache() -> caches.BaseCache:
     """Return the active cache, falling back to the configured default.
@@ -20,12 +36,7 @@ def get_cache() -> caches.BaseCache:
     The default is resolved from the configuration files on first use and memoised
     in :data:`_DEFAULTS`.
     """
-    try:
-        return _CACHE.get()
-    except LookupError:
-        if "cache" not in _DEFAULTS:
-            _DEFAULTS["cache"] = config.load_cache_config()
-        return _DEFAULTS["cache"]
+    return _lazy_default(_CACHE, "cache", config.load_cache_config)
 
 
 class _StickyContext:
@@ -136,12 +147,7 @@ def get_metadata() -> tuple[metadata.MetaData, ...]:
     The default is resolved from the configuration files on first use and memoised
     in :data:`_DEFAULTS`.
     """
-    try:
-        return _METADATA.get()
-    except LookupError:
-        if "metadata" not in _DEFAULTS:
-            _DEFAULTS["metadata"] = config.load_default_metadata()
-        return _DEFAULTS["metadata"]
+    return _lazy_default(_METADATA, "metadata", config.load_default_metadata)
 
 
 def meta(

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -4,6 +4,8 @@ import textwrap
 import pytest
 from dataclasses import dataclass
 
+from contextvars import ContextVar
+
 from fleche import state, storage, cache
 from fleche.config import (
     load_cache_config,
@@ -246,6 +248,28 @@ def test_load_default_cache(monkeypatch, config_file):
     assert isinstance(cache_obj, Cache)
     assert isinstance(cache_obj.values, storage.ValueMemory)
     assert isinstance(cache_obj.calls, storage.CallMemory)
+
+
+def test_lazy_default_returns_set_var_without_loading():
+    var: ContextVar[int] = ContextVar("test_var")
+    token = var.set(42)
+    try:
+        assert state._lazy_default(var, "unused_key", lambda: 1 / 0) == 42
+    finally:
+        var.reset(token)
+
+
+def test_lazy_default_memoises_loader_result():
+    var: ContextVar[int] = ContextVar("test_var")
+    calls = []
+
+    def loader():
+        calls.append(None)
+        return len(calls)
+
+    assert state._lazy_default(var, "counting_key", loader) == 1
+    assert state._lazy_default(var, "counting_key", loader) == 1
+    assert len(calls) == 1
 
 
 def test_tags_disallowed(monkeypatch, config_file_with_tags):


### PR DESCRIPTION
## Summary

`get_cache` and `get_metadata` in `src/fleche/state.py` were structurally identical: try the `ContextVar`, fall back to a memoised loader result keyed in `_DEFAULTS` on `LookupError`. Only the var, the `_DEFAULTS` key, and the loader callable differed.

Extracted a `_lazy_default(var, key, loader)` helper that owns the try/except + memoise dance once; both getters now collapse to a single call.

```python
def _lazy_default(var: ContextVar[_T], key: str, loader: Callable[[], _T]) -> _T:
    try:
        return var.get()
    except LookupError:
        if key not in _DEFAULTS:
            _DEFAULTS[key] = loader()
        return _DEFAULTS[key]
```

Zero behaviour change — same `_DEFAULTS` dict, same memoisation contract (clearing an entry, or the whole dict, forces re-resolution).

## Test plan

- [x] Added `test_lazy_default_returns_set_var_without_loading` and `test_lazy_default_memoises_loader_result` in `tests/unit/config/test_config.py`, exercising `_lazy_default` directly against a throwaway `ContextVar`.
- [x] Existing `get_cache`/`get_metadata` coverage (`test_load_default_cache`, `test_load_default_metadata`, and the rest of `tests/unit/config/test_config.py`) passes unchanged.
- [x] Full suite: `pytest tests/` — 1716 passed, 11 skipped (optional-dep skips), 10 deselected (the `FiveMinuteTour` notebook integration test, which requires `ase` — unrelated to this change).

Closes #806.

---
_Generated by [Claude Code](https://claude.ai/code/session_012x69gYLiFmJqz6NuezEyKn)_