### PR TITLE
test(coverage): plug _is_read_only CacheStack gap, fold redundant pool save test

### DIFF
--- a/tests/unit/caches/test_cache_pool.py
+++ b/tests/unit/caches/test_cache_pool.py
@@ -33,15 +33,14 @@ def test_cache_pool_is_recognised_as_read_only():
     assert _is_read_only(pool)
 
 
-def test_cache_pool_save_rejected():
-    pool = CachePool((Mock(), Mock()))
-    call = Call(name="test", arguments={"x": 1}, result="result")
-    with pytest.raises(Rejected):
-        pool.save(call)
-
-
-def test_cache_pool_save_does_not_touch_members():
-    """A rejected save must never reach a member cache."""
+def test_cache_pool_save_rejected_without_touching_members():
+    """A pool's ``save`` must raise :class:`Rejected` **before** reaching any
+    member cache — the read-only guarantee has to bind writes as well, and
+    the rejection has to happen at the pool layer so no member sees the
+    ``save`` at all.  The two invariants are inseparable (a silent pass-through
+    would violate both at once); the sibling ``evict`` test pins the analogous
+    pair for eviction with the same one-test shape.
+    """
     m1, m2 = Mock(), Mock()
     pool = CachePool((m1, m2))
     with pytest.raises(Rejected):

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -618,6 +618,37 @@ def test_redact_config_walks_stack_with_nested_sql_url():
     assert redacted[1]["calls"] == {"type": "memory"}
 
 
+def test_is_read_only_of_cache_stack_follows_write_target():
+    """A ``CacheStack`` is read-only iff its write layer (``stack[0]``) is.
+
+    :func:`~fleche.remote._is_read_only` is what the SSH client keys on to
+    short-circuit ``save``/``evict`` without paying a wire round-trip only to
+    receive :class:`~fleche.caches.Rejected`.  For a stack that flag must
+    match ``CacheStack.save``'s actual write target — ``stack[0]`` — regardless
+    of what the higher (read-through) layers permit; the read-only-ness of any
+    ``stack[i>0]`` never blocks a save, and a writable ``stack[0]`` fronted by
+    read-only higher layers must not be treated as read-only.  The base branch
+    (a plain :class:`~fleche.caches.Cache` → ``False``) is already exercised
+    by the ``remote`` fixture's ``info()`` handshake and the ``CachePool``
+    branch by ``test_cache_pool.test_cache_pool_is_recognised_as_read_only``;
+    this fills in the remaining ``CacheStack`` branch.
+    """
+    from fleche.caches import Cache, CacheStack, ReadOnlyCache
+    from fleche.remote import _is_read_only
+    from fleche.storage import CallMemory, ValueMemory
+
+    def _mem() -> Cache:
+        return Cache(ValueMemory({}), CallMemory({}))
+
+    # Writable at the write layer, read-only above → not read-only.
+    writable_first = CacheStack((_mem(), ReadOnlyCache(_mem())))
+    assert _is_read_only(writable_first) is False
+
+    # Read-only at the write layer → read-only (higher layers don't matter).
+    ro_first = CacheStack((ReadOnlyCache(_mem()), _mem()))
+    assert _is_read_only(ro_first) is True
+
+
 def test_info_exposes_versions(remote):
     """info() includes `fleche_version` and `cloudpickle_version`."""
     info = remote.info()


### PR DESCRIPTION
Two coverage-driven test edits, one commit each — kept on the same PR
because they came out of one measurement pass.

## Commit 1 — add missing test

`test(remote): cover _is_read_only CacheStack branch by write layer`

Adds one unit test for `fleche.remote._is_read_only` that pins its
behaviour on a `CacheStack`: a stack is read-only iff its write layer
(`stack[0]`) is read-only, regardless of the read-only-ness of higher
(read-through) layers.  The `CachePool` branch and the plain-`Cache`
fall-through were already covered by
`test_cache_pool_is_recognised_as_read_only` and the `remote` fixture's
`info()` handshake respectively; the `CacheStack` branch — the one
`remote.py` documents in its "SSH client short-circuit" paragraph — was
not.

`_is_read_only` is what the SSH client keys on to skip a wire round-trip
and locally reject `save`/`evict` when the remote cache would refuse
anyway.  Silent regressions in the `CacheStack` branch would either cost
every save an unnecessary round-trip (writable base, false read-only) or
fail loudly at the remote (read-only base, false writable).  Locking
the invariant to a test makes any future refactor fail visibly.

## Commit 2 — fold a redundant contract test

`test(caches): fold cache_pool_save_rejected into the members-untouched test`

Per-test coverage analysis over the whole suite (
`pytest --cov-context=test` → per-arc unique count) surfaced
`tests/unit/caches/test_cache_pool.py::test_cache_pool_save_rejected`
as a test with **zero unique source arcs**: everything it exercises is
also exercised by the sibling `test_cache_pool_save_does_not_touch_members`.
Its assertion (`save` raises `Rejected`) is a strict subset of the
sibling's assertions (`save` raises `Rejected` **and** no member's
`save` was called) — the members-untouched check cannot succeed unless
the pool rejected the save at its own layer, so the "just raises"
version pins a contract the other test already pins.

Merged the two into a single `test_cache_pool_save_rejected_without_touching_members`
that owns the full contract in its name and docstring.  This also
matches the shape of the neighbouring `test_cache_pool_evict_rejected`,
which already tested "raises + members untouched" in one test — so the
file's write-side and evict-side rejection tests now use the same
one-test shape.

## Coverage report

Baseline (before this PR) and PR head measured with:

```bash
pytest tests/ --cov=fleche --cov-branch --cov-report=term-missing \
       --ignore=tests/integration/test_notebooks.py \
       --ignore=tests/integration/test_remote.py \
       --ignore=tests/integration/test_parallel_execution.py
```

(Integration tests requiring live SSH / notebook kernels / real parallel
executors are excluded — coverage does not propagate out of subprocess
boundaries, so they add nothing to `remote.py`'s numbers.)

**Whole-project totals:**

| Metric | Baseline | After commit 1 | After commit 2 |
|---|---|---|---|
| Statements | 3140 | 3140 | 3140 |
| Missed stmts | 108 | 107 | 107 |
| Branches | 896 | 896 | 896 |
| Partial branches | 56 | 55 | 55 |
| Tests run | 1698 | 1699 (+1) | 1698 (net 0) |
| **Coverage** | **96%** | **96%** | **96%** |

**Delta on the target files:**

| File | Baseline | After PR |
|---|---|---|
| `src/fleche/remote.py` | 92% (24 miss, 13 partial) | 93% (22 miss, 12 partial) |
| `src/fleche/caches.py` | 95% (19 miss, 5 partial) | 95% (19 miss, 5 partial) |

Line 221 of `remote.py` (the whole `CacheStack` arm of `_is_read_only`)
and its `isinstance(cache, CacheStack)` branch are now covered.  The
consolidation in commit 2 is coverage-neutral by construction — the
folded test had zero unique arcs.

**Per-file report at the PR tip:**

```
Name                                      Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------
src/fleche/__init__.py                       13      2      2      0    87%
src/fleche/__main__.py                       21      3      6      2    81%
src/fleche/_attrs.py                         12      2      0      0    83%
src/fleche/caches.py                        376     19     96      5    95%
src/fleche/call.py                          268      8     68      5    96%
src/fleche/config.py                        235      3    110      2    99%
src/fleche/digest.py                        176      7    100      8    95%
src/fleche/metadata.py                       70      2      4      0    97%
src/fleche/query.py                         127      0     50      1    99%
src/fleche/remote.py                        395     22     88     12    93%   ← +1pp
src/fleche/state.py                          70      1     16      1    98%
src/fleche/storage/bagofholding_file.py     198      7     64      4    96%
src/fleche/storage/base.py                  147      2     34      2    98%
src/fleche/storage/destructuring.py         178      2     46      1    99%
src/fleche/storage/pickle_file.py            94      5     16      3    93%
src/fleche/storage/sql.py                   274     12     98      6    95%
src/fleche/storage/thread_safe.py            54      2      8      2    94%
src/fleche/storage/void.py                   26      1      0      0    96%
src/fleche/wrapper.py                       216      6     50      1    97%
------------------------------------------------------------------------------
TOTAL                                      3140    107    896     55    96%
```

## Method note

The random-removal step of the exercise flagged 7 of 8 sampled tests as
"coverage-neutral if removed", but on inspection every one of those was
a **contract or regression test** (parametric distinctness assertions,
issue-numbered regressions, non-mutation guards) — deleting any of them
would have thinned a documented invariant even though the totals would
have moved zero.  Rather than force-prune, I fell back to the task's
"reduce overlap" guidance and picked the one truly-redundant case in
the same duplicate-arc report (183 groups of same-file tests with
identical source-arc coverage, of which most are legitimate parametric
matrices or distinct-contract siblings; the pool-save pair was the
clean subset case).

Remaining coverage gaps in the least-covered non-trivial module,
`remote.py`, are almost all in the subprocess/SSH transport glue
(`_SshConnection._open` failure paths, `_close`'s timeout/kill
escalation, stderr-forwarder exit paths) which need process-level
fixtures rather than another one-file unit test.