### PR TITLE
docs(installation,parallel_execution): fix quoting bug, trim duplication, close gaps

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -89,8 +89,8 @@ that register themselves via :doc:`entry points <digests/entry_points>` —
 installing them alongside ``fleche`` is all that is needed:
 
 * ``fleche-ase`` (`PyPI <https://pypi.org/project/fleche-ase/>`__) — digest
-  hooks for the Atomic Simulation Environment: ``ase.Atoms``,
-  ``VibrationsData`` and ``Calculator`` objects.
+  hooks for the Atomic Simulation Environment. See :doc:`digests/entry_points`
+  for exactly which types it covers.
 
 .. code-block:: bash
 
@@ -110,7 +110,7 @@ If you are developing the project in an editable checkout, use:
 
 .. code-block:: bash
 
-   pip install -e .[docs]
+   pip install -e ".[docs]"
 
 Building the docs locally
 -------------------------

--- a/docs/parallel_execution.rst
+++ b/docs/parallel_execution.rst
@@ -53,10 +53,8 @@ automatically, serving cache hits from a pre-completed
 
 Alternatively, use :class:`~fleche.BoundWrapper` when you need explicit
 control over which callable is submitted — for example, to share a single
-bound callable across multiple pools or helper modules.
-``BoundWrapper.bind(func)`` captures the active cache **and metadata** at
-bind time and restores both on every call — including inside worker threads
-— so all tasks write to the same store with the same metadata context:
+bound callable across multiple pools or helper modules (see
+`BoundWrapper — Freezing State for Workers`_ below for the full picture):
 
 .. code-block:: pycon
 
@@ -134,12 +132,10 @@ needed:
    ...
    ...     assert file_cache.contains(heavy_computation.digest(3))
 
-Fleche's pickle-family file storage writes each entry to a temporary file that
-is atomically renamed into place, so multiple workers can safely write to the
-same directory — readers never observe a partially written entry, and no lock
-files accumulate.  (The HDF5-backed ``bagofholding_hdf`` backend mutates its
-shared multi-bag files in place and coordinates those through lock files;
-its per-key mode writes atomically like the pickle family.)
+Fleche's pickle-family and per-key ``bagofholding_hdf`` storage write each
+entry atomically, so multiple workers can safely share a directory with no
+lock files accumulating; see :doc:`dev/storage_hierarchy` for exactly how
+each backend achieves this.
 
 .. note::
 
@@ -152,15 +148,20 @@ its per-key mode writes atomically like the pickle family.)
    or `parsl <https://parsl-project.org/>`_ — do not have this restriction and
    can submit locally-defined functions directly.
 
+   Even with ``fork`` as the start method, a function defined in a REPL or
+   notebook cell (rather than an importable module) can still fail to
+   pickle — and the standard library switched away from ``fork`` as the
+   default start method on some platforms, which re-imports ``__main__`` in
+   each worker and hits the same restriction. Prefer a module-level function
+   for anything submitted to a process pool.
+
 BoundWrapper — Freezing State for Workers
 -----------------------------------------
 
-:class:`fleche.BoundWrapper` captures the current cache and metadata into
-a picklable callable, so workers automatically use the correct state without
-manual setup.
-
-This also works for **plain functions that call fleche-decorated functions
-internally**: the bound state propagates to all nested fleche calls.
+Beyond decorated functions, :class:`fleche.BoundWrapper` also works on
+**plain functions that call fleche-decorated functions internally**: the
+bound cache and metadata propagate to all nested fleche calls, so a worker
+running the plain function needs no setup of its own.
 
 .. code-block:: pycon
 
@@ -264,6 +265,15 @@ automatically:
   :class:`~fleche.BoundWrapper`, which is then submitted to the executor with
   no positional arguments.  The worker invokes ``bound()`` which calls
   ``partial(wrapper, *args)()`` with the captured cache and metadata context.
+
+.. note::
+
+   On a cache hit, ``wrap_executor`` always returns a plain
+   :class:`concurrent.futures.Future`, even when wrapping a third-party
+   executor whose own ``submit`` normally returns a different Future
+   subtype. Code that relies on executor-specific Future behaviour (e.g.
+   ``distributed.as_completed``) may see a different type on hits than on
+   misses.
 
 .. code-block:: pycon
 
@@ -423,7 +433,7 @@ Known Limitations
 Cache Stampede (Thundering Herd)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Fleche does **not** protect against cache stampedes.  When multiple workers
+Fleche does **not** protect against cache stampedes in general.  When multiple workers
 (threads or processes) call the same fleche-decorated function with identical
 arguments at the same time and the result is not yet cached, all of them will
 experience a cache miss simultaneously.  Each worker then independently


### PR DESCRIPTION
## Summary

Scheduled documentation audit of `docs/index.rst`, `docs/installation.rst`, and `docs/parallel_execution.rst`: ran every code example, verified every extras/package name against `pyproject.toml`, and cross-checked behavioral claims against `src/fleche/`. `index.rst` had no factual or toctree issues, so it's untouched.

**`installation.rst`**
- `pip install -e .[docs]` was unquoted — a bracket glob that fails under zsh's default `nomatch` option ("no matches found"). Every other extras-install example in the file is already quoted; this one wasn't.
- The "Companion packages" section restated `fleche-ase`'s digest coverage (`ase.Atoms`, `VibrationsData`, `Calculator`) less precisely than `docs/digests/entry_points.rst` already does (which uses fully-qualified names and has a worked example). Trimmed to a link.

**`parallel_execution.rst`**
- The pickle-family/`bagofholding_hdf` atomic-write mechanics were explained in-page in a way that duplicates `docs/dev/storage_hierarchy.rst`'s (more precise) treatment — replaced with a link.
- `BoundWrapper` was fully explained twice on the same page (once in the ThreadPoolExecutor section, again in its own dedicated section) — trimmed the first mention to a forward reference.
- Added a note that a fork-independent module-level function can still fail to pickle from a REPL/notebook cell, and that some platforms don't default to the `fork` start method — both send workers through a `__main__` re-import, which the existing `PicklingError` note didn't mention.
- Added a note on `wrap_executor`'s cache-hit/cache-miss Future-type asymmetry: cache hits always return a plain stdlib `Future`, even when wrapping a third-party executor whose `submit` normally returns a different Future subtype (verified against `src/fleche/executor.py`).
- Softened the Cache Stampede section's absolute "no protection" claim — a narrow in-flight-future dedup guard exists specifically for the Future pass-through pattern documented earlier on the same page (verified against `wrapper.py`'s `_in_flight` handling).

## Test plan

- [x] Parsed all three edited/audited files with `docutils` to confirm they're still valid RST.
- [x] Executed every runnable code example on the three pages against the locally `pip install -e`'d package before editing, to confirm current behavior.
- [x] Cross-checked the new wording against `src/fleche/executor.py`, `src/fleche/wrapper.py`, and `pyproject.toml`'s `[project.optional-dependencies]`.
- No code changes — docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuE52pq6tsFaQ6PbjWwS56)_