### PR TITLE
docs(digests): fix bool digest claim, dangling precedence gap, formatting

### DIFF
--- a/docs/digests/digest_equivalence.rst
+++ b/docs/digests/digest_equivalence.rst
@@ -20,6 +20,10 @@ exception: their digest is computed via Python's numeric hash protocol
 The type name is therefore **not** carried into the final digest for numbers, which is
 precisely why ``digest(1) == digest(1.0) == digest(1+0j)``.
 
+``bool`` is the one numeric subclass excluded from this equivalence: it keeps
+its own type-name salt, so ``digest(True) != digest(1)`` even though
+``isinstance(True, int)``.
+
 For all other types the type-name salt is applied normally, so
 ``digest((1, 2)) != digest([1, 2])`` because "tuple" and "list" diverge before
 the elements are processed.
@@ -61,7 +65,7 @@ argument (or returned one).
 
     >>> assert before == after
 
-Why we make them equivalent
+Why We Make Them Equivalent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **Persistence is the point.**  ``fleche`` is a *persistent* cache.  Migrating from
@@ -75,7 +79,7 @@ Why we make them equivalent
   for the same reason: when two objects of different concrete types denote the same
   value, the digest collapses them.
 
-Boundaries to keep in mind
+Boundaries to Keep in Mind
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **Equivalence is by class name, not module path.**  Two declarations with the same
@@ -97,7 +101,7 @@ Boundaries to keep in mind
   iterate differently.  The digest tells you when ``fleche`` will reuse a cached
   result; it does not tell you the two instances are observationally identical.
 
-Opting out per type
+Opting Out per Type
 ~~~~~~~~~~~~~~~~~~~
 
 If a particular class needs stricter scoping than "same name + same fields", give it

--- a/docs/digests/digests_as_args.rst
+++ b/docs/digests/digests_as_args.rst
@@ -1,7 +1,7 @@
 Digests as Arguments
 ====================
 
-`fleche` supports passing `Digest` objects as arguments to functions. When a `Digest` is passed as a top-level argument (either positional or keyword), `fleche` automatically looks up the corresponding value in the **value storage** and passes the resolved value to the decorated function.
+``fleche`` supports passing ``Digest`` objects as arguments to functions. When a ``Digest`` is passed as an immediate argument (either positional or keyword), ``fleche`` automatically looks up the corresponding value in the **value storage** and passes the resolved value to the decorated function.
 
 This allows for efficient chaining of cached functions where intermediate results can be referenced by their value digest rather than held in memory.
 
@@ -37,10 +37,10 @@ Note the distinction between a **call lookup key** (returned by ``func.digest(*a
 Behavior
 --------
 
-- **Automatic Expansion**: Only immediate `Digest` arguments are expanded.
-- **Non-recursive**: If you pass a list of digests like `[D(a), D(b)]`, the list will be passed as-is to the function, and the digests inside it will NOT be expanded.
-- **Missing Digests**: If a `Digest` is passed but its value cannot be found in the current cache, a `KeyError` will be raised.
-- **Short Digests**: If the underlying storage supports short-hand digest expansion, you can pass a short digest (at least 4 characters) to `D()`, and it will be expanded to the full value.
+- **Automatic Expansion**: Only immediate ``Digest`` arguments are expanded.
+- **Non-recursive**: If you pass a list of digests like ``[D(a), D(b)]``, the list will be passed as-is to the function, and the digests inside it will **not** be expanded.
+- **Missing Digests**: If a ``Digest`` is passed but its value cannot be found in the current cache, a ``KeyError`` will be raised.
+- **Short Digests**: If the underlying storage supports short-hand digest expansion, you can pass a short digest (at least 4 characters) to ``D()``, and it will be expanded to the full value.
 
 Looking Up a Value Directly
 ----------------------------
@@ -81,8 +81,8 @@ If you instead have the *original arguments* of a decorated call rather than its
 result, prefer ``func.load(*args, **kwargs)`` (see :doc:`/usage/helpers`) — it
 re-derives the lookup key from the arguments and needs no digest at all.
 
-The `D` Wrapper
----------------
+The ``D`` Wrapper
+------------------
 
 .. autofunction:: fleche.D
    :no-index:

--- a/docs/digests/entry_points.rst
+++ b/docs/digests/entry_points.rst
@@ -7,9 +7,11 @@ Entry Points
 :mod:`importlib.metadata` plugin mechanism): any installed package can
 register digest hooks for its types in the ``fleche`` entry point group under
 the name ``digest``.  Installing such a package is all it takes — no imports,
-no calls to :func:`~fleche.digest.add_hook`.  The first time
+no calls to :func:`~fleche.digest.add_hook`.  Each time
 :func:`~fleche.digest.digest` encounters a value it does not know how to
-handle, it loads all registered entry points and retries.
+handle, it (re-)loads all registered entry points and retries — there is no
+"already loaded" cache, so a type that stays unsupported after the retry
+pays this reload cost on every call, not just the first.
 
 Use entry points whenever digest support for a type should "just work" after
 a ``pip install``:
@@ -59,7 +61,8 @@ How Hooks Are Loaded
 
 Entry points are loaded *lazily*: to avoid import overhead, nothing happens
 until :func:`~fleche.digest.digest` raises
-:class:`~fleche.digest.Indigestible` for a value.  At that point ``fleche``:
+:class:`~fleche.digest.Indigestible` for a value.  At that point, and every
+subsequent time the same thing happens, ``fleche``:
 
 1. loads all entry points registered under the group ``fleche`` with the
    name ``digest``, and
@@ -77,6 +80,9 @@ Precedence rules:
   encountered wins.
 * An entry point that fails to load is logged as an ``ERROR`` (with
   traceback) and skipped — it never breaks digestion of other values.
+* Hooks — manual or entry-point — take priority over a type's own
+  ``__digest__`` method (see :doc:`digest_equivalence`): if a hook is
+  registered for a type, its ``__digest__`` is never consulted.
 
 Registering Your Own Entry Point
 --------------------------------
@@ -124,4 +130,4 @@ which returns the object at the given path directly — it does **not** call it.
    ... ]
 
 For guidance on writing the digest functions themselves (which fields to
-include, avoiding collisions), see :doc:`../dev/custom_digests`.
+include, avoiding collisions), see :doc:`/dev/custom_digests`.


### PR DESCRIPTION
## Summary

Scheduled documentation audit of `docs/digests/{digest_equivalence,digests_as_args,entry_points}.rst`: ran every code example and cross-checked every behavioral claim against `src/fleche/digest.py` and `src/fleche/call.py`.

**`digest_equivalence.rst`**
- The claim "Number types (`int`, `float`, `complex`, and subclasses)… `digest(1) == digest(1.0) == digest(1+0j)`" silently excludes `bool`, which *is* an `int` subclass: `digest(True) != digest(1)`, confirmed by execution. Root cause: `bool` hits the `case int():` arm directly (which keeps its type-name salt) instead of the generic `case Number():` arm that strips it. Documented the exception.
- Fixed three headings using sentence case ("Why we make them equivalent", "Boundaries to keep in mind", "Opting out per type") to Title Case, matching every other heading at the same level in this file and the other two digest pages.

**`entry_points.rst`**
- "The first time `digest()` encounters a value it does not know how to handle, it loads all registered entry points and retries" reads as (and is easy to misread as) a one-time, amortized cost. It isn't: `load_entry_points()` has no "already loaded" guard, so a type that stays `Indigestible` after the retry pays the entry-point reload cost on *every* `digest()` call, confirmed by execution (`entry_points()` called 3 times across 3 digest calls, including a repeat of a type already seen). Clarified.
- The "Precedence rules" section — which `agents/USAGE.md` designates as the canonical "full details" page for digest precedence — covered hook-vs-hook precedence but never stated where a type's own `__digest__` method sits relative to hooks. Confirmed by execution that hooks unconditionally override `__digest__`. Added the missing bullet.
- Made the `custom_digests.rst` cross-reference root-relative (`:doc:`/dev/custom_digests``), matching the convention `digest_equivalence.rst` already uses and the rest of the docs tree.

**`digests_as_args.rst`**
- Converted single-backtick spans (which render as title-references/italics under this project's default Sphinx role, not as code) to double backticks, matching every other inline-code mention in the same file and the other two digest pages.
- Unified "top-level argument" vs. "immediate argument" — two terms for the same concept — to "immediate", matching the "Automatic Expansion" bullet just below.
- Unified `NOT`/`**not**` emphasis style to RST bold, matching `digest_equivalence.rst`.

## Test plan

- [x] Executed every code example in the three pages against the locally `pip install -e`'d package before editing, to confirm current behavior.
- [x] Full `sphinx-build -b html docs docs/_build/html` (with the `docs` extra installed) — 0 warnings, 0 errors.
- No code changes — docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuE52pq6tsFaQ6PbjWwS56)_