### PR TITLE
docs(storage): fix sql url requirement, dedupe depth rule, broken TOML example

### DIFF
--- a/docs/storage/configuration.rst
+++ b/docs/storage/configuration.rst
@@ -265,8 +265,8 @@ Available storage types
    * - ``"sql"``
      - SQL via SQLAlchemy (:class:`~fleche.storage.Sql`).
        *Call storage only.*
-     - ``url``
-     - ``echo``
+     - —
+     - ``url``, ``echo``
 
 Key descriptions
 ^^^^^^^^^^^^^^^^
@@ -294,8 +294,9 @@ Key descriptions
     ``FLECHE_SECRET_KEY`` environment variable.
 
 ``url``
-    SQLAlchemy connection URL, e.g. ``"sqlite:///~/.cache/fleche/calls.db"``.
-    Leading ``~`` is expanded to the home directory in ``sqlite:///`` URLs.
+    (str, default ``"sqlite:///:memory:"``) — SQLAlchemy connection URL, e.g.
+    ``"sqlite:///~/.cache/fleche/calls.db"``. Leading ``~`` is expanded to the
+    home directory in ``sqlite:///`` URLs.
 
 ``echo``
     (bool, default ``false``) — log all SQL statements to stderr (useful for
@@ -342,14 +343,16 @@ prefix bucket grows.
    calls.url = "sqlite:///~/.cache/fleche/calls.db"
 
 Since digests are SHA256 hex strings, the default ``prefix_length = 2``
-spreads keys across up to 256 files (``"00.h5"`` .. ``"ff.h5"``); smaller
-values group more keys per file (fewer files, more contention per file),
-larger values group fewer. Digests are already uniformly distributed, so
-bucket sizes stay roughly even without any extra bookkeeping. Set it to
-``0`` for the one-file-per-key layout, or to ``None`` (only possible when
-constructing the backend from Python — TOML cannot express ``None``) to
-infer the length from the files already in ``root``, falling back to the
-default on an empty root.
+spreads keys across up to 256 files (``"00.h5"`` .. ``"ff.h5"``); among
+grouping lengths of 1 and up, a smaller value groups more keys per file
+(fewer files, more contention per file) and a larger value groups fewer.
+``0`` is not the smallest grouping length but a special case that disables
+multi-bagging entirely, reverting to one file per key — the opposite
+extreme from grouping. Digests are already uniformly distributed, so bucket
+sizes stay roughly even without any extra bookkeeping. Set it to ``None``
+(only possible when constructing the backend from Python — TOML cannot
+express ``None``) to infer the length from the files already in ``root``,
+falling back to the default on an empty root.
 
 ``prefix_length`` is checked against the files already present in ``root``
 when the storage is constructed: opening an existing cache directory with a
@@ -380,20 +383,12 @@ different cached calls.  See :doc:`destructuring` for a full discussion with
 figures, including the special cases (opaque objects, namedtuples, empty
 containers).
 
-The optional ``remaining_depth`` key (integer, default ``1``) controls the granularity:
-
-* ``remaining_depth = 0`` — maximum splitting: every element at every nesting level is
-  stored as a separate entry.
-* ``remaining_depth = N`` (positive) — elements whose structural depth is less than *N*
-  are stored inline within their parent entry rather than as separate entries.
-  Depth is measured from the deepest scalar leaf: scalars (:class:`int`, :class:`str`,
-  etc.) have depth 0; a container has depth ``1 + max(children depths)``.
-  With ``remaining_depth = 1`` (the default), scalars (depth 0) are inlined into
-  their parent container, so a flat list or dict of only scalars becomes a single
-  cache entry.  Nested sub-collections (depth ≥ 1) are still stored as separate
-  entries.
-
-Higher values mean fewer, larger storage entries and less structural sharing between calls.
+The optional ``remaining_depth`` key (integer, default ``1``) controls the
+granularity — see :doc:`destructuring` for the full depth rule, with figures.
+In short: ``0`` splits every element into its own entry; the default ``1``
+inlines scalars into their parent so a flat list or dict of scalars becomes a
+single entry; higher values inline progressively deeper sub-collections too,
+trading storage entries and structural sharing for fewer, larger entries.
 
 Example:
 

--- a/docs/storage/security.rst
+++ b/docs/storage/security.rst
@@ -27,8 +27,13 @@ The value must be a colon-separated list of hex-encoded byte strings (``[0-9a-fA
     values.type = "cloudpickle"
     values.root = "~/.fleche/values"
     values.secret_key = ["<hex-encoded-key>"]
+    calls.type = "cloudpickle"
+    calls.root = "~/.fleche/calls"
 
-The ``secret_key`` value is a list of hex-encoded strings using the same format as ``FLECHE_SECRET_KEY``.
+The ``secret_key`` value is a list of hex-encoded strings using the same
+format as ``FLECHE_SECRET_KEY``. It is set per storage backend (here only on
+``values``); see :doc:`configuration` for the full ``[mycache]`` section
+shape, including the required ``calls`` backend.
 
 .. warning::
     Storing secrets in config files risks accidentally committing them to version control.


### PR DESCRIPTION
## Summary

Scheduled documentation audit of `docs/storage/{configuration,destructuring,cache_stack,security}.rst`: ran every Python example and loaded every TOML example through `cache_from_config`/`storage_from_config` against the real backend classes. `destructuring.rst` and `cache_stack.rst` had zero findings and are untouched — every claim in both (including the CacheStack back-fill semantics, `load_value` *not* back-filling, and the nesting `ValueError`) was verified end-to-end.

**`configuration.rst`**
- The `"sql"` row of the storage-types table listed `url` as **Required**. It isn't: `Sql.url` defaults to `None` and `_coerce_sqlite_url(None)` returns `sqlite:///:memory:`. Confirmed — `storage_from_config({"type": "sql"}, "call")` succeeds and returns `Sql(url='sqlite:///:memory:', echo=False)`. Moved to the Optional column and documented the default in the `url` key description.
- The "Destructuring" subsection restated the full `remaining_depth` depth rule ("scalars have depth 0; a container has depth `1 + max(children depths)`…") that `destructuring.rst` already explains more completely and with figures — and which this very subsection already links to one paragraph above. Trimmed to a summary plus the link, matching how this page already handles `secret_key`→`security.rst` and CacheStack→`cache_stack.rst`. (The two copies had also drifted: this one said "children depths", the canonical one says "child depths".)
- The `prefix_length` description said "smaller values group more keys per file… Set it to `0` for the one-file-per-key layout", which reads as though `0` continues the same trend. It doesn't — `0` is special-cased to the plain per-key path, i.e. the opposite extreme (no grouping at all), not the smallest bucket count. Clarified.

**`security.rst`**
- The `[mycache]` TOML example showed `values.secret_key` but had no `calls` section, so `cache_from_config` on it raises `KeyError: 'calls'` — confirmed by running it. Unlike the later bare `values.secret_key = [...]` fragment (no section header, unambiguously a syntax illustration), this block has a full section header and reads as copy-pasteable. Added the missing `calls` backend and a pointer to `configuration.rst` for the full section shape.

## Test plan

- [x] Executed all Python examples and loaded all TOML examples on the four pages through `cache_from_config`/`storage_from_config` before editing, to confirm current behavior.
- [x] Verified the corrected `security.rst` TOML now builds a real cache: `cache_from_config` returns `Cache(values=ValuePickleFile(..., secret_key=(b'\xaa\xbb\xcc',)), calls=CallPickleFile(...))`.
- [x] Full `sphinx-build -b html docs docs/_build/html` — 0 warnings, 0 errors.
- No code changes — docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuE52pq6tsFaQ6PbjWwS56)_