### PR TITLE
docs(dev): fix abandon contract, destructurer contract, admin-db claim, ssh gaps

### DIFF
--- a/docs/dev/call_lifecycle.rst
+++ b/docs/dev/call_lifecycle.rst
@@ -72,8 +72,9 @@ safe form needs no ``try``:
 idempotent — argument values already written in phase 1 are
 content-addressed orphans, which a later garbage-collection sweep reclaims,
 so there is nothing to roll back.  Only
-:meth:`~fleche.call.PreparedCall.commit` is barred afterwards; calling either
-twice raises :class:`RuntimeError`.
+:meth:`~fleche.call.PreparedCall.commit` is barred afterwards: committing a
+call that was already committed or abandoned raises :class:`RuntimeError`,
+while ``abandon`` never raises no matter how often it is called.
 
 :mod:`fleche.wrapper` does not use the ``with`` form, because the commit may
 happen in a future's done-callback rather than on the calling thread, but it

--- a/docs/dev/custom_digests.rst
+++ b/docs/dev/custom_digests.rst
@@ -1,7 +1,7 @@
 Customizing Digests
 ===================
 
-``fleche`` uses digests to identify objects and determine if a cached result can be reused. By default, it supports many built-in Python types, numpy arrays, and dataclasses. For other types, or to customize how a digest is calculated, you can use one of the following methods.
+``fleche`` uses digests to identify objects and determine if a cached result can be reused. By default, it supports many built-in Python types, numpy arrays, dataclasses, and ``attrs``-decorated classes. For other types, or to customize how a digest is calculated, you can use one of the following methods.
 
 The ``__digest__`` Method
 -------------------------

--- a/docs/dev/extending_destructurer.rst
+++ b/docs/dev/extending_destructurer.rst
@@ -40,13 +40,31 @@ where:
   :class:`~fleche.storage.destructuring.Digested` subclass instance wrapping
   the children.
 - ``depth`` must be ``1 + max(child_depths)`` when children were processed,
-  or ``float("inf")`` when the value cannot be handled.
+  ``0`` when the value has no children to split, or ``float("inf")`` when the
+  value cannot be handled.
 
-The ``Digested`` subclass must implement :meth:`~fleche.storage.destructuring.Digested.mend`
-(reconstruction from storage), :meth:`~fleche.storage.destructuring.Digested.underlying`
-(for hashing), and the class-method
-:meth:`~fleche.storage.destructuring.Digested.sunder` (the ``sunder_fn``
-itself, as a classmethod).  Study
+The usual way to satisfy that contract is *not* to write ``sunder_fn`` by
+hand.  :meth:`~fleche.storage.destructuring.Digested.sunder` is already a
+concrete template method on the ABC: it enumerates child slots, interns each
+one, computes the depth, and picks the inline-vs-store branch for you.  Pass
+``YourDigested.sunder`` as the ``sunder_fn`` and implement the four abstract
+methods it dispatches to:
+
+- :meth:`~fleche.storage.destructuring.Digested._slots` — return the
+  ``(label, child)`` pairs to recurse into, or ``None`` to opt out (which is
+  what yields the ``float("inf")`` depth).
+- :meth:`~fleche.storage.destructuring.Digested._rebuild_plain` — rebuild the
+  value when no child became a :class:`~fleche.digest.Digest` reference.
+- :meth:`~fleche.storage.destructuring.Digested._rebuild_digest` — build the
+  wrapper instance when at least one child did.
+- :meth:`~fleche.storage.destructuring.Digested.mend` — reconstruct the
+  original value from storage.
+
+:meth:`~fleche.storage.destructuring.Digested.underlying` (for hashing) is
+abstract as well and must be implemented either way.  Overriding ``sunder``
+directly is possible but rarely worth it: the three ``_``-prefixed methods
+stay abstract, so you would still need to define them to make the class
+instantiable.  Study
 :class:`~fleche.storage.destructuring.DigestedIterable` or
 :class:`~fleche.storage.destructuring.DigestedDict` as the canonical
-reference implementations before writing your own.
+reference implementations — neither overrides ``sunder``.

--- a/docs/dev/sql_test_backends.rst
+++ b/docs/dev/sql_test_backends.rst
@@ -19,10 +19,12 @@ Variable                       Example value
 ``FLECHE_TEST_MYSQL_URL``      ``mysql+pymysql://fleche:fleche@localhost:3306/mysql``
 ============================== ====================================================
 
-The URL must point at a server (the database part of the URL is the
-*administrative* database used to mint per-test databases — typically
-``postgres`` for PostgreSQL, ``mysql`` for MySQL/MariaDB). The connecting role
-needs ``CREATE DATABASE`` privilege.
+The URL must point at a server. Per-test databases are minted from an
+*administrative* connection derived from it: PostgreSQL needs to be connected
+to some database to run ``CREATE DATABASE``, so ``_admin_url`` rewrites the
+database part to the conventional ``postgres``; MySQL/MariaDB needs no
+selected database, so the database part is dropped entirely (whatever the URL
+names is ignored). The connecting role needs ``CREATE DATABASE`` privilege.
 
 When set, the test session:
 

--- a/docs/dev/ssh_cache.rst
+++ b/docs/dev/ssh_cache.rst
@@ -59,7 +59,7 @@ Version handshake
 ~~~~~~~~~~~~~~~~~
 
 The first cache operation on a fresh :class:`~fleche.remote.SshCache`
-implicitly fetches an :ref:`info <ssh-cache-internals>` dict via
+implicitly fetches an :ref:`info <ssh-cache-info>` dict via
 :meth:`fleche.remote.SshCache._ensure_handshake`, which calls
 ``_warn_on_version_skew()`` on the response.  Mismatched
 ``fleche_version`` or ``cloudpickle_version`` between client and server
@@ -106,10 +106,10 @@ One :class:`~fleche.remote.SshCache` owns exactly one
    client                                       remote
    ──────                                       ──────
 
-   SshCache.<op>(...)            <op> ∈ save / load / load_value /
-       │    ▲                            contains / expand / shrink /
-   call│    │return                      query / evict / info
-       ▼    │
+   SshCache.<op>(...)            <op> ∈ save / save_value / prepare /
+       │    ▲                            load / load_value / contains /
+   call│    │return                      expand / shrink / query /
+       ▼    │                            evict / info
    ┌──────────────────────┐                ┌─────────────────────┐
    │_SshConnection        │──(stdin) req──>│ python -m           │
    │                      │                │   fleche remote     │
@@ -197,6 +197,43 @@ Two pieces need server-side translation rather than raw passthrough:
   before sending it back, because the wire protocol is request /
   response, not streaming.  Large query results pay the cost up front in
   one frame.
+
+Two-phase save over the wire
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The two-phase save protocol (see :doc:`call_lifecycle`) needs special
+handling here, because a :class:`~fleche.call.PreparedCall` carries a
+``cache`` pointer and so must never cross the wire — the same constraint
+that forces ``_strip_cache()`` on the read path.
+
+:meth:`~fleche.remote.SshCache.prepare` is **one** round trip.  The whole
+:class:`~fleche.call.Call` ships out, the server runs ``cache.prepare(call)``
+to stash the argument values and seal the record, and only the sealed
+:class:`~fleche.call.DigestedCall` comes back.  The server drops its own
+``PreparedCall`` (``abandon`` is a no-op), and the client wraps the reply in
+a fresh ``PreparedCall`` bound to itself.  Against a read-only remote,
+``prepare`` short-circuits to the base digest-only admission *before*
+dispatching, so no trip is spent on a save the commit will reject anyway.
+
+:meth:`~fleche.remote.SshCache.save` on a ``PreparedCall`` is then **two**
+round trips, recreating ``Cache.save``'s ending:
+
+1. ``save_value`` stores the pending result and returns its digest.  This RPC
+   exists only in the wire protocol — it is the write-side counterpart of
+   ``load_value``.  Server-side, ``_save_value()`` routes through
+   ``cache.prepare(...)`` with a synthetic, never-committed call so that
+   wrappers and stacks direct the value to the same storage their real saves
+   use.  The value rides in the *result* position for its strict save
+   semantics; ``None`` — the one result a stash skips — rides as an argument
+   instead, since storing ``None`` cannot fail.
+2. ``save`` files the sealed record.
+
+A failure between the two trips leaves the value as a content-addressed
+orphan for ``gc``, exactly like any locally abandoned call.
+
+Because values travel by cloudpickle, a :class:`~pathlib.Path` argument
+ships its path *string*, not the file's content — paths over
+:class:`~fleche.remote.SshCache` are unsupported today.
 
 Client side
 ~~~~~~~~~~~
@@ -290,6 +327,8 @@ calls.
 Without ``workdir`` or ``setup_commands``, the server argv is passed
 directly to ``ssh`` as separate arguments, so SSH ``exec``\\ s it as-is
 — no remote shell is involved at all.
+
+.. _ssh-cache-info:
 
 Diagnostics: the ``info`` RPC
 -----------------------------


### PR DESCRIPTION
## Summary

Scheduled documentation audit of the seven `docs/dev/*.rst` pages: ran every runnable example and cross-checked every internals claim directly against `src/fleche/`. `function_profile.rst` and `storage_hierarchy.rst` had zero findings and are untouched — `storage_hierarchy.rst`'s ten-step MRO walkthrough was checked against the live `__mro__` and matches exactly, position for position.

**`call_lifecycle.rst` — self-contradicting `abandon` contract**

> "`abandon` is a no-op by default and idempotent … Only `commit` is barred afterwards; calling **either** twice raises `RuntimeError`."

The two halves contradict each other, and the second is wrong. `abandon()` sets `_finished = True` unconditionally and never raises; only `commit()` checks it. Verified: `abandon(); abandon()` → fine, `commit(); abandon()` → fine, only a second `commit()` raises.

**`extending_destructurer.rst` — documented contract yields an uninstantiable class**

The doc says a `Digested` subclass must implement `mend`, `underlying`, and "the class-method `sunder` (the `sunder_fn` itself, as a classmethod)." Following that verbatim fails:

```
TypeError: Can't instantiate abstract class Bad with abstract methods
_rebuild_digest, _rebuild_plain, _slots
```

`sunder` is already a *concrete template method* that dispatches to three separate abstract methods the doc never mentions — and neither `DigestedIterable` nor `DigestedDict`, which the doc names as the canonical reference implementations, overrides `sunder` at all. Rewrote the contract around what those two classes actually do. Also added the depth rule's third case (`_slots` returning empty → depth `0`), which the stated "`1 + max(child_depths)` or `float("inf")`" omits.

**`sql_test_backends.rst` — wrong MySQL admin database**

> "the database part of the URL is the *administrative* database … typically `postgres` for PostgreSQL, `mysql` for MySQL/MariaDB"

For MySQL/MariaDB `_admin_url` does `url.set(database=None)` — it drops the database entirely rather than setting it to `mysql`. This also contradicted the same file's "Adding a new SQL dialect" section, which correctly says only Postgres needs one.

**`ssh_cache.rst` — broken ref, incomplete diagram, missing protocol section**

- `:ref:`info <ssh-cache-internals>`` resolved to the page's own title label (the only place that label is defined), so the link jumped to the top of the same page instead of the Diagnostics section it clearly meant. Added an `ssh-cache-info` label and repointed it.
- The wire-protocol diagram's op list omitted `prepare` and `save_value`, both real entries in `_REMOTE_METHODS`/`_CLIENT_METHODS`.
- Added a **"Two-phase save over the wire"** section. The file previously had zero mentions of `prepare`, `PreparedCall`, or `save_value`, despite `remote.py` implementing a genuinely subtle version of the protocol: one RPC for `prepare` (with a read-only short-circuit that skips the trip), two for `save`, a `PreparedCall` that must never cross the wire, and `_save_value`'s `None`-rides-as-an-argument special case. For a page whose stated purpose is "a tour of `fleche.remote` for contributors," that's a real gap rather than a nit.

**`custom_digests.rst`** — mention `attrs` classes alongside dataclasses in the natively-supported list, so readers with `attrs` types don't write an unnecessary `__digest__`.

## Test plan

- [x] Ran every runnable example on the seven pages against the locally `pip install -e`'d package; `tests/unit/test_remote.py` (54 passed) and `tests/integration/test_remote.py` (3 passed) were used to confirm the SSH claims.
- [x] Empirically confirmed both contract bugs: the `abandon`/`commit` idempotency behavior, and that the previously documented `Digested` method set raises `TypeError` on instantiation.
- [x] Full `sphinx-build -b html docs docs/_build/html` — 0 warnings, 0 errors (the previously broken `:ref:` resolved silently because it pointed at a real, if wrong, label).
- No code changes — docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuE52pq6tsFaQ6PbjWwS56)_